### PR TITLE
socket: Limit reconnect retries to 10

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -133,6 +133,7 @@ struct rpc_context {
 	/* track the address we connect to so we can auto-reconnect on session failure */
 	struct sockaddr_storage s;
 	int auto_reconnect;
+	int auto_reconnect_retries;
 
 	/* fragment reassembly */
 	struct rpc_fragment *fragments;


### PR DESCRIPTION
Limit the number of retries when autoreconnecting (to an arbitrary 10)
and return an error to the application if this limit is reached.
Without this, libnfs retries indefinitely and consumes 100% CPU.

See also: https://bugzilla.gnome.org/show_bug.cgi?id=762544

Signed-off-by: Ross Lagerwall <rosslagerwall@gmail.com>