### PR TITLE
[Cosmetic]: Remove unused variables and eliminate  [-Wunused-variable] warnings

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -759,7 +759,6 @@ int rpc_queue_length(struct rpc_context *rpc)
 {
 	int i=0;
 	struct rpc_pdu *pdu;
-	unsigned int n;
 
 	assert(rpc->magic == RPC_CONTEXT_MAGIC);
 

--- a/mount/libnfs-raw-mount.c
+++ b/mount/libnfs-raw-mount.c
@@ -6,7 +6,7 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer. 
+   list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
@@ -23,7 +23,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies, 
+of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
@@ -38,9 +38,6 @@ either expressed or implied, of the FreeBSD Project.
 uint32_t
 zdr_fhandle3 (ZDR *zdrs, fhandle3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->fhandle3_val, (u_int *) &objp->fhandle3_len, FHSIZE3))
 		 return FALSE;
 	return TRUE;
@@ -49,9 +46,6 @@ zdr_fhandle3 (ZDR *zdrs, fhandle3 *objp)
 uint32_t
 zdr_dirpath (ZDR *zdrs, dirpath *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, objp, MNTPATHLEN))
 		 return FALSE;
 	return TRUE;
@@ -60,9 +54,6 @@ zdr_dirpath (ZDR *zdrs, dirpath *objp)
 uint32_t
 zdr_name (ZDR *zdrs, name *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, objp, MNTNAMLEN))
 		 return FALSE;
 	return TRUE;
@@ -71,9 +62,6 @@ zdr_name (ZDR *zdrs, name *objp)
 uint32_t
 zdr_mountstat3 (ZDR *zdrs, mountstat3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -82,9 +70,6 @@ zdr_mountstat3 (ZDR *zdrs, mountstat3 *objp)
 uint32_t
 zdr_mountlist (ZDR *zdrs, mountlist *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pointer (zdrs, (char **)objp, sizeof (struct mountbody), (zdrproc_t) zdr_mountbody))
 		 return FALSE;
 	return TRUE;
@@ -93,9 +78,6 @@ zdr_mountlist (ZDR *zdrs, mountlist *objp)
 uint32_t
 zdr_mountbody (ZDR *zdrs, mountbody *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_name (zdrs, &objp->ml_hostname))
 		 return FALSE;
 	 if (!zdr_dirpath (zdrs, &objp->ml_directory))
@@ -108,9 +90,6 @@ zdr_mountbody (ZDR *zdrs, mountbody *objp)
 uint32_t
 zdr_groups (ZDR *zdrs, groups *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pointer (zdrs, (char **)objp, sizeof (struct groupnode), (zdrproc_t) zdr_groupnode))
 		 return FALSE;
 	return TRUE;
@@ -119,9 +98,6 @@ zdr_groups (ZDR *zdrs, groups *objp)
 uint32_t
 zdr_groupnode (ZDR *zdrs, groupnode *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_name (zdrs, &objp->gr_name))
 		 return FALSE;
 	 if (!zdr_groups (zdrs, &objp->gr_next))
@@ -132,9 +108,6 @@ zdr_groupnode (ZDR *zdrs, groupnode *objp)
 uint32_t
 zdr_exports (ZDR *zdrs, exports *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pointer (zdrs, (char **)objp, sizeof (struct exportnode), (zdrproc_t) zdr_exportnode))
 		 return FALSE;
 	return TRUE;
@@ -143,9 +116,6 @@ zdr_exports (ZDR *zdrs, exports *objp)
 uint32_t
 zdr_exportnode (ZDR *zdrs, exportnode *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_dirpath (zdrs, &objp->ex_dir))
 		 return FALSE;
 	 if (!zdr_groups (zdrs, &objp->ex_groups))
@@ -158,9 +128,6 @@ zdr_exportnode (ZDR *zdrs, exportnode *objp)
 uint32_t
 zdr_mountres3_ok (ZDR *zdrs, mountres3_ok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle3 (zdrs, &objp->fhandle))
 		 return FALSE;
 	 if (!zdr_array (zdrs, (char **)&objp->auth_flavors.auth_flavors_val, (u_int *) &objp->auth_flavors.auth_flavors_len, ~0,
@@ -172,9 +139,6 @@ zdr_mountres3_ok (ZDR *zdrs, mountres3_ok *objp)
 uint32_t
 zdr_mountres3 (ZDR *zdrs, mountres3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_mountstat3 (zdrs, &objp->fhs_status))
 		 return FALSE;
 	switch (objp->fhs_status) {
@@ -191,9 +155,6 @@ zdr_mountres3 (ZDR *zdrs, mountres3 *objp)
 uint32_t
 zdr_mountstat1 (ZDR *zdrs, mountstat1 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -202,9 +163,6 @@ zdr_mountstat1 (ZDR *zdrs, mountstat1 *objp)
 uint32_t
 zdr_fhandle1 (ZDR *zdrs, fhandle1 objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, FHSIZE))
 		 return FALSE;
 	return TRUE;
@@ -213,9 +171,6 @@ zdr_fhandle1 (ZDR *zdrs, fhandle1 objp)
 uint32_t
 zdr_mountres1_ok (ZDR *zdrs, mountres1_ok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle1 (zdrs, objp->fhandle))
 		 return FALSE;
 	return TRUE;
@@ -224,9 +179,6 @@ zdr_mountres1_ok (ZDR *zdrs, mountres1_ok *objp)
 uint32_t
 zdr_mountres1 (ZDR *zdrs, mountres1 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_mountstat1 (zdrs, &objp->fhs_status))
 		 return FALSE;
 	switch (objp->fhs_status) {

--- a/nfs/libnfs-raw-nfs.c
+++ b/nfs/libnfs-raw-nfs.c
@@ -6,7 +6,7 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer. 
+   list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
@@ -23,7 +23,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies, 
+of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
@@ -38,9 +38,6 @@ either expressed or implied, of the FreeBSD Project.
 uint32_t
 zdr_cookieverf3 (ZDR *zdrs, cookieverf3 objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, NFS3_COOKIEVERFSIZE))
 		 return FALSE;
 	return TRUE;
@@ -49,9 +46,6 @@ zdr_cookieverf3 (ZDR *zdrs, cookieverf3 objp)
 uint32_t
 zdr_cookie3 (ZDR *zdrs, cookie3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -60,9 +54,6 @@ zdr_cookie3 (ZDR *zdrs, cookie3 *objp)
 uint32_t
 zdr_nfs_fh3 (ZDR *zdrs, nfs_fh3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->data.data_val, (u_int *) &objp->data.data_len, NFS3_FHSIZE))
 		 return FALSE;
 	return TRUE;
@@ -71,9 +62,6 @@ zdr_nfs_fh3 (ZDR *zdrs, nfs_fh3 *objp)
 uint32_t
 zdr_filename3 (ZDR *zdrs, filename3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, objp, ~0))
 		 return FALSE;
 	return TRUE;
@@ -82,9 +70,6 @@ zdr_filename3 (ZDR *zdrs, filename3 *objp)
 uint32_t
 zdr_diropargs3 (ZDR *zdrs, diropargs3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->dir))
 		 return FALSE;
 	 if (!zdr_filename3 (zdrs, &objp->name))
@@ -95,9 +80,6 @@ zdr_diropargs3 (ZDR *zdrs, diropargs3 *objp)
 uint32_t
 zdr_ftype3 (ZDR *zdrs, ftype3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -106,9 +88,6 @@ zdr_ftype3 (ZDR *zdrs, ftype3 *objp)
 uint32_t
 zdr_mode3 (ZDR *zdrs, mode3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -117,9 +96,6 @@ zdr_mode3 (ZDR *zdrs, mode3 *objp)
 uint32_t
 zdr_uid3 (ZDR *zdrs, uid3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -128,9 +104,6 @@ zdr_uid3 (ZDR *zdrs, uid3 *objp)
 uint32_t
 zdr_gid3 (ZDR *zdrs, gid3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -139,9 +112,6 @@ zdr_gid3 (ZDR *zdrs, gid3 *objp)
 uint32_t
 zdr_size3 (ZDR *zdrs, size3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -150,9 +120,6 @@ zdr_size3 (ZDR *zdrs, size3 *objp)
 uint32_t
 zdr_fileid3 (ZDR *zdrs, fileid3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -161,9 +128,6 @@ zdr_fileid3 (ZDR *zdrs, fileid3 *objp)
 uint32_t
 zdr_specdata3 (ZDR *zdrs, specdata3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->specdata1))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->specdata2))
@@ -174,9 +138,6 @@ zdr_specdata3 (ZDR *zdrs, specdata3 *objp)
 uint32_t
 zdr_nfstime3 (ZDR *zdrs, nfstime3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->seconds))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->nseconds))
@@ -187,9 +148,6 @@ zdr_nfstime3 (ZDR *zdrs, nfstime3 *objp)
 uint32_t
 zdr_fattr3 (ZDR *zdrs, fattr3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_ftype3 (zdrs, &objp->type))
 		 return FALSE;
 	 if (!zdr_mode3 (zdrs, &objp->mode))
@@ -222,9 +180,6 @@ zdr_fattr3 (ZDR *zdrs, fattr3 *objp)
 uint32_t
 zdr_post_op_attr (ZDR *zdrs, post_op_attr *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->attributes_follow))
 		 return FALSE;
 	switch (objp->attributes_follow) {
@@ -243,9 +198,6 @@ zdr_post_op_attr (ZDR *zdrs, post_op_attr *objp)
 uint32_t
 zdr_nfsstat3 (ZDR *zdrs, nfsstat3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -254,9 +206,6 @@ zdr_nfsstat3 (ZDR *zdrs, nfsstat3 *objp)
 uint32_t
 zdr_stable_how (ZDR *zdrs, stable_how *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -265,9 +214,6 @@ zdr_stable_how (ZDR *zdrs, stable_how *objp)
 uint32_t
 zdr_offset3 (ZDR *zdrs, offset3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -276,9 +222,6 @@ zdr_offset3 (ZDR *zdrs, offset3 *objp)
 uint32_t
 zdr_count3 (ZDR *zdrs, count3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -287,9 +230,6 @@ zdr_count3 (ZDR *zdrs, count3 *objp)
 uint32_t
 zdr_wcc_attr (ZDR *zdrs, wcc_attr *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_size3 (zdrs, &objp->size))
 		 return FALSE;
 	 if (!zdr_nfstime3 (zdrs, &objp->mtime))
@@ -302,9 +242,6 @@ zdr_wcc_attr (ZDR *zdrs, wcc_attr *objp)
 uint32_t
 zdr_pre_op_attr (ZDR *zdrs, pre_op_attr *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->attributes_follow))
 		 return FALSE;
 	switch (objp->attributes_follow) {
@@ -323,9 +260,6 @@ zdr_pre_op_attr (ZDR *zdrs, pre_op_attr *objp)
 uint32_t
 zdr_wcc_data (ZDR *zdrs, wcc_data *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pre_op_attr (zdrs, &objp->before))
 		 return FALSE;
 	 if (!zdr_post_op_attr (zdrs, &objp->after))
@@ -336,9 +270,6 @@ zdr_wcc_data (ZDR *zdrs, wcc_data *objp)
 uint32_t
 zdr_WRITE3args (ZDR *zdrs, WRITE3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->file))
 		 return FALSE;
 	 if (!zdr_offset3 (zdrs, &objp->offset))
@@ -355,9 +286,6 @@ zdr_WRITE3args (ZDR *zdrs, WRITE3args *objp)
 uint32_t
 zdr_writeverf3 (ZDR *zdrs, writeverf3 objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, NFS3_WRITEVERFSIZE))
 		 return FALSE;
 	return TRUE;
@@ -366,9 +294,6 @@ zdr_writeverf3 (ZDR *zdrs, writeverf3 objp)
 uint32_t
 zdr_WRITE3resok (ZDR *zdrs, WRITE3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->file_wcc))
 		 return FALSE;
 	 if (!zdr_count3 (zdrs, &objp->count))
@@ -383,9 +308,6 @@ zdr_WRITE3resok (ZDR *zdrs, WRITE3resok *objp)
 uint32_t
 zdr_WRITE3resfail (ZDR *zdrs, WRITE3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->file_wcc))
 		 return FALSE;
 	return TRUE;
@@ -394,9 +316,6 @@ zdr_WRITE3resfail (ZDR *zdrs, WRITE3resfail *objp)
 uint32_t
 zdr_WRITE3res (ZDR *zdrs, WRITE3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -415,9 +334,6 @@ zdr_WRITE3res (ZDR *zdrs, WRITE3res *objp)
 uint32_t
 zdr_LOOKUP3args (ZDR *zdrs, LOOKUP3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->what))
 		 return FALSE;
 	return TRUE;
@@ -426,9 +342,6 @@ zdr_LOOKUP3args (ZDR *zdrs, LOOKUP3args *objp)
 uint32_t
 zdr_LOOKUP3resok (ZDR *zdrs, LOOKUP3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->object))
 		 return FALSE;
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -441,9 +354,6 @@ zdr_LOOKUP3resok (ZDR *zdrs, LOOKUP3resok *objp)
 uint32_t
 zdr_LOOKUP3resfail (ZDR *zdrs, LOOKUP3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->dir_attributes))
 		 return FALSE;
 	return TRUE;
@@ -452,9 +362,6 @@ zdr_LOOKUP3resfail (ZDR *zdrs, LOOKUP3resfail *objp)
 uint32_t
 zdr_LOOKUP3res (ZDR *zdrs, LOOKUP3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -473,9 +380,6 @@ zdr_LOOKUP3res (ZDR *zdrs, LOOKUP3res *objp)
 uint32_t
 zdr_COMMIT3args (ZDR *zdrs, COMMIT3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->file))
 		 return FALSE;
 	 if (!zdr_offset3 (zdrs, &objp->offset))
@@ -488,9 +392,6 @@ zdr_COMMIT3args (ZDR *zdrs, COMMIT3args *objp)
 uint32_t
 zdr_COMMIT3resok (ZDR *zdrs, COMMIT3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->file_wcc))
 		 return FALSE;
 	 if (!zdr_writeverf3 (zdrs, objp->verf))
@@ -501,9 +402,6 @@ zdr_COMMIT3resok (ZDR *zdrs, COMMIT3resok *objp)
 uint32_t
 zdr_COMMIT3resfail (ZDR *zdrs, COMMIT3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->file_wcc))
 		 return FALSE;
 	return TRUE;
@@ -512,9 +410,6 @@ zdr_COMMIT3resfail (ZDR *zdrs, COMMIT3resfail *objp)
 uint32_t
 zdr_COMMIT3res (ZDR *zdrs, COMMIT3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -533,9 +428,6 @@ zdr_COMMIT3res (ZDR *zdrs, COMMIT3res *objp)
 uint32_t
 zdr_ACCESS3args (ZDR *zdrs, ACCESS3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->object))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->access))
@@ -546,9 +438,6 @@ zdr_ACCESS3args (ZDR *zdrs, ACCESS3args *objp)
 uint32_t
 zdr_ACCESS3resok (ZDR *zdrs, ACCESS3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->access))
@@ -559,9 +448,6 @@ zdr_ACCESS3resok (ZDR *zdrs, ACCESS3resok *objp)
 uint32_t
 zdr_ACCESS3resfail (ZDR *zdrs, ACCESS3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -570,9 +456,6 @@ zdr_ACCESS3resfail (ZDR *zdrs, ACCESS3resfail *objp)
 uint32_t
 zdr_ACCESS3res (ZDR *zdrs, ACCESS3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -591,9 +474,6 @@ zdr_ACCESS3res (ZDR *zdrs, ACCESS3res *objp)
 uint32_t
 zdr_GETATTR3args (ZDR *zdrs, GETATTR3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->object))
 		 return FALSE;
 	return TRUE;
@@ -602,9 +482,6 @@ zdr_GETATTR3args (ZDR *zdrs, GETATTR3args *objp)
 uint32_t
 zdr_GETATTR3resok (ZDR *zdrs, GETATTR3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fattr3 (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -613,9 +490,6 @@ zdr_GETATTR3resok (ZDR *zdrs, GETATTR3resok *objp)
 uint32_t
 zdr_GETATTR3res (ZDR *zdrs, GETATTR3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -632,9 +506,6 @@ zdr_GETATTR3res (ZDR *zdrs, GETATTR3res *objp)
 uint32_t
 zdr_time_how (ZDR *zdrs, time_how *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -643,9 +514,6 @@ zdr_time_how (ZDR *zdrs, time_how *objp)
 uint32_t
 zdr_set_mode3 (ZDR *zdrs, set_mode3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -662,9 +530,6 @@ zdr_set_mode3 (ZDR *zdrs, set_mode3 *objp)
 uint32_t
 zdr_set_uid3 (ZDR *zdrs, set_uid3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -681,9 +546,6 @@ zdr_set_uid3 (ZDR *zdrs, set_uid3 *objp)
 uint32_t
 zdr_set_gid3 (ZDR *zdrs, set_gid3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -700,9 +562,6 @@ zdr_set_gid3 (ZDR *zdrs, set_gid3 *objp)
 uint32_t
 zdr_set_size3 (ZDR *zdrs, set_size3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -719,9 +578,6 @@ zdr_set_size3 (ZDR *zdrs, set_size3 *objp)
 uint32_t
 zdr_set_atime (ZDR *zdrs, set_atime *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_time_how (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -738,9 +594,6 @@ zdr_set_atime (ZDR *zdrs, set_atime *objp)
 uint32_t
 zdr_set_mtime (ZDR *zdrs, set_mtime *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_time_how (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -757,9 +610,6 @@ zdr_set_mtime (ZDR *zdrs, set_mtime *objp)
 uint32_t
 zdr_sattr3 (ZDR *zdrs, sattr3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_set_mode3 (zdrs, &objp->mode))
 		 return FALSE;
 	 if (!zdr_set_uid3 (zdrs, &objp->uid))
@@ -778,9 +628,6 @@ zdr_sattr3 (ZDR *zdrs, sattr3 *objp)
 uint32_t
 zdr_createmode3 (ZDR *zdrs, createmode3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -789,9 +636,6 @@ zdr_createmode3 (ZDR *zdrs, createmode3 *objp)
 uint32_t
 zdr_createverf3 (ZDR *zdrs, createverf3 objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, NFS3_CREATEVERFSIZE))
 		 return FALSE;
 	return TRUE;
@@ -800,9 +644,6 @@ zdr_createverf3 (ZDR *zdrs, createverf3 objp)
 uint32_t
 zdr_createhow3 (ZDR *zdrs, createhow3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_createmode3 (zdrs, &objp->mode))
 		 return FALSE;
 	switch (objp->mode) {
@@ -827,9 +668,6 @@ zdr_createhow3 (ZDR *zdrs, createhow3 *objp)
 uint32_t
 zdr_CREATE3args (ZDR *zdrs, CREATE3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->where))
 		 return FALSE;
 	 if (!zdr_createhow3 (zdrs, &objp->how))
@@ -840,9 +678,6 @@ zdr_CREATE3args (ZDR *zdrs, CREATE3args *objp)
 uint32_t
 zdr_post_op_fh3 (ZDR *zdrs, post_op_fh3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->handle_follows))
 		 return FALSE;
 	switch (objp->handle_follows) {
@@ -861,9 +696,6 @@ zdr_post_op_fh3 (ZDR *zdrs, post_op_fh3 *objp)
 uint32_t
 zdr_CREATE3resok (ZDR *zdrs, CREATE3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_fh3 (zdrs, &objp->obj))
 		 return FALSE;
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -876,9 +708,6 @@ zdr_CREATE3resok (ZDR *zdrs, CREATE3resok *objp)
 uint32_t
 zdr_CREATE3resfail (ZDR *zdrs, CREATE3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -887,9 +716,6 @@ zdr_CREATE3resfail (ZDR *zdrs, CREATE3resfail *objp)
 uint32_t
 zdr_CREATE3res (ZDR *zdrs, CREATE3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -908,9 +734,6 @@ zdr_CREATE3res (ZDR *zdrs, CREATE3res *objp)
 uint32_t
 zdr_REMOVE3args (ZDR *zdrs, REMOVE3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->object))
 		 return FALSE;
 	return TRUE;
@@ -919,9 +742,6 @@ zdr_REMOVE3args (ZDR *zdrs, REMOVE3args *objp)
 uint32_t
 zdr_REMOVE3resok (ZDR *zdrs, REMOVE3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -930,9 +750,6 @@ zdr_REMOVE3resok (ZDR *zdrs, REMOVE3resok *objp)
 uint32_t
 zdr_REMOVE3resfail (ZDR *zdrs, REMOVE3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -941,9 +758,6 @@ zdr_REMOVE3resfail (ZDR *zdrs, REMOVE3resfail *objp)
 uint32_t
 zdr_REMOVE3res (ZDR *zdrs, REMOVE3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -962,9 +776,6 @@ zdr_REMOVE3res (ZDR *zdrs, REMOVE3res *objp)
 uint32_t
 zdr_READ3args (ZDR *zdrs, READ3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->file))
 		 return FALSE;
 	 if (!zdr_offset3 (zdrs, &objp->offset))
@@ -977,9 +788,6 @@ zdr_READ3args (ZDR *zdrs, READ3args *objp)
 uint32_t
 zdr_READ3resok (ZDR *zdrs, READ3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->file_attributes))
 		 return FALSE;
 	 if (!zdr_count3 (zdrs, &objp->count))
@@ -994,9 +802,6 @@ zdr_READ3resok (ZDR *zdrs, READ3resok *objp)
 uint32_t
 zdr_READ3resfail (ZDR *zdrs, READ3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->file_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1005,9 +810,6 @@ zdr_READ3resfail (ZDR *zdrs, READ3resfail *objp)
 uint32_t
 zdr_READ3res (ZDR *zdrs, READ3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1026,9 +828,6 @@ zdr_READ3res (ZDR *zdrs, READ3res *objp)
 uint32_t
 zdr_FSINFO3args (ZDR *zdrs, FSINFO3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->fsroot))
 		 return FALSE;
 	return TRUE;
@@ -1039,7 +838,6 @@ zdr_FSINFO3resok (ZDR *zdrs, FSINFO3resok *objp)
 {
 	register int32_t *buf;
 	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -1143,9 +941,6 @@ zdr_FSINFO3resok (ZDR *zdrs, FSINFO3resok *objp)
 uint32_t
 zdr_FSINFO3resfail (ZDR *zdrs, FSINFO3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1154,9 +949,6 @@ zdr_FSINFO3resfail (ZDR *zdrs, FSINFO3resfail *objp)
 uint32_t
 zdr_FSINFO3res (ZDR *zdrs, FSINFO3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1175,9 +967,6 @@ zdr_FSINFO3res (ZDR *zdrs, FSINFO3res *objp)
 uint32_t
 zdr_FSSTAT3args (ZDR *zdrs, FSSTAT3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->fsroot))
 		 return FALSE;
 	return TRUE;
@@ -1186,9 +975,6 @@ zdr_FSSTAT3args (ZDR *zdrs, FSSTAT3args *objp)
 uint32_t
 zdr_FSSTAT3resok (ZDR *zdrs, FSSTAT3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	 if (!zdr_size3 (zdrs, &objp->tbytes))
@@ -1211,9 +997,6 @@ zdr_FSSTAT3resok (ZDR *zdrs, FSSTAT3resok *objp)
 uint32_t
 zdr_FSSTAT3resfail (ZDR *zdrs, FSSTAT3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1222,9 +1005,6 @@ zdr_FSSTAT3resfail (ZDR *zdrs, FSSTAT3resfail *objp)
 uint32_t
 zdr_FSSTAT3res (ZDR *zdrs, FSSTAT3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1243,9 +1023,6 @@ zdr_FSSTAT3res (ZDR *zdrs, FSSTAT3res *objp)
 uint32_t
 zdr_PATHCONF3args (ZDR *zdrs, PATHCONF3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->object))
 		 return FALSE;
 	return TRUE;
@@ -1256,7 +1033,6 @@ zdr_PATHCONF3resok (ZDR *zdrs, PATHCONF3resok *objp)
 {
 	register int32_t *buf;
 	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -1332,9 +1108,6 @@ zdr_PATHCONF3resok (ZDR *zdrs, PATHCONF3resok *objp)
 uint32_t
 zdr_PATHCONF3resfail (ZDR *zdrs, PATHCONF3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1343,9 +1116,6 @@ zdr_PATHCONF3resfail (ZDR *zdrs, PATHCONF3resfail *objp)
 uint32_t
 zdr_PATHCONF3res (ZDR *zdrs, PATHCONF3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1364,9 +1134,6 @@ zdr_PATHCONF3res (ZDR *zdrs, PATHCONF3res *objp)
 uint32_t
 zdr_nfspath3 (ZDR *zdrs, nfspath3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, objp, ~0))
 		 return FALSE;
 	return TRUE;
@@ -1375,9 +1142,6 @@ zdr_nfspath3 (ZDR *zdrs, nfspath3 *objp)
 uint32_t
 zdr_symlinkdata3 (ZDR *zdrs, symlinkdata3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_sattr3 (zdrs, &objp->symlink_attributes))
 		 return FALSE;
 	 if (!zdr_nfspath3 (zdrs, &objp->symlink_data))
@@ -1388,9 +1152,6 @@ zdr_symlinkdata3 (ZDR *zdrs, symlinkdata3 *objp)
 uint32_t
 zdr_SYMLINK3args (ZDR *zdrs, SYMLINK3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->where))
 		 return FALSE;
 	 if (!zdr_symlinkdata3 (zdrs, &objp->symlink))
@@ -1401,9 +1162,6 @@ zdr_SYMLINK3args (ZDR *zdrs, SYMLINK3args *objp)
 uint32_t
 zdr_SYMLINK3resok (ZDR *zdrs, SYMLINK3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_fh3 (zdrs, &objp->obj))
 		 return FALSE;
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -1416,9 +1174,6 @@ zdr_SYMLINK3resok (ZDR *zdrs, SYMLINK3resok *objp)
 uint32_t
 zdr_SYMLINK3resfail (ZDR *zdrs, SYMLINK3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -1427,9 +1182,6 @@ zdr_SYMLINK3resfail (ZDR *zdrs, SYMLINK3resfail *objp)
 uint32_t
 zdr_SYMLINK3res (ZDR *zdrs, SYMLINK3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1448,9 +1200,6 @@ zdr_SYMLINK3res (ZDR *zdrs, SYMLINK3res *objp)
 uint32_t
 zdr_READLINK3args (ZDR *zdrs, READLINK3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->symlink))
 		 return FALSE;
 	return TRUE;
@@ -1459,9 +1208,6 @@ zdr_READLINK3args (ZDR *zdrs, READLINK3args *objp)
 uint32_t
 zdr_READLINK3resok (ZDR *zdrs, READLINK3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->symlink_attributes))
 		 return FALSE;
 	 if (!zdr_nfspath3 (zdrs, &objp->data))
@@ -1472,9 +1218,6 @@ zdr_READLINK3resok (ZDR *zdrs, READLINK3resok *objp)
 uint32_t
 zdr_READLINK3resfail (ZDR *zdrs, READLINK3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->symlink_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1483,9 +1226,6 @@ zdr_READLINK3resfail (ZDR *zdrs, READLINK3resfail *objp)
 uint32_t
 zdr_READLINK3res (ZDR *zdrs, READLINK3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1504,9 +1244,6 @@ zdr_READLINK3res (ZDR *zdrs, READLINK3res *objp)
 uint32_t
 zdr_devicedata3 (ZDR *zdrs, devicedata3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_sattr3 (zdrs, &objp->dev_attributes))
 		 return FALSE;
 	 if (!zdr_specdata3 (zdrs, &objp->spec))
@@ -1517,9 +1254,6 @@ zdr_devicedata3 (ZDR *zdrs, devicedata3 *objp)
 uint32_t
 zdr_mknoddata3 (ZDR *zdrs, mknoddata3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_ftype3 (zdrs, &objp->type))
 		 return FALSE;
 	switch (objp->type) {
@@ -1548,9 +1282,6 @@ zdr_mknoddata3 (ZDR *zdrs, mknoddata3 *objp)
 uint32_t
 zdr_MKNOD3args (ZDR *zdrs, MKNOD3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->where))
 		 return FALSE;
 	 if (!zdr_mknoddata3 (zdrs, &objp->what))
@@ -1561,9 +1292,6 @@ zdr_MKNOD3args (ZDR *zdrs, MKNOD3args *objp)
 uint32_t
 zdr_MKNOD3resok (ZDR *zdrs, MKNOD3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_fh3 (zdrs, &objp->obj))
 		 return FALSE;
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -1576,9 +1304,6 @@ zdr_MKNOD3resok (ZDR *zdrs, MKNOD3resok *objp)
 uint32_t
 zdr_MKNOD3resfail (ZDR *zdrs, MKNOD3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -1587,9 +1312,6 @@ zdr_MKNOD3resfail (ZDR *zdrs, MKNOD3resfail *objp)
 uint32_t
 zdr_MKNOD3res (ZDR *zdrs, MKNOD3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1608,9 +1330,6 @@ zdr_MKNOD3res (ZDR *zdrs, MKNOD3res *objp)
 uint32_t
 zdr_MKDIR3args (ZDR *zdrs, MKDIR3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->where))
 		 return FALSE;
 	 if (!zdr_sattr3 (zdrs, &objp->attributes))
@@ -1621,9 +1340,6 @@ zdr_MKDIR3args (ZDR *zdrs, MKDIR3args *objp)
 uint32_t
 zdr_MKDIR3resok (ZDR *zdrs, MKDIR3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_fh3 (zdrs, &objp->obj))
 		 return FALSE;
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -1636,9 +1352,6 @@ zdr_MKDIR3resok (ZDR *zdrs, MKDIR3resok *objp)
 uint32_t
 zdr_MKDIR3resfail (ZDR *zdrs, MKDIR3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -1647,9 +1360,6 @@ zdr_MKDIR3resfail (ZDR *zdrs, MKDIR3resfail *objp)
 uint32_t
 zdr_MKDIR3res (ZDR *zdrs, MKDIR3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1668,9 +1378,6 @@ zdr_MKDIR3res (ZDR *zdrs, MKDIR3res *objp)
 uint32_t
 zdr_RMDIR3args (ZDR *zdrs, RMDIR3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->object))
 		 return FALSE;
 	return TRUE;
@@ -1679,9 +1386,6 @@ zdr_RMDIR3args (ZDR *zdrs, RMDIR3args *objp)
 uint32_t
 zdr_RMDIR3resok (ZDR *zdrs, RMDIR3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -1690,9 +1394,6 @@ zdr_RMDIR3resok (ZDR *zdrs, RMDIR3resok *objp)
 uint32_t
 zdr_RMDIR3resfail (ZDR *zdrs, RMDIR3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -1701,9 +1402,6 @@ zdr_RMDIR3resfail (ZDR *zdrs, RMDIR3resfail *objp)
 uint32_t
 zdr_RMDIR3res (ZDR *zdrs, RMDIR3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1722,9 +1420,6 @@ zdr_RMDIR3res (ZDR *zdrs, RMDIR3res *objp)
 uint32_t
 zdr_RENAME3args (ZDR *zdrs, RENAME3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->from))
 		 return FALSE;
 	 if (!zdr_diropargs3 (zdrs, &objp->to))
@@ -1735,9 +1430,6 @@ zdr_RENAME3args (ZDR *zdrs, RENAME3args *objp)
 uint32_t
 zdr_RENAME3resok (ZDR *zdrs, RENAME3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->fromdir_wcc))
 		 return FALSE;
 	 if (!zdr_wcc_data (zdrs, &objp->todir_wcc))
@@ -1748,9 +1440,6 @@ zdr_RENAME3resok (ZDR *zdrs, RENAME3resok *objp)
 uint32_t
 zdr_RENAME3resfail (ZDR *zdrs, RENAME3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->fromdir_wcc))
 		 return FALSE;
 	 if (!zdr_wcc_data (zdrs, &objp->todir_wcc))
@@ -1761,9 +1450,6 @@ zdr_RENAME3resfail (ZDR *zdrs, RENAME3resfail *objp)
 uint32_t
 zdr_RENAME3res (ZDR *zdrs, RENAME3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1782,9 +1468,6 @@ zdr_RENAME3res (ZDR *zdrs, RENAME3res *objp)
 uint32_t
 zdr_READDIRPLUS3args (ZDR *zdrs, READDIRPLUS3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->dir))
 		 return FALSE;
 	 if (!zdr_cookie3 (zdrs, &objp->cookie))
@@ -1801,9 +1484,6 @@ zdr_READDIRPLUS3args (ZDR *zdrs, READDIRPLUS3args *objp)
 uint32_t
 zdr_entryplus3 (ZDR *zdrs, entryplus3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fileid3 (zdrs, &objp->fileid))
 		 return FALSE;
 	 if (!zdr_filename3 (zdrs, &objp->name))
@@ -1822,9 +1502,6 @@ zdr_entryplus3 (ZDR *zdrs, entryplus3 *objp)
 uint32_t
 zdr_dirlistplus3 (ZDR *zdrs, dirlistplus3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pointer (zdrs, (char **)&objp->entries, sizeof (entryplus3), (zdrproc_t) zdr_entryplus3))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->eof))
@@ -1835,9 +1512,6 @@ zdr_dirlistplus3 (ZDR *zdrs, dirlistplus3 *objp)
 uint32_t
 zdr_READDIRPLUS3resok (ZDR *zdrs, READDIRPLUS3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->dir_attributes))
 		 return FALSE;
 	 if (!zdr_cookieverf3 (zdrs, objp->cookieverf))
@@ -1850,9 +1524,6 @@ zdr_READDIRPLUS3resok (ZDR *zdrs, READDIRPLUS3resok *objp)
 uint32_t
 zdr_READDIRPLUS3resfail (ZDR *zdrs, READDIRPLUS3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->dir_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1861,9 +1532,6 @@ zdr_READDIRPLUS3resfail (ZDR *zdrs, READDIRPLUS3resfail *objp)
 uint32_t
 zdr_READDIRPLUS3res (ZDR *zdrs, READDIRPLUS3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1882,9 +1550,6 @@ zdr_READDIRPLUS3res (ZDR *zdrs, READDIRPLUS3res *objp)
 uint32_t
 zdr_READDIR3args (ZDR *zdrs, READDIR3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->dir))
 		 return FALSE;
 	 if (!zdr_cookie3 (zdrs, &objp->cookie))
@@ -1899,9 +1564,6 @@ zdr_READDIR3args (ZDR *zdrs, READDIR3args *objp)
 uint32_t
 zdr_entry3 (ZDR *zdrs, entry3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fileid3 (zdrs, &objp->fileid))
 		 return FALSE;
 	 if (!zdr_filename3 (zdrs, &objp->name))
@@ -1916,9 +1578,6 @@ zdr_entry3 (ZDR *zdrs, entry3 *objp)
 uint32_t
 zdr_dirlist3 (ZDR *zdrs, dirlist3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pointer (zdrs, (char **)&objp->entries, sizeof (entry3), (zdrproc_t) zdr_entry3))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->eof))
@@ -1929,9 +1588,6 @@ zdr_dirlist3 (ZDR *zdrs, dirlist3 *objp)
 uint32_t
 zdr_READDIR3resok (ZDR *zdrs, READDIR3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->dir_attributes))
 		 return FALSE;
 	 if (!zdr_cookieverf3 (zdrs, objp->cookieverf))
@@ -1944,9 +1600,6 @@ zdr_READDIR3resok (ZDR *zdrs, READDIR3resok *objp)
 uint32_t
 zdr_READDIR3resfail (ZDR *zdrs, READDIR3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->dir_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1955,9 +1608,6 @@ zdr_READDIR3resfail (ZDR *zdrs, READDIR3resfail *objp)
 uint32_t
 zdr_READDIR3res (ZDR *zdrs, READDIR3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1976,9 +1626,6 @@ zdr_READDIR3res (ZDR *zdrs, READDIR3res *objp)
 uint32_t
 zdr_LINK3args (ZDR *zdrs, LINK3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->file))
 		 return FALSE;
 	 if (!zdr_diropargs3 (zdrs, &objp->link))
@@ -1989,9 +1636,6 @@ zdr_LINK3args (ZDR *zdrs, LINK3args *objp)
 uint32_t
 zdr_LINK3resok (ZDR *zdrs, LINK3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->file_attributes))
 		 return FALSE;
 	 if (!zdr_wcc_data (zdrs, &objp->linkdir_wcc))
@@ -2002,9 +1646,6 @@ zdr_LINK3resok (ZDR *zdrs, LINK3resok *objp)
 uint32_t
 zdr_LINK3resfail (ZDR *zdrs, LINK3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->file_attributes))
 		 return FALSE;
 	 if (!zdr_wcc_data (zdrs, &objp->linkdir_wcc))
@@ -2015,9 +1656,6 @@ zdr_LINK3resfail (ZDR *zdrs, LINK3resfail *objp)
 uint32_t
 zdr_LINK3res (ZDR *zdrs, LINK3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2036,9 +1674,6 @@ zdr_LINK3res (ZDR *zdrs, LINK3res *objp)
 uint32_t
 zdr_sattrguard3 (ZDR *zdrs, sattrguard3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->check))
 		 return FALSE;
 	switch (objp->check) {
@@ -2057,9 +1692,6 @@ zdr_sattrguard3 (ZDR *zdrs, sattrguard3 *objp)
 uint32_t
 zdr_SETATTR3args (ZDR *zdrs, SETATTR3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->object))
 		 return FALSE;
 	 if (!zdr_sattr3 (zdrs, &objp->new_attributes))
@@ -2072,9 +1704,6 @@ zdr_SETATTR3args (ZDR *zdrs, SETATTR3args *objp)
 uint32_t
 zdr_SETATTR3resok (ZDR *zdrs, SETATTR3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->obj_wcc))
 		 return FALSE;
 	return TRUE;
@@ -2083,9 +1712,6 @@ zdr_SETATTR3resok (ZDR *zdrs, SETATTR3resok *objp)
 uint32_t
 zdr_SETATTR3resfail (ZDR *zdrs, SETATTR3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->obj_wcc))
 		 return FALSE;
 	return TRUE;
@@ -2094,9 +1720,6 @@ zdr_SETATTR3resfail (ZDR *zdrs, SETATTR3resfail *objp)
 uint32_t
 zdr_SETATTR3res (ZDR *zdrs, SETATTR3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2115,9 +1738,6 @@ zdr_SETATTR3res (ZDR *zdrs, SETATTR3res *objp)
 uint32_t
 zdr_fhandle2 (ZDR *zdrs, fhandle2 objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, FHSIZE2))
 		 return FALSE;
 	return TRUE;
@@ -2126,9 +1746,6 @@ zdr_fhandle2 (ZDR *zdrs, fhandle2 objp)
 uint32_t
 zdr_ftype2 (ZDR *zdrs, ftype2 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -2139,7 +1756,6 @@ zdr_fattr2 (ZDR *zdrs, fattr2 *objp)
 {
 	register int32_t *buf;
 	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		 if (!zdr_ftype2 (zdrs, &objp->type))
@@ -2270,7 +1886,6 @@ zdr_sattr2 (ZDR *zdrs, sattr2 *objp)
 	register int32_t *buf;
 	buf = NULL;
 
-
 	if (zdrs->x_op == ZDR_ENCODE) {
 		buf = ZDR_INLINE (zdrs, 4 * BYTES_PER_ZDR_UNIT);
 		if (buf == NULL) {
@@ -2337,9 +1952,6 @@ zdr_sattr2 (ZDR *zdrs, sattr2 *objp)
 uint32_t
 zdr_filename2 (ZDR *zdrs, filename2 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, objp, MAXNAMLEN2))
 		 return FALSE;
 	return TRUE;
@@ -2348,9 +1960,6 @@ zdr_filename2 (ZDR *zdrs, filename2 *objp)
 uint32_t
 zdr_path2 (ZDR *zdrs, path2 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, objp, MAXPATHLEN2))
 		 return FALSE;
 	return TRUE;
@@ -2359,9 +1968,6 @@ zdr_path2 (ZDR *zdrs, path2 *objp)
 uint32_t
 zdr_nfsdata2 (ZDR *zdrs, nfsdata2 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->nfsdata2_val, (u_int *) &objp->nfsdata2_len, NFSMAXDATA2))
 		 return FALSE;
 	return TRUE;
@@ -2370,9 +1976,6 @@ zdr_nfsdata2 (ZDR *zdrs, nfsdata2 *objp)
 uint32_t
 zdr_nfscookie2 (ZDR *zdrs, nfscookie2 objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, NFSCOOKIESIZE2))
 		 return FALSE;
 	return TRUE;
@@ -2381,9 +1984,6 @@ zdr_nfscookie2 (ZDR *zdrs, nfscookie2 objp)
 uint32_t
 zdr_entry2 (ZDR *zdrs, entry2 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->fileid))
 		 return FALSE;
 	 if (!zdr_filename2 (zdrs, &objp->name))
@@ -2398,9 +1998,6 @@ zdr_entry2 (ZDR *zdrs, entry2 *objp)
 uint32_t
 zdr_diropargs2 (ZDR *zdrs, diropargs2 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->dir))
 		 return FALSE;
 	 if (!zdr_filename2 (zdrs, &objp->name))
@@ -2411,9 +2008,6 @@ zdr_diropargs2 (ZDR *zdrs, diropargs2 *objp)
 uint32_t
 zdr_GETATTR2args (ZDR *zdrs, GETATTR2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->fhandle))
 		 return FALSE;
 	return TRUE;
@@ -2422,9 +2016,6 @@ zdr_GETATTR2args (ZDR *zdrs, GETATTR2args *objp)
 uint32_t
 zdr_GETATTR2resok (ZDR *zdrs, GETATTR2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
 		 return FALSE;
 	return TRUE;
@@ -2433,9 +2024,6 @@ zdr_GETATTR2resok (ZDR *zdrs, GETATTR2resok *objp)
 uint32_t
 zdr_GETATTR2res (ZDR *zdrs, GETATTR2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2452,9 +2040,6 @@ zdr_GETATTR2res (ZDR *zdrs, GETATTR2res *objp)
 uint32_t
 zdr_SETATTR2args (ZDR *zdrs, SETATTR2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->fhandle))
 		 return FALSE;
 	 if (!zdr_sattr2 (zdrs, &objp->attributes))
@@ -2465,9 +2050,6 @@ zdr_SETATTR2args (ZDR *zdrs, SETATTR2args *objp)
 uint32_t
 zdr_SETATTR2resok (ZDR *zdrs, SETATTR2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
 		 return FALSE;
 	return TRUE;
@@ -2476,9 +2058,6 @@ zdr_SETATTR2resok (ZDR *zdrs, SETATTR2resok *objp)
 uint32_t
 zdr_SETATTR2res (ZDR *zdrs, SETATTR2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2495,9 +2074,6 @@ zdr_SETATTR2res (ZDR *zdrs, SETATTR2res *objp)
 uint32_t
 zdr_LOOKUP2args (ZDR *zdrs, LOOKUP2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->what))
 		 return FALSE;
 	return TRUE;
@@ -2506,9 +2082,6 @@ zdr_LOOKUP2args (ZDR *zdrs, LOOKUP2args *objp)
 uint32_t
 zdr_LOOKUP2resok (ZDR *zdrs, LOOKUP2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->file))
 		 return FALSE;
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
@@ -2519,9 +2092,6 @@ zdr_LOOKUP2resok (ZDR *zdrs, LOOKUP2resok *objp)
 uint32_t
 zdr_LOOKUP2res (ZDR *zdrs, LOOKUP2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2538,9 +2108,6 @@ zdr_LOOKUP2res (ZDR *zdrs, LOOKUP2res *objp)
 uint32_t
 zdr_READLINK2args (ZDR *zdrs, READLINK2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->file))
 		 return FALSE;
 	return TRUE;
@@ -2549,9 +2116,6 @@ zdr_READLINK2args (ZDR *zdrs, READLINK2args *objp)
 uint32_t
 zdr_READLINK2resok (ZDR *zdrs, READLINK2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_path2 (zdrs, &objp->data))
 		 return FALSE;
 	return TRUE;
@@ -2560,9 +2124,6 @@ zdr_READLINK2resok (ZDR *zdrs, READLINK2resok *objp)
 uint32_t
 zdr_READLINK2res (ZDR *zdrs, READLINK2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2579,9 +2140,6 @@ zdr_READLINK2res (ZDR *zdrs, READLINK2res *objp)
 uint32_t
 zdr_READ2args (ZDR *zdrs, READ2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->file))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->offset))
@@ -2596,9 +2154,6 @@ zdr_READ2args (ZDR *zdrs, READ2args *objp)
 uint32_t
 zdr_READ2resok (ZDR *zdrs, READ2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
 		 return FALSE;
 	 if (!zdr_nfsdata2 (zdrs, &objp->data))
@@ -2609,9 +2164,6 @@ zdr_READ2resok (ZDR *zdrs, READ2resok *objp)
 uint32_t
 zdr_READ2res (ZDR *zdrs, READ2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2630,7 +2182,6 @@ zdr_WRITE2args (ZDR *zdrs, WRITE2args *objp)
 {
 	register int32_t *buf;
 	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		 if (!zdr_fhandle2 (zdrs, objp->file))
@@ -2690,9 +2241,6 @@ zdr_WRITE2args (ZDR *zdrs, WRITE2args *objp)
 uint32_t
 zdr_WRITE2resok (ZDR *zdrs, WRITE2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
 		 return FALSE;
 	return TRUE;
@@ -2701,9 +2249,6 @@ zdr_WRITE2resok (ZDR *zdrs, WRITE2resok *objp)
 uint32_t
 zdr_WRITE2res (ZDR *zdrs, WRITE2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2720,9 +2265,6 @@ zdr_WRITE2res (ZDR *zdrs, WRITE2res *objp)
 uint32_t
 zdr_CREATE2args (ZDR *zdrs, CREATE2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->where))
 		 return FALSE;
 	 if (!zdr_sattr2 (zdrs, &objp->attributes))
@@ -2733,9 +2275,6 @@ zdr_CREATE2args (ZDR *zdrs, CREATE2args *objp)
 uint32_t
 zdr_CREATE2resok (ZDR *zdrs, CREATE2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->file))
 		 return FALSE;
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
@@ -2746,9 +2285,6 @@ zdr_CREATE2resok (ZDR *zdrs, CREATE2resok *objp)
 uint32_t
 zdr_CREATE2res (ZDR *zdrs, CREATE2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2765,9 +2301,6 @@ zdr_CREATE2res (ZDR *zdrs, CREATE2res *objp)
 uint32_t
 zdr_REMOVE2args (ZDR *zdrs, REMOVE2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->what))
 		 return FALSE;
 	return TRUE;
@@ -2776,9 +2309,6 @@ zdr_REMOVE2args (ZDR *zdrs, REMOVE2args *objp)
 uint32_t
 zdr_REMOVE2res (ZDR *zdrs, REMOVE2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2787,9 +2317,6 @@ zdr_REMOVE2res (ZDR *zdrs, REMOVE2res *objp)
 uint32_t
 zdr_RENAME2args (ZDR *zdrs, RENAME2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->from))
 		 return FALSE;
 	 if (!zdr_diropargs2 (zdrs, &objp->to))
@@ -2800,9 +2327,6 @@ zdr_RENAME2args (ZDR *zdrs, RENAME2args *objp)
 uint32_t
 zdr_RENAME2res (ZDR *zdrs, RENAME2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2811,9 +2335,6 @@ zdr_RENAME2res (ZDR *zdrs, RENAME2res *objp)
 uint32_t
 zdr_LINK2args (ZDR *zdrs, LINK2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->from))
 		 return FALSE;
 	 if (!zdr_diropargs2 (zdrs, &objp->to))
@@ -2824,9 +2345,6 @@ zdr_LINK2args (ZDR *zdrs, LINK2args *objp)
 uint32_t
 zdr_LINK2res (ZDR *zdrs, LINK2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2835,9 +2353,6 @@ zdr_LINK2res (ZDR *zdrs, LINK2res *objp)
 uint32_t
 zdr_SYMLINK2args (ZDR *zdrs, SYMLINK2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->from))
 		 return FALSE;
 	 if (!zdr_path2 (zdrs, &objp->to))
@@ -2850,9 +2365,6 @@ zdr_SYMLINK2args (ZDR *zdrs, SYMLINK2args *objp)
 uint32_t
 zdr_SYMLINK2res (ZDR *zdrs, SYMLINK2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2861,9 +2373,6 @@ zdr_SYMLINK2res (ZDR *zdrs, SYMLINK2res *objp)
 uint32_t
 zdr_MKDIR2args (ZDR *zdrs, MKDIR2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->where))
 		 return FALSE;
 	 if (!zdr_sattr2 (zdrs, &objp->attributes))
@@ -2874,9 +2383,6 @@ zdr_MKDIR2args (ZDR *zdrs, MKDIR2args *objp)
 uint32_t
 zdr_MKDIR2resok (ZDR *zdrs, MKDIR2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->file))
 		 return FALSE;
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
@@ -2887,9 +2393,6 @@ zdr_MKDIR2resok (ZDR *zdrs, MKDIR2resok *objp)
 uint32_t
 zdr_MKDIR2res (ZDR *zdrs, MKDIR2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2906,9 +2409,6 @@ zdr_MKDIR2res (ZDR *zdrs, MKDIR2res *objp)
 uint32_t
 zdr_RMDIR2args (ZDR *zdrs, RMDIR2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->what))
 		 return FALSE;
 	return TRUE;
@@ -2917,9 +2417,6 @@ zdr_RMDIR2args (ZDR *zdrs, RMDIR2args *objp)
 uint32_t
 zdr_RMDIR2res (ZDR *zdrs, RMDIR2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2928,9 +2425,6 @@ zdr_RMDIR2res (ZDR *zdrs, RMDIR2res *objp)
 uint32_t
 zdr_READDIR2args (ZDR *zdrs, READDIR2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->dir))
 		 return FALSE;
 	 if (!zdr_nfscookie2 (zdrs, objp->cookie))
@@ -2943,9 +2437,6 @@ zdr_READDIR2args (ZDR *zdrs, READDIR2args *objp)
 uint32_t
 zdr_READDIR2resok (ZDR *zdrs, READDIR2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pointer (zdrs, (char **)&objp->entries, sizeof (entry2), (zdrproc_t) zdr_entry2))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->eof))
@@ -2956,9 +2447,6 @@ zdr_READDIR2resok (ZDR *zdrs, READDIR2resok *objp)
 uint32_t
 zdr_READDIR2res (ZDR *zdrs, READDIR2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2975,9 +2463,6 @@ zdr_READDIR2res (ZDR *zdrs, READDIR2res *objp)
 uint32_t
 zdr_STATFS2args (ZDR *zdrs, STATFS2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->dir))
 		 return FALSE;
 	return TRUE;
@@ -2988,7 +2473,6 @@ zdr_STATFS2resok (ZDR *zdrs, STATFS2resok *objp)
 {
 	register int32_t *buf;
 	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		buf = ZDR_INLINE (zdrs, 5 * BYTES_PER_ZDR_UNIT);
@@ -3050,9 +2534,6 @@ zdr_STATFS2resok (ZDR *zdrs, STATFS2resok *objp)
 uint32_t
 zdr_STATFS2res (ZDR *zdrs, STATFS2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -3069,9 +2550,6 @@ zdr_STATFS2res (ZDR *zdrs, STATFS2res *objp)
 uint32_t
 zdr_nfsacl_type (ZDR *zdrs, nfsacl_type *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -3080,9 +2558,6 @@ zdr_nfsacl_type (ZDR *zdrs, nfsacl_type *objp)
 uint32_t
 zdr_nfsacl_ace (ZDR *zdrs, nfsacl_ace *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsacl_type (zdrs, &objp->type))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->id))
@@ -3095,9 +2570,6 @@ zdr_nfsacl_ace (ZDR *zdrs, nfsacl_ace *objp)
 uint32_t
 zdr_GETACL3args (ZDR *zdrs, GETACL3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->dir))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->mask))
@@ -3108,9 +2580,6 @@ zdr_GETACL3args (ZDR *zdrs, GETACL3args *objp)
 uint32_t
 zdr_GETACL3resok (ZDR *zdrs, GETACL3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->attr))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->mask))
@@ -3131,9 +2600,6 @@ zdr_GETACL3resok (ZDR *zdrs, GETACL3resok *objp)
 uint32_t
 zdr_GETACL3res (ZDR *zdrs, GETACL3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -3150,9 +2616,6 @@ zdr_GETACL3res (ZDR *zdrs, GETACL3res *objp)
 uint32_t
 zdr_SETACL3args (ZDR *zdrs, SETACL3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->dir))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->mask))
@@ -3173,9 +2636,6 @@ zdr_SETACL3args (ZDR *zdrs, SETACL3args *objp)
 uint32_t
 zdr_SETACL3resok (ZDR *zdrs, SETACL3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->attr))
 		 return FALSE;
 	return TRUE;
@@ -3184,9 +2644,6 @@ zdr_SETACL3resok (ZDR *zdrs, SETACL3resok *objp)
 uint32_t
 zdr_SETACL3res (ZDR *zdrs, SETACL3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {

--- a/nlm/libnfs-raw-nlm.c
+++ b/nlm/libnfs-raw-nlm.c
@@ -6,7 +6,7 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer. 
+   list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
@@ -23,7 +23,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies, 
+of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
@@ -38,9 +38,6 @@ either expressed or implied, of the FreeBSD Project.
 uint32_t
 zdr_nlm_fh4 (ZDR *zdrs, nlm_fh4 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->data.data_val, (u_int *) &objp->data.data_len, ~0))
 		 return FALSE;
 	return TRUE;
@@ -49,9 +46,6 @@ zdr_nlm_fh4 (ZDR *zdrs, nlm_fh4 *objp)
 uint32_t
 zdr_nlm4_oh (ZDR *zdrs, nlm4_oh *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, objp, ~0))
 		 return FALSE;
 	return TRUE;
@@ -60,9 +54,6 @@ zdr_nlm4_oh (ZDR *zdrs, nlm4_oh *objp)
 uint32_t
 zdr_nlm_cookie (ZDR *zdrs, nlm_cookie *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->data.data_val, (u_int *) &objp->data.data_len, ~0))
 		 return FALSE;
 	return TRUE;
@@ -71,9 +62,6 @@ zdr_nlm_cookie (ZDR *zdrs, nlm_cookie *objp)
 uint32_t
 zdr_nlmstat4 (ZDR *zdrs, nlmstat4 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -82,9 +70,6 @@ zdr_nlmstat4 (ZDR *zdrs, nlmstat4 *objp)
 uint32_t
 zdr_nlm4_holder (ZDR *zdrs, nlm4_holder *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->exclusive))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->svid))
@@ -101,9 +86,6 @@ zdr_nlm4_holder (ZDR *zdrs, nlm4_holder *objp)
 uint32_t
 zdr_nlm4_lock (ZDR *zdrs, nlm4_lock *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, &objp->caller_name, NLM_MAXNAME))
 		 return FALSE;
 	 if (!zdr_nlm_fh4 (zdrs, &objp->fh))
@@ -122,9 +104,6 @@ zdr_nlm4_lock (ZDR *zdrs, nlm4_lock *objp)
 uint32_t
 zdr_nlm4_share (ZDR *zdrs, nlm4_share *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, &objp->caller_name, NLM_MAXNAME))
 		 return FALSE;
 	 if (!zdr_nlm_fh4 (zdrs, &objp->fh))
@@ -141,9 +120,6 @@ zdr_nlm4_share (ZDR *zdrs, nlm4_share *objp)
 uint32_t
 zdr_nlm4_testres_denied (ZDR *zdrs, nlm4_testres_denied *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nlm4_holder (zdrs, &objp->holder))
 		 return FALSE;
 	return TRUE;
@@ -152,9 +128,6 @@ zdr_nlm4_testres_denied (ZDR *zdrs, nlm4_testres_denied *objp)
 uint32_t
 zdr_nlm4_testreply (ZDR *zdrs, nlm4_testreply *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nlmstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -171,9 +144,6 @@ zdr_nlm4_testreply (ZDR *zdrs, nlm4_testreply *objp)
 uint32_t
 zdr_NLM4_TESTres (ZDR *zdrs, NLM4_TESTres *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nlm_cookie (zdrs, &objp->cookie))
 		 return FALSE;
 	 if (!zdr_nlm4_testreply (zdrs, &objp->reply))
@@ -184,9 +154,6 @@ zdr_NLM4_TESTres (ZDR *zdrs, NLM4_TESTres *objp)
 uint32_t
 zdr_NLM4_TESTargs (ZDR *zdrs, NLM4_TESTargs *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nlm_cookie (zdrs, &objp->cookie))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->exclusive))
@@ -199,9 +166,6 @@ zdr_NLM4_TESTargs (ZDR *zdrs, NLM4_TESTargs *objp)
 uint32_t
 zdr_NLM4_CANCres (ZDR *zdrs, NLM4_CANCres *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nlm_cookie (zdrs, &objp->cookie))
 		 return FALSE;
 	 if (!zdr_nlmstat4 (zdrs, &objp->status))
@@ -212,9 +176,6 @@ zdr_NLM4_CANCres (ZDR *zdrs, NLM4_CANCres *objp)
 uint32_t
 zdr_NLM4_CANCargs (ZDR *zdrs, NLM4_CANCargs *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nlm_cookie (zdrs, &objp->cookie))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->block))
@@ -229,9 +190,6 @@ zdr_NLM4_CANCargs (ZDR *zdrs, NLM4_CANCargs *objp)
 uint32_t
 zdr_NLM4_UNLOCKres (ZDR *zdrs, NLM4_UNLOCKres *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nlm_cookie (zdrs, &objp->cookie))
 		 return FALSE;
 	 if (!zdr_nlmstat4 (zdrs, &objp->status))
@@ -242,9 +200,6 @@ zdr_NLM4_UNLOCKres (ZDR *zdrs, NLM4_UNLOCKres *objp)
 uint32_t
 zdr_NLM4_UNLOCKargs (ZDR *zdrs, NLM4_UNLOCKargs *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nlm_cookie (zdrs, &objp->cookie))
 		 return FALSE;
 	 if (!zdr_nlm4_lock (zdrs, &objp->lock))
@@ -255,9 +210,6 @@ zdr_NLM4_UNLOCKargs (ZDR *zdrs, NLM4_UNLOCKargs *objp)
 uint32_t
 zdr_NLM4_LOCKres (ZDR *zdrs, NLM4_LOCKres *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nlm_cookie (zdrs, &objp->cookie))
 		 return FALSE;
 	 if (!zdr_nlmstat4 (zdrs, &objp->status))
@@ -268,9 +220,6 @@ zdr_NLM4_LOCKres (ZDR *zdrs, NLM4_LOCKres *objp)
 uint32_t
 zdr_NLM4_LOCKargs (ZDR *zdrs, NLM4_LOCKargs *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nlm_cookie (zdrs, &objp->cookie))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->block))
@@ -289,9 +238,6 @@ zdr_NLM4_LOCKargs (ZDR *zdrs, NLM4_LOCKargs *objp)
 uint32_t
 zdr_NLM4_GRANTEDargs (ZDR *zdrs, NLM4_GRANTEDargs *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nlm_cookie (zdrs, &objp->cookie))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->exclusive))
@@ -304,9 +250,6 @@ zdr_NLM4_GRANTEDargs (ZDR *zdrs, NLM4_GRANTEDargs *objp)
 uint32_t
 zdr_NLM4_GRANTEDres (ZDR *zdrs, NLM4_GRANTEDres *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nlm_cookie (zdrs, &objp->cookie))
 		 return FALSE;
 	 if (!zdr_nlmstat4 (zdrs, &objp->status))

--- a/nsm/libnfs-raw-nsm.c
+++ b/nsm/libnfs-raw-nsm.c
@@ -6,7 +6,7 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer. 
+   list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
@@ -23,7 +23,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies, 
+of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
@@ -38,9 +38,6 @@ either expressed or implied, of the FreeBSD Project.
 uint32_t
 zdr_nsmstat1 (ZDR *zdrs, nsmstat1 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -49,9 +46,6 @@ zdr_nsmstat1 (ZDR *zdrs, nsmstat1 *objp)
 uint32_t
 zdr_nsm_my_id (ZDR *zdrs, nsm_my_id *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, &objp->my_name, NSM_MAXSTRLEN))
 		 return FALSE;
 	 if (!zdr_int (zdrs, &objp->my_prog))
@@ -66,9 +60,6 @@ zdr_nsm_my_id (ZDR *zdrs, nsm_my_id *objp)
 uint32_t
 zdr_nsm_mon_id (ZDR *zdrs, nsm_mon_id *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, &objp->mon_name, NSM_MAXSTRLEN))
 		 return FALSE;
 	 if (!zdr_nsm_my_id (zdrs, &objp->my_id))
@@ -79,9 +70,6 @@ zdr_nsm_mon_id (ZDR *zdrs, nsm_mon_id *objp)
 uint32_t
 zdr_NSM1_STATres (ZDR *zdrs, NSM1_STATres *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nsmstat1 (zdrs, &objp->res))
 		 return FALSE;
 	 if (!zdr_int (zdrs, &objp->state))
@@ -92,9 +80,6 @@ zdr_NSM1_STATres (ZDR *zdrs, NSM1_STATres *objp)
 uint32_t
 zdr_NSM1_STATargs (ZDR *zdrs, NSM1_STATargs *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, &objp->mon_name, NSM_MAXSTRLEN))
 		 return FALSE;
 	return TRUE;
@@ -103,9 +88,6 @@ zdr_NSM1_STATargs (ZDR *zdrs, NSM1_STATargs *objp)
 uint32_t
 zdr_NSM1_MONres (ZDR *zdrs, NSM1_MONres *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nsmstat1 (zdrs, &objp->res))
 		 return FALSE;
 	 if (!zdr_int (zdrs, &objp->state))
@@ -116,10 +98,6 @@ zdr_NSM1_MONres (ZDR *zdrs, NSM1_MONres *objp)
 uint32_t
 zdr_NSM1_MONargs (ZDR *zdrs, NSM1_MONargs *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
-	int i;
 	 if (!zdr_nsm_mon_id (zdrs, &objp->mon_id))
 		 return FALSE;
 	 if (!zdr_opaque (zdrs, objp->priv, 16))
@@ -130,9 +108,6 @@ zdr_NSM1_MONargs (ZDR *zdrs, NSM1_MONargs *objp)
 uint32_t
 zdr_NSM1_UNMONres (ZDR *zdrs, NSM1_UNMONres *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_int (zdrs, &objp->state))
 		 return FALSE;
 	return TRUE;
@@ -141,9 +116,6 @@ zdr_NSM1_UNMONres (ZDR *zdrs, NSM1_UNMONres *objp)
 uint32_t
 zdr_NSM1_UNMONargs (ZDR *zdrs, NSM1_UNMONargs *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nsm_mon_id (zdrs, &objp->mon_id))
 		 return FALSE;
 	return TRUE;
@@ -152,9 +124,6 @@ zdr_NSM1_UNMONargs (ZDR *zdrs, NSM1_UNMONargs *objp)
 uint32_t
 zdr_NSM1_UNMONALLres (ZDR *zdrs, NSM1_UNMONALLres *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_int (zdrs, &objp->state))
 		 return FALSE;
 	return TRUE;
@@ -163,9 +132,6 @@ zdr_NSM1_UNMONALLres (ZDR *zdrs, NSM1_UNMONALLres *objp)
 uint32_t
 zdr_NSM1_UNMONALLargs (ZDR *zdrs, NSM1_UNMONALLargs *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nsm_my_id (zdrs, &objp->my_id))
 		 return FALSE;
 	return TRUE;
@@ -174,9 +140,6 @@ zdr_NSM1_UNMONALLargs (ZDR *zdrs, NSM1_UNMONALLargs *objp)
 uint32_t
 zdr_NSM1_NOTIFYargs (ZDR *zdrs, NSM1_NOTIFYargs *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, &objp->mon_name, NSM_MAXSTRLEN))
 		 return FALSE;
 	 if (!zdr_int (zdrs, &objp->state))

--- a/portmap/libnfs-raw-portmap.c
+++ b/portmap/libnfs-raw-portmap.c
@@ -6,7 +6,7 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer. 
+   list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
@@ -23,7 +23,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies, 
+of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
@@ -40,7 +40,6 @@ zdr_pmap2_mapping (ZDR *zdrs, pmap2_mapping *objp)
 {
 	register int32_t *buf;
 	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		buf = ZDR_INLINE (zdrs, 4 * BYTES_PER_ZDR_UNIT);
@@ -97,7 +96,6 @@ zdr_pmap2_call_args (ZDR *zdrs, pmap2_call_args *objp)
 	register int32_t *buf;
 	buf = NULL;
 
-
 	if (zdrs->x_op == ZDR_ENCODE) {
 		buf = ZDR_INLINE (zdrs, 3 * BYTES_PER_ZDR_UNIT);
 		if (buf == NULL) {
@@ -150,9 +148,6 @@ zdr_pmap2_call_args (ZDR *zdrs, pmap2_call_args *objp)
 uint32_t
 zdr_pmap2_call_result (ZDR *zdrs, pmap2_call_result *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->port))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->res.res_val, (u_int *) &objp->res.res_len, ~0))
@@ -163,9 +158,6 @@ zdr_pmap2_call_result (ZDR *zdrs, pmap2_call_result *objp)
 uint32_t
 zdr_pmap2_mapping_list (ZDR *zdrs, pmap2_mapping_list *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pmap2_mapping (zdrs, &objp->map))
 		 return FALSE;
 	 if (!zdr_pointer (zdrs, (char **)&objp->next, sizeof (pmap2_mapping_list), (zdrproc_t) zdr_pmap2_mapping_list))
@@ -176,9 +168,6 @@ zdr_pmap2_mapping_list (ZDR *zdrs, pmap2_mapping_list *objp)
 uint32_t
 zdr_pmap2_dump_result (ZDR *zdrs, pmap2_dump_result *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pointer (zdrs, (char **)&objp->list, sizeof (pmap2_mapping_list), (zdrproc_t) zdr_pmap2_mapping_list))
 		 return FALSE;
 	return TRUE;
@@ -187,9 +176,6 @@ zdr_pmap2_dump_result (ZDR *zdrs, pmap2_dump_result *objp)
 uint32_t
 zdr_pmap3_string_result (ZDR *zdrs, pmap3_string_result *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, &objp->addr, ~0))
 		 return FALSE;
 	return TRUE;
@@ -198,9 +184,6 @@ zdr_pmap3_string_result (ZDR *zdrs, pmap3_string_result *objp)
 uint32_t
 zdr_pmap3_mapping (ZDR *zdrs, pmap3_mapping *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->prog))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->vers))
@@ -217,9 +200,6 @@ zdr_pmap3_mapping (ZDR *zdrs, pmap3_mapping *objp)
 uint32_t
 zdr_pmap3_mapping_list (ZDR *zdrs, pmap3_mapping_list *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pmap3_mapping (zdrs, &objp->map))
 		 return FALSE;
 	 if (!zdr_pointer (zdrs, (char **)&objp->next, sizeof (pmap3_mapping_list), (zdrproc_t) zdr_pmap3_mapping_list))
@@ -230,9 +210,6 @@ zdr_pmap3_mapping_list (ZDR *zdrs, pmap3_mapping_list *objp)
 uint32_t
 zdr_pmap3_dump_result (ZDR *zdrs, pmap3_dump_result *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pointer (zdrs, (char **)&objp->list, sizeof (pmap3_mapping_list), (zdrproc_t) zdr_pmap3_mapping_list))
 		 return FALSE;
 	return TRUE;
@@ -243,7 +220,6 @@ zdr_pmap3_call_args (ZDR *zdrs, pmap3_call_args *objp)
 {
 	register int32_t *buf;
 	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		buf = ZDR_INLINE (zdrs, 3 * BYTES_PER_ZDR_UNIT);
@@ -297,9 +273,6 @@ zdr_pmap3_call_args (ZDR *zdrs, pmap3_call_args *objp)
 uint32_t
 zdr_pmap3_call_result (ZDR *zdrs, pmap3_call_result *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->port))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->res.res_val, (u_int *) &objp->res.res_len, ~0))
@@ -310,9 +283,6 @@ zdr_pmap3_call_result (ZDR *zdrs, pmap3_call_result *objp)
 uint32_t
 zdr_pmap3_netbuf (ZDR *zdrs, pmap3_netbuf *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->maxlen))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->buf.buf_val, (u_int *) &objp->buf.buf_len, ~0))

--- a/rquota/libnfs-raw-rquota.c
+++ b/rquota/libnfs-raw-rquota.c
@@ -6,7 +6,7 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer. 
+   list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
@@ -23,7 +23,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies, 
+of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
@@ -38,9 +38,6 @@ either expressed or implied, of the FreeBSD Project.
 uint32_t
 zdr_rquotastat (ZDR *zdrs, rquotastat *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -49,9 +46,6 @@ zdr_rquotastat (ZDR *zdrs, rquotastat *objp)
 uint32_t
 zdr_exportpath (ZDR *zdrs, exportpath *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, objp, RQUOTAPATHLEN))
 		 return FALSE;
 	return TRUE;
@@ -60,9 +54,6 @@ zdr_exportpath (ZDR *zdrs, exportpath *objp)
 uint32_t
 zdr_GETQUOTA1args (ZDR *zdrs, GETQUOTA1args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_exportpath (zdrs, &objp->export))
 		 return FALSE;
 	 if (!zdr_int (zdrs, &objp->uid))
@@ -73,9 +64,6 @@ zdr_GETQUOTA1args (ZDR *zdrs, GETQUOTA1args *objp)
 uint32_t
 zdr_quotatype (ZDR *zdrs, quotatype *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -84,9 +72,6 @@ zdr_quotatype (ZDR *zdrs, quotatype *objp)
 uint32_t
 zdr_GETQUOTA2args (ZDR *zdrs, GETQUOTA2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_exportpath (zdrs, &objp->export))
 		 return FALSE;
 	 if (!zdr_quotatype (zdrs, &objp->type))
@@ -101,7 +86,6 @@ zdr_GETQUOTA1res_ok (ZDR *zdrs, GETQUOTA1res_ok *objp)
 {
 	register int32_t *buf;
 	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		buf = ZDR_INLINE (zdrs, 10 * BYTES_PER_ZDR_UNIT);
@@ -203,9 +187,6 @@ zdr_GETQUOTA1res_ok (ZDR *zdrs, GETQUOTA1res_ok *objp)
 uint32_t
 zdr_GETQUOTA1res (ZDR *zdrs, GETQUOTA1res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_rquotastat (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {

--- a/utils/nfs-ls.c
+++ b/utils/nfs-ls.c
@@ -1,16 +1,16 @@
-/* 
+/*
    Copyright (C) by Ronnie Sahlberg <ronniesahlberg@gmail.com> 2010
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
@@ -25,7 +25,7 @@
 #ifdef AROS
 #include "aros_compat.h"
 #endif
- 
+
 #ifdef WIN32
 #include "win32_compat.h"
 #pragma comment(lib, "ws2_32.lib")
@@ -92,9 +92,8 @@ int process_server(const char *server) {
 void process_dir(struct nfs_context *nfs, char *dir, int level) {
 	int ret;
 	struct nfsdirent *nfsdirent;
-	struct statvfs svfs;
 	struct nfsdir *nfsdir;
-	
+
 	if (!level) {
 		printf("Recursion detected!\n");
 		exit(10);
@@ -162,12 +161,10 @@ void process_dir(struct nfs_context *nfs, char *dir, int level) {
 int main(int argc, char *argv[])
 {
 	struct nfs_context *nfs = NULL;
-	int i, ret = 1, res;
-	uint64_t offset;
+	int i, ret = 1;
 	struct client client;
 	struct statvfs stvfs;
 	struct nfs_url *url = NULL;
-	exports export, tmp;
 
 #ifdef WIN32
 	if (WSAStartup(MAKEWORD(2,2), &wsaData) != 0) {


### PR DESCRIPTION
As discussed: https://github.com/sahlberg/libnfs/commit/84607f4821f0210a62a4e7b93480a702b10fb83a#commitcomment-10157262