### PR TITLE
build: add m4 directory to source tree

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,5 +1,2 @@
-#!/bin/bash
-
-mkdir -p m4
+#!/bin/sh
 autoreconf -vif
-


### PR DESCRIPTION
m4 directory is required for autotools generation, the use of bootstrap
script is nice helper, however, the autoreconf -ivf should be usable
for autotools based checkout without any other action.

these days the bootstrap script is kinda useless, in the old days it was
a very complex set of autoconf/automake/libtool/gettext commands.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>