### PR TITLE
Support Win32 compilation with Mingw

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,8 @@ fi
 AC_SUBST(WARN_CFLAGS)
 
 LIBSOCKET=
+SYS=
+
 case $host in
   *solaris*)
     AC_CHECK_HEADERS([sys/filio.h])
@@ -100,10 +102,12 @@ case $host in
     ;;
   *mingw32* | *cygwin* | *wince* | *mingwce*)
     LIBSOCKET='-lws2_32'
+    SYS=mingw32
     ;;
   *)
     ;;
 esac
+AM_CONDITIONAL(HAVE_WIN32,   test "${SYS}" = "mingw32")
 AC_SUBST([LIBSOCKET])
 
 # check for poll.h

--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ if test "$ac_cv_prog_gcc" = yes; then
 fi
 AC_SUBST(WARN_CFLAGS)
 
-
+LIBSOCKET=
 case $host in
   *solaris*)
     AC_CHECK_HEADERS([sys/filio.h])
@@ -98,9 +98,13 @@ case $host in
     AC_CHECK_LIB([socket], [main], , [AC_MSG_ERROR([Can not find required library])])
     AC_CHECK_LIB([nsl],    [main], , [AC_MSG_ERROR([Can not find required library])])
     ;;
+  *mingw32* | *cygwin* | *wince* | *mingwce*)
+    LIBSOCKET='-lws2_32'
+    ;;
   *)
     ;;
 esac
+AC_SUBST([LIBSOCKET])
 
 # check for poll.h
 dnl Check for poll.h

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(2.50)
 AC_INIT([libnfs], [1.9.8], [ronniesahlberg@gmail.com])
 AC_CONFIG_HEADERS([config.h])
-AM_INIT_AUTOMAKE([-Wall foreign])
+AM_INIT_AUTOMAKE([-Wall foreign subdir-objects])
 AC_CANONICAL_HOST
 AC_CONFIG_MACRO_DIR([m4])
 m4_pattern_allow([AM_PROG_AR])

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -3,6 +3,7 @@ noinst_PROGRAMS = nfsclient-async nfsclient-raw nfsclient-sync nfsclient-bcast n
 AM_CPPFLAGS = \
 	-I$(abs_top_srcdir)/include \
 	-I$(abs_top_srcdir)/include/nfsc \
+	-I$(abs_top_srcdir)/include/win32 \
 	-I$(abs_top_srcdir)/mount \
 	-I$(abs_top_srcdir)/nfs \
 	-I$(abs_top_srcdir)/portmap \

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -10,4 +10,11 @@ AM_CPPFLAGS = \
 	-I$(abs_top_srcdir)/rquota \
 	"-D_U_=__attribute__((unused))"
 
-AM_LDFLAGS = ../lib/.libs/libnfs.la -lpopt
+COMMON_LIBS = ../lib/libnfs.la -lpopt
+nfsclient_async_LDADD = $(COMMON_LIBS)
+nfsclient_raw_LDADD = $(COMMON_LIBS)
+nfsclient_sync_LDADD = $(COMMON_LIBS)
+nfsclient_bcast_LDADD = $(COMMON_LIBS)
+nfsclient_listservers_LDADD = $(COMMON_LIBS)
+nfs_io_LDADD = $(COMMON_LIBS)
+portmap_client_LDADD = $(COMMON_LIBS)

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -8,7 +8,8 @@ dist_nfsc_HEADERS = \
 	../nfs/libnfs-raw-nfs.h \
 	../nlm/libnfs-raw-nlm.h \
 	../nsm/libnfs-raw-nsm.h \
-	../rquota/libnfs-raw-rquota.h
+	../rquota/libnfs-raw-rquota.h \
+	../win32/win32_compat.h
 
 dist_noinst_HEADERS = \
         libnfs-private.h \

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -69,10 +69,12 @@ struct statvfs {
 	uint32_t	f_flag;
 	uint32_t	f_namemax;
 };
+#if !defined(__MINGW32__)
 struct utimbuf {
 	time_t actime;
 	time_t modtime;
 };
+#endif
 #define R_OK	4
 #define W_OK	2
 #define X_OK	1

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -10,6 +10,7 @@ libnfs_la_CPPFLAGS = -I$(abs_top_srcdir)/include \
 		     -I$(abs_top_srcdir)/nsm \
 		     -I$(abs_top_srcdir)/portmap \
 		     -I$(abs_top_srcdir)/rquota \
+		     -I$(abs_top_srcdir)/win32 \
 		     "-D_U_=__attribute__((unused))"
 
 libnfs_la_SOURCES = \
@@ -18,7 +19,8 @@ libnfs_la_SOURCES = \
 	libnfs-sync.c \
 	libnfs-zdr.c \
 	pdu.c \
-	socket.c
+	socket.c \
+	../win32/win32_compat.c
 
 SOCURRENT=9
 SOREVISION=0

--- a/lib/libnfs-sync.c
+++ b/lib/libnfs-sync.c
@@ -457,7 +457,11 @@ int nfs_close(struct nfs_context *nfs, struct nfsfh *nfsfh)
 /*
  * fstat()
  */
+#ifdef WIN32
+int nfs_fstat(struct nfs_context *nfs, struct nfsfh *nfsfh, struct __stat64 *st)
+#else
 int nfs_fstat(struct nfs_context *nfs, struct nfsfh *nfsfh, struct stat *st)
+#endif
 {
 	struct sync_cb_data cb_data;
 

--- a/mount/Makefile.am
+++ b/mount/Makefile.am
@@ -7,7 +7,8 @@ mount_GENERATED = $(mount_SOURCES_GENERATED) $(mount_HEADERS_GENERATED)
 CLEANFILES = $(mount_GENERATED) mount-stamp
 
 libmount_la_CPPFLAGS = -I$(abs_top_srcdir)/include \
-		       -I$(abs_top_srcdir)/include/nfsc
+		       -I$(abs_top_srcdir)/include/nfsc \
+		       -I$(abs_top_srcdir)/win32
 libmount_la_SOURCES = \
 	$(mount_SOURCES_GENERATED) \
 	mount.c libnfs-raw-mount.c libnfs-raw-mount.h

--- a/nfs/Makefile.am
+++ b/nfs/Makefile.am
@@ -7,7 +7,8 @@ nfs_GENERATED = $(nfs_SOURCES_GENERATED) $(nfs_HEADERS_GENERATED)
 CLEANFILES = $(nfs_GENERATED) nfs-stamp
 
 libnfs_la_CPPFLAGS = -I$(abs_top_srcdir)/include \
-		     -I$(abs_top_srcdir)/include/nfsc
+		     -I$(abs_top_srcdir)/include/nfsc \
+		     -I$(abs_top_srcdir)/win32
 libnfs_la_SOURCES = \
 	$(nfs_SOURCES_GENERATED) \
 	nfs.c nfsacl.c libnfs-raw-nfs.c libnfs-raw-nfs.h

--- a/nlm/Makefile.am
+++ b/nlm/Makefile.am
@@ -7,7 +7,8 @@ nlm_GENERATED = $(nlm_SOURCES_GENERATED) $(nlm_HEADERS_GENERATED)
 CLEANFILES = $(nlm_GENERATED) nlm-stamp
 
 libnlm_la_CPPFLAGS = -I$(abs_top_srcdir)/include \
-		     -I$(abs_top_srcdir)/include/nfsc
+		     -I$(abs_top_srcdir)/include/nfsc \
+		     -I$(abs_top_srcdir)/win32
 libnlm_la_SOURCES = \
 	$(nlm_SOURCES_GENERATED) \
 	nlm.c libnfs-raw-nlm.c libnfs-raw-nlm.h

--- a/nsm/Makefile.am
+++ b/nsm/Makefile.am
@@ -7,7 +7,8 @@ nsm_GENERATED = $(nsm_SOURCES_GENERATED) $(nsm_HEADERS_GENERATED)
 CLEANFILES = $(nsm_GENERATED) nsm-stamp
 
 libnsm_la_CPPFLAGS = -I$(abs_top_srcdir)/include \
-		     -I$(abs_top_srcdir)/include/nfsc
+		     -I$(abs_top_srcdir)/include/nfsc \
+		     -I$(abs_top_srcdir)/win32
 libnsm_la_SOURCES = \
 	$(nsm_SOURCES_GENERATED) \
 	nsm.c libnfs-raw-nsm.c libnfs-raw-nsm.h

--- a/portmap/Makefile.am
+++ b/portmap/Makefile.am
@@ -7,7 +7,8 @@ portmap_GENERATED = $(portmap_SOURCES_GENERATED) $(portmap_HEADERS_GENERATED)
 CLEANFILES = $(portmap_GENERATED) portmap-stamp
 
 libportmap_la_CPPFLAGS = -I$(abs_top_srcdir)/include \
-			 -I$(abs_top_srcdir)/include/nfsc
+			 -I$(abs_top_srcdir)/include/nfsc \
+			 -I$(abs_top_srcdir)/win32
 libportmap_la_SOURCES = \
 	$(portmap_SOURCES_GENERATED) \
 	portmap.c libnfs-raw-portmap.c libnfs-raw-portmap.h

--- a/rquota/Makefile.am
+++ b/rquota/Makefile.am
@@ -7,7 +7,8 @@ rquota_GENERATED = $(rquota_SOURCES_GENERATED) $(rquota_HEADERS_GENERATED)
 CLEANFILES = $(rquota_GENERATED) rquota-stamp
 
 librquota_la_CPPFLAGS = -I$(abs_top_srcdir)/include \
-			-I$(abs_top_srcdir)/include/nfsc
+			-I$(abs_top_srcdir)/include/nfsc \
+			-I$(abs_top_srcdir)/win32
 librquota_la_SOURCES = \
 	$(rquota_SOURCES_GENERATED) \
 	rquota.c libnfs-raw-rquota.c libnfs-raw-rquota.h

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -4,6 +4,7 @@ AM_CPPFLAGS = \
 	-I$(abs_top_srcdir)/include \
 	-I$(abs_top_srcdir)/include/nfsc \
 	-I$(abs_top_srcdir)/mount \
+	-I$(abs_top_srcdir)/win32 \
 	"-D_U_=__attribute__((unused))"
 
 AM_LDFLAGS = ../lib/.libs/libnfs.la

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -11,4 +11,8 @@ AM_CPPFLAGS = \
 	-I$(abs_top_srcdir)/win32 \
 	"-D_U_=__attribute__((unused))"
 
-AM_LDFLAGS = ../lib/.libs/libnfs.la $(LIBSOCKET)
+COMMON_LIBS = ../lib/libnfs.la $(LIBSOCKET)
+
+nfs_cat_LDADD = $(COMMON_LIBS)
+nfs_ls_LDADD = $(COMMON_LIBS)
+nfs_cp_LDADD = $(COMMON_LIBS)

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -7,4 +7,4 @@ AM_CPPFLAGS = \
 	-I$(abs_top_srcdir)/win32 \
 	"-D_U_=__attribute__((unused))"
 
-AM_LDFLAGS = ../lib/.libs/libnfs.la
+AM_LDFLAGS = ../lib/.libs/libnfs.la $(LIBSOCKET)

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -1,4 +1,8 @@
-bin_PROGRAMS = nfs-cat nfs-cp nfs-ls
+bin_PROGRAMS = nfs-cat nfs-ls
+
+if !HAVE_WIN32
+bin_PROGRAMS += nfs-cp
+endif
 
 AM_CPPFLAGS = \
 	-I$(abs_top_srcdir)/include \

--- a/win32/win32_compat.c
+++ b/win32/win32_compat.c
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 #ifndef WIN32
 
-static int dummy ATTRIBUTE((unused));
+static int dummy _U_;
 
 #else
 #include "win32_compat.h"

--- a/win32/win32_compat.c
+++ b/win32/win32_compat.c
@@ -156,6 +156,7 @@ int win32_poll(struct pollfd *fds, unsigned int nfds, int timo)
   #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
 #endif
  
+#ifndef __MINGW32__
 struct timezone 
 {
   int  tz_minuteswest; /* minutes W of Greenwich */
@@ -197,4 +198,5 @@ int win32_gettimeofday(struct timeval *tv, struct timezone *tz)
   return 0;
 }
 
+#endif
 #endif

--- a/win32/win32_compat.h
+++ b/win32/win32_compat.h
@@ -28,7 +28,7 @@ THE SOFTWARE.
 
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#include <Ws2ipdef.h>
+#include <ws2ipdef.h>
 #include <basetsd.h>
 #include <io.h>
 #include <sys/stat.h>

--- a/win32/win32_compat.h
+++ b/win32/win32_compat.h
@@ -108,6 +108,9 @@ struct pollfd {
 int     win32_inet_pton(int af, const char * src, void * dst);
 int     win32_poll(struct pollfd *fds, unsigned int nfsd, int timeout);
 int     win32_gettimeofday(struct timeval *tv, struct timezone *tz);
+#ifdef __MINGW32__
+# define win32_gettimeofday mingw_gettimeofday
+#endif
 
 #define DllExport
 


### PR DESCRIPTION
This is a set of patches that should allow to cross-compile this library through Mingw on Linux

This is using autotools to compile for Win32, and not the win32build.bat

Some stuff are a bit kludgy to be honest, but the existing code was already a bit weird (nfs_stat declaration is fishy).

Some more work is required, I believe to clean everything for Win32, but this should be a good first step.