### PR TITLE
Adjust Makefile.am's to support out-of-source builds

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -3,10 +3,10 @@ noinst_PROGRAMS = nfsclient-async nfsclient-raw nfsclient-sync nfsclient-bcast n
 AM_CPPFLAGS = \
 	-I$(abs_top_srcdir)/include \
 	-I$(abs_top_srcdir)/include/nfsc \
-	-I../mount \
-	-I../nfs \
-	-I../rquota \
-	-I../portmap \
+	-I$(abs_top_srcdir)/mount \
+	-I$(abs_top_srcdir)/nfs \
+	-I$(abs_top_srcdir)/rquota \
+	-I$(abs_top_srcdir)/portmap \
 	"-D_U_=__attribute__((unused))"
 
 AM_LDFLAGS = ../lib/.libs/libnfs.la -lpopt

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -2,12 +2,12 @@ lib_LTLIBRARIES = libnfs.la
 
 libnfs_la_CPPFLAGS = -I$(abs_top_srcdir)/include \
 		     -I$(abs_top_srcdir)/include/nfsc \
-		     -I../mount \
-		     -I../nfs \
-		     -I../nlm \
-		     -I../nsm \
-		     -I../portmap \
-		     -I../rquota \
+		     -I$(abs_top_srcdir)/mount \
+		     -I$(abs_top_srcdir)/nfs \
+		     -I$(abs_top_srcdir)/nlm \
+		     -I$(abs_top_srcdir)/nsm \
+		     -I$(abs_top_srcdir)/portmap \
+		     -I$(abs_top_srcdir)/rquota \
 		     "-D_U_=__attribute__((unused))"
 
 libnfs_la_SOURCES = \


### PR DESCRIPTION
Just a simple modification to enable out-of-source builds. There's no reason why it's broken.
