### PR TITLE
 - fixed library path for mac osx (there is no lib64 path here...)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,9 @@ ldconfig="ldconfig"
 case `uname` in
   Linux*)
     ;;
+  Darwin*)
+    libdir='${exec_prefix}/lib'
+    ;;
   AIX*)
     ;;
   SunOS)


### PR DESCRIPTION
Hi Ronnie,

here another pull request for fixing libdir for osx on 64bit mashines (lib64 path is linux only) ... i also removed an unneeded default case for non 64bit os (the if test ... above already secures this case).

ciao

Christian
