### PR TITLE
examples/ld_nfs.c improvements

### DIFF
--- a/README
+++ b/README
@@ -151,6 +151,11 @@ LD_NFS_DEBUG=9 LD_PRELOAD=./ld_nfs.so cat nfs://127.0.0.1/data/tmp/foo123
 
 LD_NFS_DEBUG=9 LD_PRELOAD=./ld_nfs.so cp nfs://127.0.0.1/data/tmp/foo123 nfs://127.0.0.1/data/tmp/foo123.copy
 
+LD_NFS_UID and LD_NFS_GID can be used to fake the uid andthe gid in the nfs context.
+This can be useful on "insecure" enabled NFS share to make the server trust you as a root.
+You can try to run as a normal user things like :
+LD_NFS_DEBUG=9 LD_NFS_UID=0 LD_NFS_GID=0 LD_PRELOAD=./ld_nfs.so chown root:root nfs://127.0.0.1/data/tmp/foo123
+
 This is just a toy preload module. Don't open bugs if it does not work. Send
 patches to make it better instead.
 

--- a/examples/ld_nfs.c
+++ b/examples/ld_nfs.c
@@ -34,6 +34,8 @@
 #define NFS_MAX_FD  255
 
 static int debug = 0;
+static int nfsuid = -1;
+static int nfsgid = -1;
 
 #ifndef discard_const
 #define discard_const(ptr) ((void *)((intptr_t)(ptr)))
@@ -78,6 +80,11 @@ int open(const char *path, int flags, mode_t mode)
 			errno = ENOMEM;
 			return -1;
 		}
+
+		if (nfsuid >= 0)
+			nfs_set_uid(nfs, nfsuid);
+		if (nfsgid >= 0)
+			nfs_set_gid(nfs, nfsgid);
 
 		url = nfs_parse_url_full(nfs, path);
 		if (url == NULL) {
@@ -673,6 +680,14 @@ static void __attribute__((constructor)) _init(void)
 
 	if (getenv("LD_NFS_DEBUG") != NULL) {
 		debug = atoi(getenv("LD_NFS_DEBUG"));
+	}
+
+	if (getenv("LD_NFS_UID") != NULL) {
+		nfsuid = atoi(getenv("LD_NFS_UID"));
+	}
+
+	if (getenv("LD_NFS_GID") != NULL) {
+		nfsgid = atoi(getenv("LD_NFS_GID"));
 	}
 
 	real_open = dlsym(RTLD_NEXT, "open");

--- a/examples/ld_nfs.c
+++ b/examples/ld_nfs.c
@@ -442,11 +442,8 @@ int __fxstat(int ver, int fd, struct stat *buf)
 		buf->st_blksize = st64.nfs_blksize;
 		buf->st_blocks  = st64.nfs_blocks;
 		buf->st_atim.tv_sec   = st64.nfs_atime;
-		buf->st_atim.tv_usec  = st64.nfs_atime_nsec / 1000;
 		buf->st_mtim.tv_sec   = st64.nfs_mtime;
-		buf->st_mtim.tv_usec  = st64.nfs_mtime_nsec / 1000;
 		buf->st_ctim.tv_sec   = st64.nfs_ctime;
-		buf->st_ctim.tv_usec  = st64.nfs_ctime_nsec / 1000;
 
 		LD_NFS_DPRINTF(9, "__fxstat(%d) success", fd);
 		return ret;
@@ -481,11 +478,8 @@ int __fxstat64(int ver, int fd, struct stat64 *buf)
 		buf->st_blksize = st64.nfs_blksize;
 		buf->st_blocks  = st64.nfs_blocks;
 		buf->st_atim.tv_sec   = st64.nfs_atime;
-		buf->st_atim.tv_usec  = st64.nfs_atime_nsec / 1000;
 		buf->st_mtim.tv_sec   = st64.nfs_mtime;
-		buf->st_mtim.tv_usec  = st64.nfs_mtime_nsec / 1000;
 		buf->st_ctim.tv_sec   = st64.nfs_ctime;
-		buf->st_ctim.tv_usec  = st64.nfs_ctime_nsec / 1000;
 
 		LD_NFS_DPRINTF(9, "__fxstat64(%d) success", fd);
 		return ret;


### PR DESCRIPTION
I did few improvements for my personal needs in examples/ld_nfs.c that may be useful to someone else :
- Fixing compilation bug caused by usec not anymore present in stat_t.
- Adding other hooks to fix support for chmod and to add support for chown.
- Add support for faking uid and gid in the nfs context.