### PR TITLE
[win32] - fixed bad number casting when using libnfs on 64bit win8 syste...

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -169,8 +169,11 @@ EXTERN int nfs_stat_async(struct nfs_context *nfs, const char *path, nfs_cb cb, 
  *      0 : The operation was successfull.
  * -errno : The command failed.
  */
+#ifdef WIN32
+EXTERN int nfs_stat(struct nfs_context *nfs, const char *path, struct __stat64 *st);
+#else
 EXTERN int nfs_stat(struct nfs_context *nfs, const char *path, struct stat *st);
-
+#endif
 
 /*
  * FSTAT()
@@ -194,7 +197,11 @@ EXTERN int nfs_fstat_async(struct nfs_context *nfs, struct nfsfh *nfsfh, nfs_cb 
  *      0 : The operation was successfull.
  * -errno : The command failed.
  */
+#ifdef WIN32
+EXTERN int nfs_fstat(struct nfs_context *nfs, struct nfsfh *nfsfh, struct __stat64 *st);
+#else
 EXTERN int nfs_fstat(struct nfs_context *nfs, struct nfsfh *nfsfh, struct stat *st);
+#endif
 
 
 

--- a/lib/libnfs-sync.c
+++ b/lib/libnfs-sync.c
@@ -208,11 +208,18 @@ static void stat_cb(int status, struct nfs_context *nfs, void *data, void *priva
 		nfs_set_error(nfs, "stat call failed with \"%s\"", (char *)data);
 		return;
 	}
-
-	memcpy(cb_data->return_data, data, sizeof(struct stat));
+#ifdef WIN32
+	memcpy(cb_data->return_data, data, sizeof(struct __stat64));
+#else
+  memcpy(cb_data->return_data, data, sizeof(struct stat));
+#endif
 }
 
+#ifdef WIN32
+int nfs_stat(struct nfs_context *nfs, const char *path, struct __stat64 *st)
+#else
 int nfs_stat(struct nfs_context *nfs, const char *path, struct stat *st)
+#endif
 {
 	struct sync_cb_data cb_data;
 

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -713,7 +713,11 @@ static void nfs_stat_1_cb(struct rpc_context *rpc, int status, void *command_dat
 	GETATTR3res *res;
 	struct nfs_cb_data *data = private_data;
 	struct nfs_context *nfs = data->nfs;
+#ifdef WIN32
+  struct __stat64 st;
+#else
 	struct stat st;
+#endif
 
 	assert(rpc->magic == RPC_CONTEXT_MAGIC);
 


### PR DESCRIPTION
...ms - force the usage of struct __stat64 as its done on other platforms implicitly.

Fixes issue #46
