### PR TITLE
Fix missing include for osx

### DIFF
--- a/lib/libnfs-sync.c
+++ b/lib/libnfs-sync.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <poll.h>
+#include <sys/socket.h>
 #include <net/if.h>
 #include <netdb.h>
 #include "libnfs.h"


### PR DESCRIPTION
Hi ronnie,

this fixes the compile on osx. if.h seems to be a bit b0rked on osx - so we need to include socket.h before ...

bye

memphiz
