### PR TITLE
libnfs.c: add nfs_create

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -682,6 +682,33 @@ EXTERN int nfs_creat_async(struct nfs_context *nfs, const char *path, int mode, 
  */
 EXTERN int nfs_creat(struct nfs_context *nfs, const char *path, int mode, struct nfsfh **nfsfh);
 
+/*
+ * Async create()
+ *
+ * Same as nfs_creat_async but allows passing flags:
+ * O_APPEND
+ * O_SYNC
+ * O_EXCL
+ *
+ * Function returns
+ *  0 : The operation was initiated. Once the operation finishes, the callback will be invoked.
+ * <0 : An error occured when trying to set up the operation. The callback will not be invoked.
+ *
+ * When the callback is invoked, status indicates the result:
+ *      0 : Success.
+ *          data is a struct *nfsfh;
+ * -errno : An error occured.
+ *          data is the error string.
+ */
+EXTERN int nfs_create_async(struct nfs_context *nfs, const char *path, int flags, int mode, nfs_cb cb, void *private_data);
+/*
+ * Sync create()
+ * Function returns
+ *      0 : Success
+ * -errno : An error occured.
+ */
+EXTERN int nfs_create(struct nfs_context *nfs, const char *path, int flags, int mode, struct nfsfh **nfsfh);
+
 
 /*
  * MKNOD()

--- a/lib/libnfs-sync.c
+++ b/lib/libnfs-sync.c
@@ -696,21 +696,26 @@ static void creat_cb(int status, struct nfs_context *nfs, void *data, void *priv
 	*nfsfh = fh;
 }
 
-int nfs_creat(struct nfs_context *nfs, const char *path, int mode, struct nfsfh **nfsfh)
+int nfs_create(struct nfs_context *nfs, const char *path, int flags, int mode, struct nfsfh **nfsfh)
 {
 	struct sync_cb_data cb_data;
 
 	cb_data.is_finished = 0;
 	cb_data.return_data = nfsfh;
 
-	if (nfs_creat_async(nfs, path, mode, creat_cb, &cb_data) != 0) {
-		nfs_set_error(nfs, "nfs_creat_async failed");
+	if (nfs_create_async(nfs, path, flags, mode, creat_cb, &cb_data) != 0) {
+		nfs_set_error(nfs, "nfs_create_async failed");
 		return -1;
 	}
 
 	wait_for_nfs_reply(nfs, &cb_data);
 
 	return cb_data.status;
+}
+
+int nfs_creat(struct nfs_context *nfs, const char *path, int mode, struct nfsfh **nfsfh)
+{
+	return nfs_create(nfs, path, 0, mode, nfsfh);
 }
 
 /*


### PR DESCRIPTION
Add a new family of functions, nfs_create, like nfs_creat but takes an
additional flags argument which allows extra flags like O_SYNC, O_EXCL
and O_APPEND to be specified.
