### PR TITLE
Release callback data on nfs_create_2_cb() failure

### DIFF
--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -3270,7 +3270,7 @@ static void nfs_create_2_cb(struct rpc_context *rpc, int status, void *command_d
 	if (res->status != NFS3_OK) {
 		rpc_set_error(nfs->rpc, "NFS: CREATE of %s/%s failed with %s(%d)", data->saved_path, str, nfsstat3_to_str(res->status), nfsstat3_to_errno(res->status));
 		data->cb(nfsstat3_to_errno(res->status), nfs, rpc_get_error(nfs->rpc), data->private_data);
-
+		free_nfs_cb_data(data);
 		return;
 	}
 


### PR DESCRIPTION
Signed-off-by: Earl Chew <earl_chew@yahoo.com>