### PR TITLE
set_tcp_sockopt should be static

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -109,7 +109,7 @@ static void set_nolinger(int fd)
 }
 
 #ifdef HAVE_NETINET_TCP_H
-int set_tcp_sockopt(int sockfd, int optname, int value)
+static int set_tcp_sockopt(int sockfd, int optname, int value)
 {
 	int level;
 


### PR DESCRIPTION
otherwise it prevents linking with libiscsi, which has function of the same name, also not static.

Same fix needs to go in to libiscsi.