### PR TITLE
[osx] - fix compile

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -28,6 +28,9 @@
 #if defined(AROS)
 #include <sys/time.h>
 #endif
+#if defined(__APPLE__) && defined(__MACH__)
+#include <sys/time.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/libnfs-sync.c
+++ b/lib/libnfs-sync.c
@@ -29,6 +29,10 @@
 #include "win32_compat.h"
 #endif
 
+#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
+
 #ifdef HAVE_NET_IF_H
 #include <net/if.h>
 #endif
@@ -47,10 +51,6 @@
 
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
-#endif
-
-#ifdef HAVE_SYS_SOCKET_H
-#include <sys/socket.h>
 #endif
 
 #ifdef HAVE_POLL_H


### PR DESCRIPTION
Tried to compile latest HEAD on osx - and the following changes were needed for it to compile successfully. 

Also i was told to inform you about this during configure:

configure: WARNING: net/if.h: present but cannot be compiled
configure: WARNING: net/if.h:     check for missing prerequisite headers?
configure: WARNING: net/if.h: see the Autoconf documentation
configure: WARNING: net/if.h:     section "Present But Cannot Be Compiled"
configure: WARNING: net/if.h: proceeding with the preprocessor's result
configure: WARNING: net/if.h: in the future, the compiler will take precedence
configure: WARNING:     ## --------------------------------------- ##
configure: WARNING:     ## Report this to ronniesahlberg@gmail.com ##
configure: WARNING:     ## --------------------------------------- ##

(thats why i needed to move the include of sys/socket.h in front of net/if.h i guess).
