### PR TITLE
fuse_nfs: Disable multithreading

### DIFF
--- a/examples/fuse_nfs.c
+++ b/examples/fuse_nfs.c
@@ -210,14 +210,14 @@ int main(int argc, char *argv[])
 	char *url = NULL;
 	char *mnt = NULL;
 	char *server = NULL, *export = NULL, *strp;
-	int fuse_nfs_argc = 5;
+	int fuse_nfs_argc = 6;
 	char *fuse_nfs_argv[16] = {
 		"fuse-nfs",
 		"<export>",
 		"-oallow_other",
 		"-odefault_permissions",
 		"-omax_write=32768",
-		NULL,
+		"-s",
 		NULL,
 		NULL,
 		NULL,


### PR DESCRIPTION
If we blindly spawn new threads based on existing open NFS shares, all
threads will concurrently still run on the same file descriptors for NFS
traffic, colliding sooner or later.

This is what happens with the fuse-nfs example program. To steer us back
into safety, we can just tell fuse to not do multi-threading which this
patch does.

This patch fixes random connection aborts with fuse_nfs for me.

Signed-off-by: Alexander Graf <agraf@suse.de>