### PR TITLE
Add a check if S_IRWXG is already defined

### DIFF
--- a/win32/win32_compat.h
+++ b/win32/win32_compat.h
@@ -45,6 +45,7 @@ typedef int socklen_t;
 #define S_IWUSR 0000200
 #define S_IXUSR 0000100
 #endif
+#ifndef S_IRWXG
 #define	S_IRWXG	0000070			/* RWX mask for group */
 #define S_IRGRP 0000040
 #define S_IWGRP 0000020
@@ -53,6 +54,7 @@ typedef int socklen_t;
 #define S_IROTH 0000004
 #define S_IWOTH 0000002
 #define S_IXOTH 0000001
+#endif
 
 #define F_GETFL  3
 #define F_SETFL  4


### PR DESCRIPTION
msys2 mingw-w64 added the defines for S_IRWXG, S_IRGRP, etc. in sys/stat.h in commit f713f639f6f017371c5176f4deab07d1a92473b4[1]. This commit adds a check to prevent these macros to be redefined.

1) https://github.com/msys2-contrib/mingw-w64/blame/f713f639f6f017371c5176f4deab07d1a92473b4/mingw-w64-headers/crt/sys/stat.h#L158
