### PR TITLE
add readahead support

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -73,6 +73,7 @@ struct rpc_queue {
 };
 
 #define HASHES 1024
+#define NFS_RA_TIMEOUT 5
 
 struct rpc_context {
 	uint32_t magic;
@@ -115,6 +116,7 @@ struct rpc_context {
 	int tcp_syncnt;
 	int uid;
 	int gid;
+	uint32_t readahead;
 };
 
 struct rpc_pdu {
@@ -174,6 +176,7 @@ void rpc_unset_autoreconnect(struct rpc_context *rpc);
 void rpc_set_tcp_syncnt(struct rpc_context *rpc, int v);
 void rpc_set_uid(struct rpc_context *rpc, int uid);
 void rpc_set_gid(struct rpc_context *rpc, int gid);
+void rpc_set_readahead(struct rpc_context *rpc, uint32_t v);
 
 int rpc_add_fragment(struct rpc_context *rpc, char *data, uint64_t size);
 void rpc_free_all_fragments(struct rpc_context *rpc);

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -36,6 +36,9 @@
 extern "C" {
 #endif
 
+#define LIBNFS_FEATURE_READAHEAD
+#define NFS_BLKSIZE 4096
+
 struct nfs_context;
 struct rpc_context;
 
@@ -184,6 +187,7 @@ EXTERN uint64_t nfs_get_writemax(struct nfs_context *nfs);
 EXTERN void nfs_set_tcp_syncnt(struct nfs_context *nfs, int v);
 EXTERN void nfs_set_uid(struct nfs_context *nfs, int uid);
 EXTERN void nfs_set_gid(struct nfs_context *nfs, int gid);
+EXTERN void nfs_set_readahead(struct nfs_context *nfs, uint32_t v);
 
 /*
  * MOUNT THE EXPORT

--- a/lib/init.c
+++ b/lib/init.c
@@ -91,6 +91,12 @@ struct rpc_context *rpc_init_context(void)
 	return rpc;
 }
 
+void rpc_set_readahead(struct rpc_context *rpc, uint32_t v)
+{
+	assert(rpc->magic == RPC_CONTEXT_MAGIC);
+
+	rpc->readahead = v;
+}
 
 struct rpc_context *rpc_init_udp_context(void)
 {

--- a/lib/libnfs-win32.def
+++ b/lib/libnfs-win32.def
@@ -70,6 +70,7 @@ nfs_set_auth
 nfs_set_gid
 nfs_set_tcp_syncnt
 nfs_set_uid
+nfs_set_readahead
 nfs_stat
 nfs_stat_async
 nfs_stat64


### PR DESCRIPTION
This patch add support for an internal readahead machanism. The maximum readahead
size can be specified via URL parameter readahead. This should significantly
speed up small sequential reads.

Signed-off-by: Peter Lieven pl@kamp.de
