### PR TITLE
Fix crash on timed out mount-nfs calls.

### DIFF
--- a/lib/libnfs-sync.c
+++ b/lib/libnfs-sync.c
@@ -209,6 +209,14 @@ int nfs_mount(struct nfs_context *nfs, const char *server, const char *export)
 	/* Dont want any more callbacks even if the socket is closed */
 	rpc->connect_cb = NULL;
 
+	/* Ensure that no RPCs are pending. In error case (e.g. timeout in
+	 * wait_for_nfs_reply()) we can disconnect; in success case all RPCs
+	 * are completed by definition.
+	 */
+	if (cb_data.status) {
+		rpc_disconnect(rpc, "failed mount");
+	}
+
 	return cb_data.status;
 }
 


### PR DESCRIPTION
If wait_for_nfs_reply() times out, nfs_mount can return with RPCs
still pending. In that case when the RPCs complete (perhaps because
someone calls destroy_context()), the callbacks run, and private_data
is pointing at what was the stack-allocated cb_data structure. Stack
smashing and segfaulty fun ensue.

Fix by ensuring no RPCs are pending before returning from nfs_mount()
by disconnecting on errors.