### PR TITLE
nfs-ls: Fix crash when called with no arguments

### DIFF
--- a/utils/nfs-ls.c
+++ b/utils/nfs-ls.c
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
 	uint64_t offset;
 	struct client client;
 	struct statvfs stvfs;
-	struct nfs_url *url;
+	struct nfs_url *url = NULL;
 	exports export, tmp;
 
 #ifdef WIN32


### PR DESCRIPTION
When called with no argument we jump to 'finished' label
after which nfs_destroy_url is called with *url having
some garbage stack value.
