### PR TITLE
Define F_RDLCK for windows builds

### DIFF
--- a/win32/win32_compat.h
+++ b/win32/win32_compat.h
@@ -63,6 +63,12 @@ typedef int socklen_t;
 #define S_IFLNK        0xA000  /* Link */
 #endif
 
+#ifndef F_RDLCK
+#define F_RDLCK 0
+#define F_WRLCK 1
+#define F_UNLCK 2
+#endif
+
 #ifndef S_IFIFO
 #define S_IFIFO        0x1000  /* FIFO */
 #endif


### PR DESCRIPTION
The current libnfs master branch didn't build anymore with mingw+msys since commit "50068b84329fe6e9b8c972fcc22c0c1886775b4b NFSv4: add support for fcntl locking", because F_RDLCK isn't defined in that build environment. This commit defines F_RDLCK if it's not already defined.
