### PR TITLE
set rpc_queue tails to NULL after removing last item in rpc_timeout_scan

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -396,6 +396,9 @@ rpc_timeout_scan(struct rpc_context *rpc)
 			continue;
 		}
 		LIBNFS_LIST_REMOVE(&rpc->outqueue.head, pdu);
+		if (!rpc->outqueue.head) {
+			rpc->outqueue.tail = NULL;
+		}
 		rpc_set_error(rpc, "command timed out");
 		pdu->cb(rpc, RPC_STATUS_TIMEOUT,
 			NULL, pdu->private_data);
@@ -416,6 +419,9 @@ rpc_timeout_scan(struct rpc_context *rpc)
 				continue;
 			}
 			LIBNFS_LIST_REMOVE(&q->head, pdu);
+			if (!q->head) {
+				q->tail = NULL;
+			}
 			rpc_set_error(rpc, "command timed out");
 			pdu->cb(rpc, RPC_STATUS_TIMEOUT,
 				NULL, pdu->private_data);


### PR DESCRIPTION
rpc_timeout_scan uses the LIBNFS_LIST_REMOVE macro to remove items from rpc_queues, but doesn't set the queue.tail to NULL if every item in the queue was removed.