### PR TITLE
socket: fix broken connect for non broadcast traffic

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -506,7 +506,7 @@ static int rpc_connect_sockaddr_async(struct rpc_context *rpc, struct sockaddr_s
 					((struct sockaddr_in6 *)&ss)->sin6_port = port;
 					((struct sockaddr_in6 *)&ss)->sin6_family      = AF_INET6;
 #ifdef HAVE_SOCKADDR_LEN
-					((struct sockaddr_in6 *)&ss)->sin6_len = sizeof(struct sockaddr_in);
+					((struct sockaddr_in6 *)&ss)->sin6_len = sizeof(struct sockaddr6_in);
 #endif
 					break;
 				}
@@ -560,6 +560,7 @@ int rpc_connect_async(struct rpc_context *rpc, const char *server, int port, rpc
 	case AF_INET:
 		((struct sockaddr_in *)&rpc->s)->sin_family = ai->ai_family;
 		((struct sockaddr_in *)&rpc->s)->sin_port   = htons(port);
+		((struct sockaddr_in *)&rpc->s)->sin_addr   = ((struct sockaddr_in *)(ai->ai_addr))->sin_addr;
 #ifdef HAVE_SOCKADDR_LEN
 		((struct sockaddr_in *)&rpc->s)->sin_len = sizeof(struct sockaddr_in);
 #endif
@@ -567,6 +568,7 @@ int rpc_connect_async(struct rpc_context *rpc, const char *server, int port, rpc
 	case AF_INET6:
 		((struct sockaddr_in6 *)&rpc->s)->sin6_family = ai->ai_family;
 		((struct sockaddr_in6 *)&rpc->s)->sin6_port   = htons(port);
+		((struct sockaddr_in6 *)&rpc->s)->sin6_addr   = ((struct sockaddr_in6 *)(ai->ai_addr))->sin6_addr;
 #ifdef HAVE_SOCKADDR_LEN
 		((struct sockaddr_in6 *)&rpc->s)->sin6_len = sizeof(struct sockaddr_in6);
 #endif


### PR DESCRIPTION
commit 1c1e09a completely broke connects for non broadcast
traffic since it forgot to copy the server address into
the socket_storage struct.

Signed-off-by: Peter Lieven pl@kamp.de
