### PR TITLE
bootstrap: create m4 directory

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+mkdir -p m4
 autoreconf -vif
 


### PR DESCRIPTION
newer versions of autotools fail if the directory is not there.

Signed-off-by: Peter Lieven <pl@kamp.de>