### PR TITLE
Added the ability to bind to a specific interface

### DIFF
--- a/README
+++ b/README
@@ -44,6 +44,7 @@ Arguments supported by libnfs are :
                    : Should libnfs try to traverse across nested mounts
                      automatically or not. Default is 1 == enabled.
  dircache=<0|1>    : Disable/enable directory caching. Enabled by default.
+ if=<interface>    : Interface name (e.g., eth1) to bind; requires `root`
 
 Auto_traverse_mounts
 ====================

--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -22,6 +22,10 @@
 #include "config.h"  /* HAVE_SOCKADDR_STORAGE ? */
 #endif
 
+#ifdef HAVE_NET_IF_H
+#include <net/if.h>
+#endif
+
 #ifndef WIN32
 #include <sys/socket.h>  /* struct sockaddr_storage */
 #endif
@@ -128,6 +132,7 @@ struct rpc_context {
 	uint32_t pagecache_ttl;
 	int debug;
 	int timeout;
+	char ifname[IFNAMSIZ];
 };
 
 struct rpc_pdu {
@@ -191,6 +196,8 @@ struct sockaddr *rpc_get_recv_sockaddr(struct rpc_context *rpc);
 
 void rpc_set_autoreconnect(struct rpc_context *rpc);
 void rpc_unset_autoreconnect(struct rpc_context *rpc);
+
+void rpc_set_interface(struct rpc_context *rpc, const char *ifname);
 
 void rpc_set_tcp_syncnt(struct rpc_context *rpc, int v);
 void rpc_set_uid(struct rpc_context *rpc, int uid);

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -120,6 +120,11 @@ struct AUTH;
 EXTERN void nfs_set_auth(struct nfs_context *nfs, struct AUTH *auth);
 
 /*
+ * Used if you need to bind to a specific interface.
+ */
+EXTERN void nfs_set_interface(struct nfs_context *nfs, const char *ifname);
+
+/*
  * When an operation failed, this function can extract a detailed error string.
  */
 EXTERN char *nfs_get_error(struct nfs_context *nfs);

--- a/lib/init.c
+++ b/lib/init.c
@@ -131,6 +131,25 @@ void rpc_set_readahead(struct rpc_context *rpc, uint32_t v)
 	}
 }
 
+void rpc_set_interface(struct rpc_context *rpc, const char *ifname)
+{
+	/*
+	 * This only copies the interface information into the RPC
+	 * structure.  It doesn't stop whatever interface is being used. The
+	 * connection needs to be restarted for that happen. In other words,
+	 * set this before you connect.
+	 */
+	assert(rpc->magic == RPC_CONTEXT_MAGIC);
+
+	if (ifname) {
+		/*
+		 * Allow at one-less character just-in-case IFNAMSIZ for
+		 * the defined platform does not include the NUL-terminator.
+		 */
+		strncpy(rpc->ifname, ifname, sizeof(rpc->ifname) - 1);
+	}
+}
+
 void rpc_set_debug(struct rpc_context *rpc, int level)
 {
 	assert(rpc->magic == RPC_CONTEXT_MAGIC);

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -318,6 +318,11 @@ char *nfs_get_error(struct nfs_context *nfs)
 	return rpc_get_error(nfs->rpc);
 };
 
+void nfs_set_interface(struct nfs_context *nfs, const char *ifname)
+{
+	rpc_set_interface(nfs_get_rpc_context(nfs), ifname);
+}
+
 static int nfs_set_context_args(struct nfs_context *nfs, const char *arg, const char *val)
 {
 	if (!strcmp(arg, "tcp-syncnt")) {
@@ -336,6 +341,8 @@ static int nfs_set_context_args(struct nfs_context *nfs, const char *arg, const 
 		nfs->auto_traverse_mounts = atoi(val);
 	} else if (!strcmp(arg, "dircache")) {
 		nfs_set_dircache(nfs, atoi(val));
+	} else if (!strcmp(arg, "if")) {
+		nfs_set_interface(nfs, val);
 	}
 	return 0;
 }


### PR DESCRIPTION
Added the ability to bind to a specific interface with the `nfs_set_interface` and `rpc_set_interface` APIs, or via the NFS URL `if=<interface>` parameter. This feature requires `root` permissions.

NOTE: This has only been compiled and tested on Ubuntu 14.04. It's unlikely that it'll work on other platforms without modification, particularly around the inclusion of `<net/if.h>` and `IFNAMSIZ` define in `libnfs-private.h`.