### PR TITLE
nfs_rewinddir: introduce additional nfs_rewinddir()

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -949,6 +949,14 @@ struct nfsdirent  {
 EXTERN struct nfsdirent *nfs_readdir(struct nfs_context *nfs, struct nfsdir *nfsdir);
 
 
+/*
+ * REWINDDIR()
+ */
+/*
+ * nfs_rewinddir() cancel all previous nfs_readdir() side effects
+ */
+EXTERN void nfs_rewinddir(struct nfs_context *nfs, struct nfsdir *nfsdir);
+
 
 /*
  * CLOSEDIR()

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -4144,6 +4144,12 @@ struct nfsdirent *nfs_readdir(struct nfs_context *nfs _U_, struct nfsdir *nfsdir
 }
 
 
+void nfs_rewinddir(struct nfs_context *nfs _U_, struct nfsdir *nfsdir)
+{
+	nfsdir->current = nfsdir->entries;
+}
+
+
 /*
  * closedir()
  */


### PR DESCRIPTION
Introduce the nfs_rewinddir() utility function used
to cancel previous nfs_readdir() side effects.

Signed-off-by: Benoît Canet <benoit@scylladb.com>