### PR TITLE
Fix help message for fuse_nfs example

### DIFF
--- a/examples/fuse_nfs.c
+++ b/examples/fuse_nfs.c
@@ -248,11 +248,13 @@ int main(int argc, char *argv[])
 
 	if (url == NULL) {
 		fprintf(stderr, "-n was not specified.\n");
+		print_usage(argv[0]);
 		ret = 10;
 		goto finished;
 	}
 	if (mnt == NULL) {
 		fprintf(stderr, "-m was not specified.\n");
+		print_usage(argv[0]);
 		ret = 10;
 		goto finished;
 	}


### PR DESCRIPTION
Changes the help message to reflect actual behaviour (`-m` or `--mountpoint` expected).

Second commit prints the usage message when a mandatory argument is missing because chances are you didn't read the docs and are also missing `-m` if you're missing `-n`.
