### PR TITLE
Add a configure option to disable the utils compilation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = doc mount nfs nlm nsm portmap rquota lib include utils . $(MAYBE_EXAMPLES)
+SUBDIRS = doc mount nfs nlm nsm portmap rquota lib include $(MAYBE_UTILS) . $(MAYBE_EXAMPLES)
 ACLOCAL_AMFLAGS = -I m4
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,14 @@ fi
 # We always want 64 bit file offsets
 CFLAGS="${CFLAGS} -D_FILE_OFFSET_BITS=64"
 
+#option: utils
+AC_ARG_ENABLE([utils],
+              [AC_HELP_STRING([--enable-utils],
+                              [Build util programs])],
+	      [MAYBE_UTILS=""],
+	      [MAYBE_UTILS="utils"])
+AC_SUBST(MAYBE_UTILS)
+
 #option: examples
 AC_ARG_ENABLE([examples],
               [AC_HELP_STRING([--enable-examples],


### PR DESCRIPTION
For some targets like iOS, utils are not useable, so it should be possible to disable their compilation

This is implemented in this pull request matching an existing configure switch to disable examples.