### PR TITLE
Here are some changes to resolve some conflicts with MinGW and fuse_dokan

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -148,6 +148,10 @@ AC_CHECK_HEADERS([sys/vfs.h])
 dnl Check for sys/statvfs.h
 AC_CHECK_HEADERS([sys/statvfs.h])
 
+# check for fuse.h
+dnl Check for fuse.h
+AC_CHECK_HEADERS([fuse.h])
+
 # check for sys/socket.h
 dnl Check for sys/socket.h
 AC_CHECK_HEADERS([sys/socket.h])

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -22,14 +22,11 @@
 #define _LIBNFS_H_
 
 #include <stdint.h>
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(AROS) \
+ || ( defined(__APPLE__) && defined(__MACH__) )
 #include <sys/time.h>
-#endif
-#if defined(AROS)
-#include <sys/time.h>
-#endif
-#if defined(__APPLE__) && defined(__MACH__)
-#include <sys/time.h>
+#else
+#include <time.h>
 #endif
 
 #ifdef __cplusplus
@@ -57,7 +54,10 @@ struct nfs_url {
 #define EXTERN
 #endif
 
-#if defined(WIN32)
+#ifdef WIN32
+#ifdef HAVE_FUSE_H
+#include <fuse.h>
+#else
 struct statvfs {
 	uint32_t	f_bsize;
 	uint32_t	f_frsize;
@@ -71,6 +71,7 @@ struct statvfs {
 	uint32_t	f_flag;
 	uint32_t	f_namemax;
 };
+#endif
 #if !defined(__MINGW32__)
 struct utimbuf {
 	time_t actime;

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -27,9 +27,12 @@
 
 #ifdef WIN32
 #include "win32_compat.h"
-#define PRIu64 "llu"
-#else
+#endif
+
+#ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
+#else
+#define PRIu64 "llu"
 #endif
 
 #ifdef HAVE_UTIME_H

--- a/win32/win32_compat.h
+++ b/win32/win32_compat.h
@@ -34,8 +34,8 @@ THE SOFTWARE.
 #include <sys/stat.h>
 #include <time.h>
 
-typedef int uid_t;
-typedef int gid_t;
+typedef unsigned int uid_t;
+typedef unsigned int gid_t;
 typedef int socklen_t;
 
 #ifndef S_IRUSR

--- a/win32/win32_compat.h
+++ b/win32/win32_compat.h
@@ -38,9 +38,11 @@ typedef int uid_t;
 typedef int gid_t;
 typedef int socklen_t;
 
+#ifndef S_IRUSR
 #define S_IRUSR 0000400
 #define S_IWUSR 0000200
 #define S_IXUSR 0000100
+#endif
 #define	S_IRWXG	0000070			/* RWX mask for group */
 #define S_IRGRP 0000040
 #define S_IWGRP 0000020
@@ -102,12 +104,18 @@ struct pollfd {
 #define close closesocket
 #define ioctl ioctlsocket
 
+#ifndef ESTALE
+#define ESTALE 116
+#endif
+
 /* Wrapper macros to call misc. functions win32 is missing */
 #define poll(x, y, z)        win32_poll(x, y, z)
 #define snprintf             sprintf_s
 #define inet_pton(x,y,z)     win32_inet_pton(x,y,z)
 #define open(x, y, z)        _open(x, y, z)
+#ifndef lseek
 #define lseek(x, y, z)       _lseek(x, y, z)
+#endif
 #define read(x, y, z)        _read(x, y, z)
 #define write(x, y, z)       _write(x, y, z)
 int     getpid(void);


### PR DESCRIPTION
When I tried do cross-compile this library with x86_64-w64-mingw32-gcc and i686-w64-mingw32-gcc, i got some conflicts between mingw and win32_compat.h. Also, when I tried to cross-compile fuse-nfs and dokan_fuse, I got some conflicts between the version of struct statvfs provided by libnfs and dokan_fuse. This pull request resolves both problems.
