### PR TITLE
Android: only redefine statvfs if it is not already defined

### DIFF
--- a/lib/libnfs-sync.c
+++ b/lib/libnfs-sync.c
@@ -37,16 +37,16 @@
 #include <net/if.h>
 #endif
 
-#ifdef __ANDROID__
-#define statvfs statfs
-#endif
-
 #ifdef HAVE_SYS_VFS_H
 #include <sys/vfs.h>
 #endif
 
 #ifdef HAVE_SYS_STATVFS_H
 #include <sys/statvfs.h>
+#endif
+
+#if defined(__ANDROID__) && !defined(HAVE_SYS_STATVFS_H)
+#define statvfs statfs
 #endif
 
 #ifdef HAVE_SYS_IOCTL_H

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -33,10 +33,6 @@
 #include <utime.h>
 #endif
 
-#ifdef __ANDROID__
-#define statvfs statfs
-#endif
-
 #define _GNU_SOURCE
 
 #ifdef HAVE_UNISTD_H
@@ -49,6 +45,10 @@
 
 #ifdef HAVE_SYS_STATVFS_H
 #include <sys/statvfs.h>
+#endif
+
+#if defined(__ANDROID__) && !defined(HAVE_SYS_STATVFS_H)
+#define statvfs statfs
 #endif
 
 #ifdef HAVE_NETINET_IN_H


### PR DESCRIPTION
It is defined with recent platforms version 21 and more recent