### PR TITLE
buildsys was missing the installation of the raw haders...

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -3,4 +3,8 @@ dist_nfsc_HEADERS = \
 	libnfs.h \
 	libnfs-private.h \
 	libnfs-raw.h \
-	slist.h
+	slist.h \
+	${abs_top_srcdir}/mount/libnfs-raw-mount.h \
+	${abs_top_srcdir}/portmap/libnfs-raw-portmap.h \
+	${abs_top_srcdir}/nfs/libnfs-raw-nfs.h \
+	${abs_top_srcdir}/rquota/libnfs-raw-rquota.h


### PR DESCRIPTION
at least for the server list feature i need the libnfs-raw-mount.h ... so better save then sorry and install all raw headers or what do you think?
