### PR TITLE
Make --disable-werror actually work

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,7 @@ AC_ARG_ENABLE([werror], [AS_HELP_STRING([--disable-werror],
               [Disables building with -Werror by default])])
 
 if test "$ac_cv_prog_gcc" = yes; then
-   WARN_CFLAGS="-Wall -Werror -Wshadow -Wno-write-strings -Wstrict-prototypes -Wpointer-arith -Wcast-align -Wno-strict-aliasing"
+   WARN_CFLAGS="-Wall -Wshadow -Wno-write-strings -Wstrict-prototypes -Wpointer-arith -Wcast-align -Wno-strict-aliasing"
    if test "x$enable_werror" != "xno"; then
        WARN_CFLAGS="$WARN_CFLAGS -Werror"
    fi


### PR DESCRIPTION
In 84607f4821f0210a62a4e7b93480a702b10fb83a  WARN_CFLAGS has -Werror set from the beginning and test "x$enable_werror" != "xno" adds it for the second time,  thus --disable-werror will not work.