### PR TITLE
[fix] - handle improper struct AUTH definition from osx

### DIFF
--- a/include/libnfs.h
+++ b/include/libnfs.h
@@ -18,10 +18,17 @@
  * This is the highlevel interface to access NFS resources using a posix-like interface
  */
 #include <stdint.h>
+#include <rpc/rpc.h>
 #include <rpc/auth.h>
 
 struct nfs_context;
 struct rpc_context;
+
+//on osx struct AUTH is anonym typedef
+//forward declare struct AUTH in that case
+#ifndef struct AUTH
+struct AUTH;
+#endif
 
 #if defined(WIN32)
 #define EXTERN __declspec( dllexport )


### PR DESCRIPTION
This is one off 2 solutions for fixing the build on osx. The auth.h header defines struct AUTH as anoynmous struct / typedef only. So it doesn't get found. This PR fixes it by just forward declare struct AUTH (which isn't completly correct imho - because it isn't defined anywhere but anonym).
