### PR TITLE
For upstream

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -112,7 +112,7 @@ struct rpc_context {
 	struct rpc_queue waitpdu[HASHES];
 
 	uint32_t inpos;
-	uint32_t insize;
+	char rm_buf[4];
 	char *inbuf;
 
 	/* special fields for UDP, which can sometimes be BROADCASTed */

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -298,6 +298,7 @@ again:
 
 		if (rpc_process_pdu(rpc, buf, pdu_size) != 0) {
 			rpc_set_error(rpc, "Invalid/garbage pdu received from server. Closing socket");
+			free(buf);
 			return -1;
 		}
 		free(buf);

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -223,6 +223,7 @@ static int rpc_read_from_socket(struct rpc_context *rpc)
 	uint32_t pdu_size;
 	ssize_t count;
 	char *buf;
+	int available;
 
 	assert(rpc->magic == RPC_CONTEXT_MAGIC);
 
@@ -252,57 +253,64 @@ static int rpc_read_from_socket(struct rpc_context *rpc)
 		return 0;
 	}
 
-again:
-	/* read record marker, 4 bytes at the beginning of every pdu first */
-	if (rpc->inpos < 4) {
-		buf = (void *)rpc->rm_buf;
-		pdu_size = 4;
-	} else {
-		pdu_size = rpc_get_pdu_size((void *)&rpc->rm_buf);
-		if (rpc->inbuf == NULL) {
-			if (pdu_size > NFS_MAX_XFER_SIZE + 4096) {
-				rpc_set_error(rpc, "Incoming PDU exceeds limit of %d bytes.", NFS_MAX_XFER_SIZE + 4096);
-				return -1;
-			}
-			rpc->inbuf = malloc(pdu_size);
+	/* check how much data is in the input buffer of the socket and read as many
+	 * PDUs as available */
+	if (ioctl(rpc->fd, FIONREAD, &available) < 0) {
+		return -1;
+	}
+
+	while (available > 0) {
+		/* read record marker, 4 bytes at the beginning of every pdu first */
+		if (rpc->inpos < 4) {
+			buf = (void *)rpc->rm_buf;
+			pdu_size = 4;
+		} else {
+			pdu_size = rpc_get_pdu_size((void *)&rpc->rm_buf);
 			if (rpc->inbuf == NULL) {
-				rpc_set_error(rpc, "Failed to allocate buffer of %d bytes for pdu, errno:%d. Closing socket.", pdu_size, errno);
-				return -1;
+				if (pdu_size <= 4) {
+					rpc_set_error(rpc, "Incoming PDU of %d bytes is too small.", pdu_size);
+					return -1;
+				}
+				if (pdu_size > NFS_MAX_XFER_SIZE + 4096) {
+					rpc_set_error(rpc, "Incoming PDU of %d bytes exceeds limit of %d bytes.", pdu_size, NFS_MAX_XFER_SIZE + 4096);
+					return -1;
+				}
+				rpc->inbuf = malloc(pdu_size);
+				if (rpc->inbuf == NULL) {
+					rpc_set_error(rpc, "Failed to allocate buffer of %d bytes for pdu, errno:%d. Closing socket.", pdu_size, errno);
+					return -1;
+				}
+				memcpy(rpc->inbuf, &rpc->rm_buf, 4);
 			}
-			memcpy(rpc->inbuf, &rpc->rm_buf, 4);
+			buf = rpc->inbuf;
 		}
-		buf = rpc->inbuf;
-	}
 
-	count = recv(rpc->fd, buf + rpc->inpos, pdu_size - rpc->inpos, MSG_DONTWAIT);
-	if (count < 0) {
-		if (errno == EINTR || errno == EAGAIN) {
-			return 0;
-		}
-		rpc_set_error(rpc, "Read from socket failed, errno:%d. Closing socket.", errno);
-		return -1;
-	}
-	if (count == 0) {
-		/* remote side has closed the socket. Reconnect. */
-		return -1;
-	}
-	rpc->inpos += count;
-
-	if (rpc->inpos == 4) {
-		/* we have just read the header there is likely more data available */
-		goto again;
-	}
-
-	if (rpc->inpos == pdu_size) {
-		rpc->inbuf  = NULL;
-		rpc->inpos  = 0;
-
-		if (rpc_process_pdu(rpc, buf, pdu_size) != 0) {
-			rpc_set_error(rpc, "Invalid/garbage pdu received from server. Closing socket");
-			free(buf);
+		count = recv(rpc->fd, buf + rpc->inpos, pdu_size - rpc->inpos, MSG_DONTWAIT);
+		if (count < 0) {
+			if (errno == EINTR || errno == EAGAIN) {
+				return 0;
+			}
+			rpc_set_error(rpc, "Read from socket failed, errno:%d. Closing socket.", errno);
 			return -1;
 		}
-		free(buf);
+		if (count == 0) {
+			/* remote side has closed the socket. Reconnect. */
+			return -1;
+		}
+		rpc->inpos += count;
+		available -= count;
+
+		if (rpc->inpos > 4 && rpc->inpos == pdu_size) {
+			rpc->inbuf  = NULL;
+			rpc->inpos  = 0;
+
+			if (rpc_process_pdu(rpc, buf, pdu_size) != 0) {
+				rpc_set_error(rpc, "Invalid/garbage pdu received from server. Closing socket");
+				free(buf);
+				return -1;
+			}
+			free(buf);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
Hi Ronnie,

libnfs suffers from the same issue in rpc_read_from_socket. This patch changes the behaviour similar to libnfs. However, it only reads what is available when we enter rpc_read_from_socket to avoid starvation in rpc_read_from_socket. I also found that we nowhere check if the incoming PDU is too small. I added a check for 0 bytes, but I have no idea what the mimum PDU size really is. Maybe you have an idea.

Peter