### PR TITLE
init: do not write to stderr in rpc_set_error

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -168,7 +168,7 @@ void rpc_set_error(struct rpc_context *rpc, const char *error_string, ...)
 	vsnprintf(rpc->error_string, 1024, error_string, ap);
         va_end(ap);
 
-	fprintf(stderr, "libnfs error: %s\n", rpc->error_string);
+	RPC_LOG(rpc, 1, "error: %s", rpc->error_string);
 
 	if (old_error_string != NULL) {
 		free(old_error_string);


### PR DESCRIPTION
only log error if debug >= 1.

Signed-off-by: Peter Lieven <pl@kamp.de>