### PR TITLE
Use sockaddr_in6 on FreeBSD

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -506,7 +506,7 @@ static int rpc_connect_sockaddr_async(struct rpc_context *rpc, struct sockaddr_s
 					((struct sockaddr_in6 *)&ss)->sin6_port = port;
 					((struct sockaddr_in6 *)&ss)->sin6_family      = AF_INET6;
 #ifdef HAVE_SOCKADDR_LEN
-					((struct sockaddr_in6 *)&ss)->sin6_len = sizeof(struct sockaddr6_in);
+					((struct sockaddr_in6 *)&ss)->sin6_len = sizeof(struct sockaddr_in6);
 #endif
 					break;
 				}


### PR DESCRIPTION
This is expected to fix build failure on Debian/kFreeBSD:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=754646

I could not test this commit on FreeBSD, but on Linux it does not break the build.
