### PR TITLE
Fix vpath build

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -2,13 +2,13 @@ noinst_PROGRAMS = nfsclient-async nfsclient-raw nfsclient-sync nfsclient-bcast n
 
 AM_CPPFLAGS = \
 	-I$(abs_top_srcdir)/include \
-	-I$(abs_top_srcdir)/mount \
-	-I$(abs_top_srcdir)/nfs \
-	-I$(abs_top_srcdir)/rquota \
-	-I$(abs_top_srcdir)/portmap \
+	-I../mount \
+	-I../nfs \
+	-I../rquota \
+	-I../portmap \
 	"-D_U_=__attribute__((unused))"
 
-AM_LDFLAGS = $(abs_top_srcdir)/lib/.libs/libnfs.la
+AM_LDFLAGS = ../lib/.libs/libnfs.la
 
 nfsclient_async_SOURCES = nfsclient-async.c
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,10 +1,10 @@
 lib_LTLIBRARIES = libnfs.la
 
 libnfs_la_CPPFLAGS = -I$(abs_top_srcdir)/include \
-		     -I$(abs_top_srcdir)/mount \
-		     -I$(abs_top_srcdir)/nfs \
-		     -I$(abs_top_srcdir)/portmap \
-		     -I$(abs_top_srcdir)/rquota \
+		     -I../mount \
+		     -I../nfs \
+		     -I../portmap \
+		     -I../rquota \
 		     "-D_U_=__attribute__((unused))"
 
 libnfs_la_SOURCES = \
@@ -16,8 +16,8 @@ libnfs_la_SOURCES = \
 
 libnfs_la_LDFLAGS = -version-info 0:0:0
 libnfs_la_LIBADD = \
-	$(abs_top_srcdir)/mount/libmount.la \
-	$(abs_top_srcdir)/nfs/libnfs.la \
-	$(abs_top_srcdir)/portmap/libportmap.la \
-	$(abs_top_srcdir)/rquota/librquota.la 
+	../mount/libmount.la \
+	../nfs/libnfs.la \
+	../portmap/libportmap.la \
+	../rquota/librquota.la 
 


### PR DESCRIPTION
This patch set fixes out of tree builds. ie
 $ tar xf libnfs.tar.gz
 $ mkdir libnfs-build
 $ cd libnfs-build
 $ ../libnfs/configure
 $ make

A few of the include and link paths weren't quite right for this to work initially.

There's also a rider commit here cleaning up the examples Makefile.am.
