### PR TITLE
add environment variable to set TCP_SYNCNT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,10 @@ AC_CHECK_HEADERS([sys/statvfs.h])
 dnl Check for sys/socket.h
 AC_CHECK_HEADERS([sys/socket.h])
 
+# check for netinet/tcp.h
+dnl Check for netinet/tcp.h
+AC_CHECK_HEADERS([netinet/tcp.h])
+
 # check for netinet/in.h
 dnl Check for netinet/in.h
 AC_CHECK_HEADERS([netinet/in.h])

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -46,6 +46,10 @@
 #include <sys/socket.h>
 #endif
 
+#ifdef HAVE_NETINET_TCP_H
+#include <netinet/tcp.h>
+#endif
+
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif
@@ -91,6 +95,26 @@ static void set_nonblocking(int fd)
         fcntl(fd, F_SETFL, v | O_NONBLOCK);
 #endif //FIXME
 }
+
+#ifdef HAVE_NETINET_TCP_H
+int set_tcp_sockopt(int sockfd, int optname, int value)
+{
+	int level;
+
+	#if defined(__FreeBSD__) || defined(__sun) || (defined(__APPLE__) && defined(__MACH__))
+	struct protoent *buf;
+
+	if ((buf = getprotobyname("tcp")) != NULL)
+		level = buf->p_proto;
+	else
+		return -1;
+	#else
+		level = SOL_TCP;
+	#endif
+
+	return setsockopt(sockfd, level, optname, (char *)&value, sizeof(value));
+}
+#endif
 
 int rpc_get_fd(struct rpc_context *rpc)
 {
@@ -378,6 +402,11 @@ static int rpc_connect_sockaddr_async(struct rpc_context *rpc, struct sockaddr_s
 	case AF_INET:
 		socksize = sizeof(struct sockaddr_in);
 		rpc->fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+#ifdef HAVE_NETINET_TCP_H
+		if (getenv("LIBNFS_TCP_SYNCNT") != NULL) {
+			set_tcp_sockopt(rpc->fd, TCP_SYNCNT, atoi(getenv("LIBNFS_TCP_SYNCNT")));
+		}
+#endif
 		break;
 	default:
 		rpc_set_error(rpc, "Can not handle AF_FAMILY:%d", s->ss_family);


### PR DESCRIPTION
this adds the possibility to set the TCP_SYNCNT sockopt to alternate value
via environment variable LIBNFS_TCP_SYNCNT.

This allows indirect support for a configurable connect timeout.

Linux uses a exponential backoff for SYN retries starting
with 1 second.

This means for a value n for TCP_SYNCNT, the connect will
effectively timeout after 2^(n+1)-1 seconds.

Example:
LIBNFS_TCP_SYNCNT=1 examples/nfs-ls nfs://10.0.0.1/export

Signed-off-by: Peter Lieven pl@kamp.de
