### PR TITLE
[fix] - fix improper definition of struct AUTH from osx (caution - API ch

### DIFF
--- a/include/libnfs.h
+++ b/include/libnfs.h
@@ -18,6 +18,7 @@
  * This is the highlevel interface to access NFS resources using a posix-like interface
  */
 #include <stdint.h>
+#include <rpc/rpc.h>
 #include <rpc/auth.h>
 
 struct nfs_context;
@@ -63,7 +64,7 @@ EXTERN int nfs_queue_length(struct nfs_context *nfs);
 /*
  * Used if you need different credentials than the default for the current user.
  */
-EXTERN void nfs_set_auth(struct nfs_context *nfs, struct AUTH *auth);
+EXTERN void nfs_set_auth(struct nfs_context *nfs, AUTH *auth);
 
 
 /*

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -111,7 +111,7 @@ struct nfs_mcb_data {
 static int nfs_lookup_path_async_internal(struct nfs_context *nfs, struct nfs_cb_data *data, struct nfs_fh3 *fh);
 
 
-void nfs_set_auth(struct nfs_context *nfs, struct AUTH *auth)
+void nfs_set_auth(struct nfs_context *nfs, AUTH *auth)
 {
 	rpc_set_auth(nfs->rpc, auth);
 }


### PR DESCRIPTION
This is the second approach for fixing compilation for osx because of anonym defined struct AUTH. It changes the prototype of set_auth to using AUTH \* instead of struct AUTH*. But i'm not sure if the typedef is there on all plattforms and there rpc headers. Beside that this is an API change.

Only merge one of these 2 pull requests of course. Or maybe find a 3rd option ;)
