### PR TITLE
socket: handle count == 0 in rpc_read_from_socket

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -249,6 +249,12 @@ static int rpc_read_from_socket(struct rpc_context *rpc)
 		rpc_set_error(rpc, "Read from socket failed, errno:%d. Closing socket.", errno);
 		return -1;
 	}
+
+	if (count == 0) {
+		/* remote side has closed the socket. Reconnect. */
+		return -1;
+	}
+
 	rpc->inpos += count;
 
 	while (rpc->inpos >= 4) {


### PR DESCRIPTION
An EOF is signalled through a POLLIN event and subsequen recvs return
always 0. Handle this condition and reconnect. Otherwise we might
deadlock here.

Signed-off-by: Peter Lieven <pl@kamp.de>