### PR TITLE
The correct NDK define for Android is __ANDROID__

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -22,7 +22,7 @@
 #define _LIBNFS_H_
 
 #include <stdint.h>
-#if defined(ANDROID)
+#if defined(__ANDROID__)
 #include <sys/time.h>
 #endif
 #if defined(AROS)

--- a/lib/libnfs-sync.c
+++ b/lib/libnfs-sync.c
@@ -37,7 +37,7 @@
 #include <net/if.h>
 #endif
 
-#ifdef ANDROID
+#ifdef __ANDROID__
 #define statvfs statfs
 #endif
 

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -33,7 +33,7 @@
 #include <utime.h>
 #endif
 
-#ifdef ANDROID
+#ifdef __ANDROID__
 #define statvfs statfs
 #endif
 
@@ -4220,7 +4220,7 @@ static void nfs_statvfs_1_cb(struct rpc_context *rpc, int status, void *command_
 	svfs.f_bavail  = res->FSSTAT3res_u.resok.abytes/NFS_BLKSIZE;
 	svfs.f_files   = res->FSSTAT3res_u.resok.tfiles;
 	svfs.f_ffree   = res->FSSTAT3res_u.resok.ffiles;
-#if !defined(ANDROID)
+#if !defined(__ANDROID__)
 	svfs.f_favail  = res->FSSTAT3res_u.resok.afiles;
 	svfs.f_fsid    = 0;
 	svfs.f_flag    = 0;

--- a/utils/nfs-ls.c
+++ b/utils/nfs-ls.c
@@ -36,7 +36,7 @@ WSADATA wsaData;
 #include <string.h>
 #include <sys/stat.h>
 #ifndef AROS
-#ifdef ANDROID
+#ifdef __ANDROID__
 #define statvfs statfs
 #include <sys/vfs.h>
 #else


### PR DESCRIPTION
The ANDROID macro is not recommended and will not work in all cases.

This fixes the compilation for libnfs on Android.