### PR TITLE
add cmake build system support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ stamp-h1
 
 libnfs.pc
 !libnfs.pc.in
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,97 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(libnfs
+        LANGUAGES C
+        VERSION 2.0.0)
+
+set(SOVERSION 11.0.0 CACHE STRING "" FORCE)
+
+set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
+set(INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "Installation directory for headers")
+set(INSTALL_MAN_DIR "${CMAKE_INSTALL_PREFIX}/share/man" CACHE PATH "Installation directory for manual pages")
+set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
+set(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_PREFIX}/lib/cmake/libnfs" CACHE PATH "Installation directory for cmake (.cmake) files")
+
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(ENABLE_TESTS "Build and run test programs" OFF)
+option(ENABLE_DOCUMENTATION "Build Documentation" OFF)
+option(ENABLE_UTILS "Build util programs" OFF)
+option(ENABLE_EXAMPLES "Build example programs" OFF)
+
+if(ENABLE_TESTS)
+  set(ENABLE_UTILS ON CACHE BOOL "Building utils required by tests" FORCE)
+endif()
+
+include(cmake/Macros.cmake)
+include(cmake/ConfigureChecks.cmake)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR}
+                    include
+                    include/nfsc)
+
+set(CORE_LIBRARIES nfs)
+set(core_DEPENDS "" CACHE STRING "" FORCE)
+
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  list(APPEND CORE_LIBRARIES -lws2_32.lib)
+  add_subdirectory(win32)
+elseif(CMAKE_SYSTEM_NAME STREQUAL Solaris)
+  find_library(SOCKET_LIBRARY socket)
+  find_library(NSL_LIBRARY nsl)
+  list(APPEND CORE_LIBRARIES ${SOCKET_LIBRARY} ${NSL_LIBRARY})
+elseif(CMAKE_SYSTEM_NAME STREQUAL aros)
+  add_definitions(-DAROS)
+  add_subdirectory(aros)
+endif()
+
+if(ENABLE_DOCUMENTATION)
+  add_subdirectory(doc)
+endif()
+
+if(ENABLE_EXAMPLES)
+  add_subdirectory(examples)
+endif()
+
+if(ENABLE_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
+endif()
+
+if(ENABLE_UTILS)
+  add_subdirectory(utils)
+endif()
+
+add_subdirectory(mount)
+add_subdirectory(nfs)
+add_subdirectory(nfs4)
+add_subdirectory(nlm)
+add_subdirectory(nsm)
+add_subdirectory(portmap)
+add_subdirectory(rquota)
+add_subdirectory(lib)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/libnfs-config-version.cmake
+                                 VERSION ${PROJECT_VERSION}
+                                 COMPATIBILITY AnyNewerVersion)
+
+configure_file(cmake/libnfs.pc.cmake
+               ${CMAKE_CURRENT_BINARY_DIR}/libnfs.pc @ONLY)
+
+install(DIRECTORY include/nfsc
+        DESTINATION ${INSTALL_INC_DIR})
+
+install(FILES mount/libnfs-raw-mount.h
+              nfs/libnfs-raw-nfs.h
+              nlm/libnfs-raw-nlm.h
+              nsm/libnfs-raw-nsm.h
+              portmap/libnfs-raw-portmap.h
+              rquota/libnfs-raw-rquota.h
+        DESTINATION ${INSTALL_INC_DIR}/nfsc)
+
+install(FILES cmake/FindNFS.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/libnfs-config-version.cmake
+        DESTINATION ${INSTALL_CMAKE_DIR})
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libnfs.pc
+        DESTINATION ${INSTALL_PKGCONFIG_DIR})

--- a/aros/CMakeLists.txt
+++ b/aros/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(SOURCES aros_compat.c)
+set(HEADERS aros_compat.h)
+
+core_add_library(aros)

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -1,0 +1,103 @@
+include(CheckIncludeFile)
+check_include_file("arpa/inet.h" HAVE_ARPA_INET_H)
+check_include_file("dlfcn.h" HAVE_DLFCN_H)
+check_include_file("fuse.h" HAVE_FUSE_H)
+check_include_file("inttypes.h" HAVE_INTTYPES_H)
+check_include_file("memory.h" HAVE_MEMORY_H)
+check_include_file("netdb.h" HAVE_NETDB_H)
+check_include_file("netinet/in.h" HAVE_NETINET_IN_H)
+check_include_file("netinet/tcp.h" HAVE_NETINET_IN_H)
+check_include_file("net/if.h" HAVE_NET_IF_H)
+check_include_file("poll.h" HAVE_POLL_H)
+check_include_file("stdint.h" HAVE_STDINT_H)
+check_include_file("stdlib.h" HAVE_STDLIB_H)
+check_include_file("strings.h" HAVE_STRINGS_H)
+check_include_file("string.h" HAVE_STRING_H)
+check_include_file("sys/filio.h" HAVE_SYS_FILIO_H)
+check_include_file("sys/ioctl.h" HAVE_SYS_IOCTL_H)
+check_include_file("sys/socket.h" HAVE_SYS_SOCKET_H)
+check_include_file("sys/statvfs.h" HAVE_SYS_STATVFS_H)
+check_include_file("sys/stat.h" HAVE_SYS_STAT_H)
+check_include_file("sys/sysmacros.h" HAVE_SYS_SYSMACROS_H)
+check_include_file("sys/time.h" HAVE_SYS_TIME_H)
+check_include_file("sys/types.h" HAVE_SYS_TYPES_H)
+check_include_file("sys/vfs.h" HAVE_SYS_VFS_H)
+check_include_file("unistd.h" HAVE_UNISTD_H)
+check_include_file("utime.h" HAVE_UTIME_H)
+
+include(CheckStructHasMember)
+check_struct_has_member("struct sockaddr" sa_len sys/socket.h HAVE_SOCKADDR_LEN)
+check_struct_has_member("struct sockaddr_storage" ss_family sys/socket.h HAVE_SOCKADDR_STORAGE)
+check_struct_has_member("struct stat" st_mtim.tv_nsec sys/stat.h HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC)
+
+include(CheckCSourceCompiles)
+check_c_source_compiles("#include <net/if.h>
+                         int main(void)
+                         {
+                           int i = SO_BINDTODEVICE;
+                         }"
+                        HAVE_SO_BINDTODEVICE)
+
+check_c_source_compiles("#include <talloc.h>
+                         #include <tevent.h>
+                         int main(void)
+                         {
+                           struct tevent_context *ctx = tevent_context_init(NULL);
+                           int major = talloc_version_major();
+                         }"
+                        HAVE_TALLOC_TEVENT)
+
+check_c_source_compiles("#include <time.h>
+                         int main(void)
+                         {
+                           int i = clock_gettime(CLOCK_MONOTONIC_COARSE, NULL);
+                         }"
+                        HAVE_CLOCK_GETTIME)
+
+check_c_source_compiles("#include <sys/types.h>
+                         #define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+                         int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721 && LARGE_OFF_T % 2147483647 == 1) ? 1 : -1];
+                         int main()
+                         {
+                           return 0;
+                         }"
+                        NO_LFS_REQUIRED)
+
+if(NOT NO_LFS_REQUIRED)
+  check_c_source_compiles("#include <sys/types.h>
+                           #define _FILE_OFFSET_BITS 64
+                           #define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+                           int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721 && LARGE_OFF_T % 2147483647 == 1) ? 1 : -1];
+                           int main()
+                           {
+                             return 0;
+                           }"
+                          _FILE_OFFSET_BITS)
+
+  check_c_source_compiles("#include <sys/types.h>
+                           #define _LARGE_FILES 1
+                           #define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+                           int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721 && LARGE_OFF_T % 2147483647 == 1) ? 1 : -1];
+                           int main()
+                           {
+                             return 0;
+                           }"
+                          _LARGE_FILES)
+endif()
+
+
+include(CheckSymbolExists)
+check_symbol_exists("makedev" "sys/mkdev.h" MAJOR_IN_MKDEV)
+check_symbol_exists("makedev" "sys/sysmacros.h" MAJOR_IN_SYSMACROS)
+
+include(CheckCCompilerFlag)
+if(CMAKE_COMPILER_IS_GNUCC)
+  check_c_compiler_flag(-Wall C_ACCEPTS_WALL)
+
+  if(C_ACCEPTS_WALL)
+    add_definitions(-Wall)
+  endif()
+endif()
+
+configure_file(cmake/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+add_definitions(-DHAVE_CONFIG_H)

--- a/cmake/FindNFS.cmake
+++ b/cmake/FindNFS.cmake
@@ -1,0 +1,37 @@
+#.rst:
+# FindNFS
+# -------
+# Finds the libnfs library
+#
+# This will will define the following variables::
+#
+# NFS_FOUND - system has libnfs
+# NFS_INCLUDE_DIRS - the libnfs include directory
+# NFS_LIBRARIES - the libnfs libraries
+# NFS_DEFINITIONS - the libnfs compile definitions
+#
+
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_NFS libnfs QUIET)
+endif()
+
+find_path(NFS_INCLUDE_DIR nfsc/libnfs.h
+                          PATHS ${PC_NFS_INCLUDEDIR})
+find_library(NFS_LIBRARY NAMES nfs
+                         PATHS ${PC_NFS_LIBDIR})
+
+set(NFS_VERSION ${PC_NFS_VERSION})
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(NFS
+                                  REQUIRED_VARS NFS_LIBRARY NFS_INCLUDE_DIR
+                                  VERSION_VAR NFS_VERSION)
+
+if(NFS_FOUND)
+  set(NFS_LIBRARIES ${NFS_LIBRARY})
+  set(NFS_INCLUDE_DIRS ${NFS_INCLUDE_DIR})
+  set(NFS_DEFINITIONS -DHAVE_LIBNFS=1)
+endif()
+
+mark_as_advanced(NFS_INCLUDE_DIR NFS_LIBRARY)

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -1,0 +1,15 @@
+# Add sources to main application
+# Arguments:
+#   name name of the library to add
+# Implicit arguments:
+#   SOURCES the sources of the library
+#   HEADERS the headers of the library (only for IDE support)
+# On return:
+#   Library will be built and added to ${core_DEPENDS}
+function(core_add_library name)
+  set(name core_${name})
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  add_library(${name} STATIC ${SOURCES} ${HEADERS})
+  target_include_directories(${name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+  set(core_DEPENDS ${name} ${core_DEPENDS} CACHE STRING "" FORCE)
+endfunction()

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -1,0 +1,122 @@
+/* config.h.cmake  */
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#cmakedefine HAVE_ARPA_INET_H
+
+/* Whether we have clock_gettime */
+#cmakedefine HAVE_CLOCK_GETTIME
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#cmakedefine HAVE_DLFCN_H
+
+/* Define to 1 if you have the <fuse.h> header file. */
+#cmakedefine HAVE_FUSE_H
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#cmakedefine HAVE_INTTYPES_H
+
+/* Define to 1 if you have the `nsl' library (-lnsl). */
+#cmakedefine HAVE_LIBNSL
+
+/* Define to 1 if you have the `socket' library (-lsocket). */
+#cmakedefine HAVE_LIBSOCKET
+
+/* Define to 1 if you have the <memory.h> header file. */
+#cmakedefine HAVE_MEMORY_H
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#cmakedefine HAVE_NETDB_H
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#cmakedefine HAVE_NETINET_IN_H
+
+/* Define to 1 if you have the <netinet/tcp.h> header file. */
+#cmakedefine HAVE_NETINET_TCP_H
+
+/* Define to 1 if you have the <net/if.h> header file. */
+#cmakedefine HAVE_NET_IF_H
+
+/* Define to 1 if you have the <poll.h> header file. */
+#cmakedefine HAVE_POLL_H
+
+/* Whether sockaddr struct has sa_len */
+#cmakedefine HAVE_SOCKADDR_LEN
+
+/* Whether we have sockaddr_Storage */
+#cmakedefine HAVE_SOCKADDR_STORAGE
+
+/* Whether our sockets support SO_BINDTODEVICE */
+#cmakedefine HAVE_SO_BINDTODEVICE
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#cmakedefine HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#cmakedefine HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#cmakedefine HAVE_STRING_H
+
+/* Define to 1 if `st_mtim.tv_nsec' is a member of `struct stat'. */
+#cmakedefine HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC
+
+/* Define to 1 if you have the <sys/filio.h> header file. */
+#cmakedefine HAVE_SYS_FILIO_H
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+#cmakedefine HAVE_SYS_IOCTL_H
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#cmakedefine HAVE_SYS_SOCKET_H
+
+/* Define to 1 if you have the <sys/sockio.h> header file. */
+#cmakedefine HAVE_SYS_SOCKIO_H
+
+/* Define to 1 if you have the <sys/statvfs.h> header file. */
+#cmakedefine HAVE_SYS_STATVFS_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#cmakedefine HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/sysmacros.h> header file. */
+#cmakedefine HAVE_SYS_SYSMACROS_H
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#cmakedefine HAVE_SYS_TIME_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#cmakedefine HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <sys/vfs.h> header file. */
+#cmakedefine HAVE_SYS_VFS_H
+
+/* Whether we have talloc nad tevent support */
+#cmakedefine HAVE_TALLOC_TEVENT
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#cmakedefine HAVE_UNISTD_H
+
+/* Define to 1 if you have the <utime.h> header file. */
+#cmakedefine HAVE_UTIME_H
+
+/* Define to 1 if `major', `minor', and `makedev' are declared in <mkdev.h>.
+   */
+#cmakedefine MAJOR_IN_MKDEV
+
+/* Define to 1 if `major', `minor', and `makedev' are declared in
+   <sysmacros.h>. */
+#cmakedefine MAJOR_IN_SYSMACROS
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#cmakedefine _FILE_OFFSET_BITS
+
+/* Define for large files, on AIX-style hosts. */
+#cmakedefine _LARGE_FILES

--- a/cmake/libnfs.pc.cmake
+++ b/cmake/libnfs.pc.cmake
@@ -1,0 +1,14 @@
+# libnfs pkg-config file
+
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@INSTALL_LIB_DIR@
+includedir=@INSTALL_INC_DIR@
+
+Name: libnfs
+Description: libnfs is a client library for accessing NFS shares over a network.
+Version: @PROJECT_VERSION@
+Requires:
+Conflicts:
+Libs: -L${libdir} -lnfs
+Cflags: -I${includedir}

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,21 @@
+find_program(XSLTPROC_PROGRAM xsltproc)
+
+set(MANPAGES nfs-cat.1
+             nfs-cp.1
+             nfs-ls.1)
+
+set(DOCKBOOK_URL http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl)
+
+if(XSLTPROC_PROGRAM)
+  foreach(TARGET ${MANPAGES})
+    file(COPY ${TARGET}.xml
+         DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+    add_custom_command(OUTPUT ${TARGET}
+                       COMMAND ${XSLTPROC_PROGRAM} -o ${TARGET} ${DOCKBOOK_URL} ${TARGET}.xml)
+  endforeach()
+
+  add_custom_target(doc ALL DEPENDS ${MANPAGES})
+endif()
+
+install(FILES ${MANPAGES}
+        DESTINATION ${INSTALL_MAN_DIR}/man1/)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,34 @@
+find_library(TALLOC_LIBRARY talloc)
+find_library(TALLOC_EVENT_LIBRARY tevent)
+find_library(EVENT_LIBARY event)
+find_library(POPT_LIBRARY popt)
+
+list(APPEND CORE_LIBRARIES ${POPT_LIBRARY})
+
+set(SOURCES nfsclient-async
+            nfsclient-raw
+            nfsclient-sync
+            nfsclient-bcast
+            nfsclient-listservers
+            nfs-io
+            nfs-ln
+            portmap-client)
+
+if(HAVE_TALLOC_TEVENT)
+  list(APPEND SOURCES nfs4-cat-talloc)
+  list(APPEND CORE_LIBRARIES ${TALLOC_EVENT_LIBRARY} ${TALLOC_LIBRARY})
+endif()
+
+if(EVENT_LIBARY)
+  list(APPEND SOURCES nfs4-cat
+                      portmap-server)
+  list(APPEND CORE_LIBRARIES ${EVENT_LIBARY})
+endif()
+
+foreach(TARGET ${SOURCES})
+  add_executable(${TARGET} ${TARGET}.c)
+  target_link_libraries(${TARGET} ${CORE_LIBRARIES})
+  add_dependencies(${TARGET} nfs)
+endforeach()
+
+add_definitions("-D_U_=__attribute__((unused))")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(SOURCES init.c
+            libnfs.c
+            libnfs-sync.c
+            libnfs-zdr.c
+            nfs_v3.c
+            nfs_v4.c
+            pdu.c
+            socket.c)
+
+add_library(nfs ${SOURCES})
+target_link_libraries(nfs PUBLIC ${core_DEPENDS})
+set_target_properties(nfs PROPERTIES
+                          VERSION ${PROJECT_VERSION}
+                          SOVERSION ${SOVERSION})
+add_dependencies(nfs ${core_DEPENDS})
+add_definitions("-D_U_=__attribute__((unused))")
+
+install(TARGETS nfs EXPORT nfs
+                    RUNTIME DESTINATION bin
+                    ARCHIVE DESTINATION lib
+                    LIBRARY DESTINATION lib)

--- a/mount/CMakeLists.txt
+++ b/mount/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES libnfs-raw-mount.c
+            mount.c)
+set(HEADERS libnfs-raw-mount.h)
+
+core_add_library(mount)

--- a/nfs/CMakeLists.txt
+++ b/nfs/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(SOURCES libnfs-raw-nfs.c
+            nfs.c
+            nfsacl.c)
+set(HEADERS libnfs-raw-nfs.h)
+
+core_add_library(nfs)

--- a/nfs4/CMakeLists.txt
+++ b/nfs4/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES libnfs-raw-nfs4.c
+            nfs4.c)
+set(HEADERS libnfs-raw-nfs4.h)
+
+core_add_library(nfs4)

--- a/nlm/CMakeLists.txt
+++ b/nlm/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES libnfs-raw-nlm.c
+            nlm.c)
+set(HEADERS libnfs-raw-nlm.h)
+
+core_add_library(nlm)

--- a/nsm/CMakeLists.txt
+++ b/nsm/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES libnfs-raw-nsm.c
+            nsm.c)
+set(HEADERS libnfs-raw-nsm.h)
+
+core_add_library(nsm)

--- a/portmap/CMakeLists.txt
+++ b/portmap/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES libnfs-raw-portmap.c
+            portmap.c)
+set(HEADERS libnfs-raw-portmap.h)
+
+core_add_library(portmap)

--- a/rquota/CMakeLists.txt
+++ b/rquota/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES libnfs-raw-rquota.c
+            rquota.c)
+set(HEADERS libnfs-raw-rquota.h)
+
+core_add_library(rquota)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,54 @@
+find_library(DL_LIBRARY dl)
+
+set(SOURCES prog_access
+            prog_access2
+            prog_chmod
+            prog_chown
+            prog_create
+            prog_fchmod
+            prog_fchown
+            prog_fstat
+            prog_ftruncate
+            prog_lchmod
+            prog_lchown
+            prog_link
+            prog_lseek
+            prog_lstat
+            prog_mkdir
+            prog_mknod
+            prog_mount
+            prog_open_read
+            prog_open_write
+            prog_rename
+            prog_rmdir
+            prog_stat
+            prog_statvfs
+            prog_symlink
+            prog_timeout
+            prog_truncate
+            prog_unlink
+            prog_utimes)
+
+foreach(TARGET ${SOURCES})
+  add_executable(${TARGET} ${TARGET}.c)
+  target_link_libraries(${TARGET} ${CORE_LIBRARIES})
+  add_dependencies(${TARGET} nfs)
+endforeach()
+
+add_library(ld_timeout SHARED ld_timeout.c)
+set_target_properties(ld_timeout PROPERTIES PREFIX "")
+target_link_libraries(ld_timeout ${CORE_LIBRARIES} ${DL_LIBRARY})
+add_dependencies(ld_timeout nfs)
+
+file(GLOB TESTS test_*.sh)
+
+file(COPY functions.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+foreach(TEST ${TESTS})
+  file(COPY ${TEST} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+  add_test(NAME ${TEST}
+           COMMAND ${TEST}
+           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endforeach()
+
+add_definitions("-D_U_=__attribute__((unused))")

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,0 +1,16 @@
+list(APPEND CORE_LIBRARIES ${SOCKET_LIBRARY})
+
+set(SOURCES nfs-cat
+            nfs-ls)
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+  list(APPEND SOURCES nfs-cp)
+endif()
+
+foreach(TARGET ${SOURCES})
+  add_executable(${TARGET} ${TARGET}.c)
+  target_link_libraries(${TARGET} ${CORE_LIBRARIES})
+  add_dependencies(${TARGET} nfs)
+endforeach()
+
+add_definitions("-D_U_=__attribute__((unused))")

--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES win32_compat.c)
+set(HEADERS win32_compat.h
+            win32_errnowrapper.h)
+
+core_add_library(win32)


### PR DESCRIPTION
I've added cmake build system support. I hope you find this useful. I took this on to help some of the other Team Kodi windows guys as windows does not support autotools but does support cmake.

I've only tested this on linux (needs testing on windows, osx, solaris, and whatever aros is)

It contains all the functionality (plus more) that autotools did.

You can now use the following build options
```
BUILD_SHARED_LIBS
ENABLE_DOCUMENTATION
ENABLE_EXAMPLES
ENABLE_TESTS
ENABLE_UTILS
```

I did not add support for the `compile_rpc` part as I don't quite understand what it is for and when it is called but it seems fine without it. It should be trivial to add when I know what it is for though.

Also, this installs the following libraries
```
libnfs.so -> libnfs.so.11.0.0
libnfs.so.11.0.0 -> libnfs.so.2.0.0
libnfs.so.2.0.0
```
compared to the old autotools
```
libnfs.so -> libnfs.so.11.0.0
libnfs.so.11 -> libnfs.so.11.0.0
libnfs.so.11.0.0
```
Let me know if this is ok otherwise I will change it.

You can build as follows

```
mkdir -p build
cd build
cmake -DBUILD_SHARED_LIBS=ON
      -DCMAKE_INSTALL_PREFIX=/usr/local
      -DENABLE_EXAMPLES=ON
      -DENABLE_UTILS=ON
      -DENABLE_TESTS=ON
      -DENABLE_DOCUMENTATION=ON
      ..
make -j9
make test
```

Please let me know if you have any questions or concerns