### PR TITLE
Cygwin should not use winsock2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,7 +102,7 @@ case $host in
     AC_CHECK_LIB([socket], [main], , [AC_MSG_ERROR([Can not find required library])])
     AC_CHECK_LIB([nsl],    [main], , [AC_MSG_ERROR([Can not find required library])])
     ;;
-  *mingw32* | *cygwin* | *wince* | *mingwce*)
+  *mingw32* | *wince* | *mingwce*)
     LIBSOCKET='-lws2_32'
     SYS=mingw32
     ;;


### PR DESCRIPTION
As per the commit message:

> The configure.ac script was erroneously including -lws2_32,
> i.e. the winsock2 library. Cygwin is a full POSIX environment
> and does not need the winsock2 functionality as it supplies its
> own POSIX compatible sockets.
>
> Including -lws2_32 caused getnameinfo to fail with error 10093
> (WSANOTINITIALISED). This usually means that the Winsock
> WSAStartup function has not been called. Calling WSAStartup is
> not necessary for Cygwin programs and in fact should be avoided.