### PR TITLE
socket: fix deadlock in rpc_reconnect_requeue

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -585,7 +585,7 @@ static void reconnect_cb(struct rpc_context *rpc, int status, void *data _U_, vo
 /* disconnect but do not error all PDUs, just move pdus in-flight back to the outqueue and reconnect */
 static int rpc_reconnect_requeue(struct rpc_context *rpc)
 {
-	struct rpc_pdu *pdu;
+	struct rpc_pdu *pdu, *next;
 	unsigned int i;
 
 	assert(rpc->magic == RPC_CONTEXT_MAGIC);
@@ -606,8 +606,8 @@ static int rpc_reconnect_requeue(struct rpc_context *rpc)
 	 */
 	for (i = 0; i < HASHES; i++) {
 		struct rpc_queue *q = &rpc->waitpdu[i];
-
-		for (pdu=q->head; pdu; pdu=pdu->next) {
+		for (pdu = q->head; pdu; pdu = next) {
+			next = pdu->next;
 			rpc_return_to_queue(&rpc->outqueue, pdu);
 			/* we have to re-send the whole pdu again */
 			pdu->written = 0;


### PR DESCRIPTION
the requeueing code is broken because we access pdu->next
after we mangled it in rpc_return_to_queue.

This leads to losing of waitqueue elements and more severe
a deadlock as soon as more than one waitpdu queue has elements.

Reason for that is that the first elements of the first
two queues are linked to each other.

Example:
waitpdu[0]->head = pduA ; pduA->next = pduB; pduB->next = NULL;
waitpdu[1]->head = pduC ; pduC->next = NULL;
outqueue->head = NULL;

After the for loop for waitpdu[0] queue the outqueue looks like

outqueue->head = pduA; pduA->next = NULL;

At this point pduB is lost!

In the for loop for waitpdu[1] queue the outqueue looks like this
after the first iteration:

outqueue->head = pduC; pduC->next = pduA; pduA->next = NULL;

We now fetch pdu->next of pduC which is pduA.

In the next iteration we put pduA in front of pduC. pduA->next
is then pduC and pduC->next is pduA. => Deadlock.

Signed-off-by: Peter Lieven <pl@kamp.de>