### PR TITLE
status variable for the callback function is error

### DIFF
--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -580,7 +580,7 @@ rpc_connect_program_4_cb(struct rpc_context *rpc, int status,
 
         if (rpc_null_async(rpc, data->program, data->version,
                            rpc_connect_program_5_cb, data) != 0) {
-                data->cb(rpc, status, command_data, data->private_data);
+                data->cb(rpc, RPC_STATUS_ERROR, command_data, data->private_data);
                 free_rpc_cb_data(data);
                 return;
         }
@@ -638,7 +638,7 @@ rpc_connect_program_3_cb(struct rpc_context *rpc, int status,
 	rpc_disconnect(rpc, "normal disconnect");
 	if (rpc_connect_async(rpc, data->server, rpc_port,
                               rpc_connect_program_4_cb, data) != 0) {
-		data->cb(rpc, status, command_data, data->private_data);
+		data->cb(rpc, RPC_STATUS_ERROR, command_data, data->private_data);
 		free_rpc_cb_data(data);
 		return;
 	}
@@ -665,7 +665,7 @@ rpc_connect_program_2_cb(struct rpc_context *rpc, int status,
                                             IPPROTO_TCP,
                                             rpc_connect_program_3_cb,
                                             private_data) != 0) {
-			data->cb(rpc, status, command_data, data->private_data);
+			data->cb(rpc, RPC_STATUS_ERROR, command_data, data->private_data);
 			free_rpc_cb_data(data);
 			return;
 		}
@@ -679,7 +679,7 @@ rpc_connect_program_2_cb(struct rpc_context *rpc, int status,
 		if (rpc_pmap3_getaddr_async(rpc, &map,
                                             rpc_connect_program_3_cb,
                                             private_data) != 0) {
-			data->cb(rpc, status, command_data, data->private_data);
+			data->cb(rpc, RPC_STATUS_ERROR, command_data, data->private_data);
 			free_rpc_cb_data(data);
 			return;
 		}
@@ -708,7 +708,7 @@ rpc_connect_program_1_cb(struct rpc_context *rpc, int status,
 	case AF_INET:
 		if (rpc_pmap2_null_async(rpc, rpc_connect_program_2_cb,
                                          data) != 0) {
-			data->cb(rpc, status, command_data, data->private_data);
+			data->cb(rpc, RPC_STATUS_ERROR, command_data, data->private_data);
 			free_rpc_cb_data(data);
 			return;
 		}
@@ -716,7 +716,7 @@ rpc_connect_program_1_cb(struct rpc_context *rpc, int status,
 	case AF_INET6:
 		if (rpc_pmap3_null_async(rpc, rpc_connect_program_2_cb,
                                          data) != 0) {
-			data->cb(rpc, status, command_data, data->private_data);
+			data->cb(rpc, RPC_STATUS_ERROR, command_data, data->private_data);
 			free_rpc_cb_data(data);
 			return;
 		}


### PR DESCRIPTION
When a function fails, its status for the callback function should be passed RPC_STATUS_ERROR,because the original status variable is RPC_STATUS_SUCCESS.

Signed-off-by: cosmoer <cosmoer@qq.com>