### PR TITLE
The check for getpwnam wrongly succeeded on some systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,7 +82,10 @@ else
 fi
 
 AC_MSG_CHECKING(whether getpwnam() is available)
-AC_TRY_COMPILE([#include <sys/types.h>, #include <pwd.h>], [
+AC_TRY_COMPILE([
+	#include <sys/types.h>
+	#include <pwd.h>
+], [
         struct passwd *pwd = getpwnam("nobody");
 ], ac_cv_have_getpwnam=yes, ac_cv_have_getpwnam=no)
 if test "$ac_cv_have_getpwnam" = yes ; then

--- a/lib/nfs_v4.c
+++ b/lib/nfs_v4.c
@@ -423,6 +423,8 @@ nfs_get_ugid(struct nfs_context *nfs, const char *buf, int slen, int is_user)
                                         return pwd->pw_gid;
                                 }
                         }
+#else
+			(void) name; // Let the compiler know that this variable is intentionally unused, build would fail with -Werror=unused-variable otherwise
 #endif
                         return 65534;
                 }


### PR DESCRIPTION
It didn't fail if pwd.h is missing because #includes must be seperated with a newline, a comma won't work.
The compile works anyway because the "struct passwd *pwd" implicitly declares an anonymus struct type "passwd"
and using an undeclared function is an implicit function declaration. Here's the output of configure in that case:
```
configure:13381: checking whether getpwnam() is available
configure:13396: i686-w64-mingw32-gcc -c -I/home/daniel/fsetmp/dokany/src/dokan_fuse/include/  -I/home/daniel/fsetmp/dokany/src/dokan_fuse/include/  conftest.c >&5
conftest.c:23:23: warning: extra tokens at end of #include directive
 #include <sys/types.h>, #include <pwd.h>
                       ^
conftest.c: In function 'main':
conftest.c:28:30: warning: implicit declaration of function 'getpwnam' [-Wimplicit-function-declaration]
         struct passwd *pwd = getpwnam("nobody");
                              ^~~~~~~~
conftest.c:28:30: warning: initialization makes pointer from integer without a cast [-Wint-conversion]
configure:13396: $? = 0
configure:13403: result: yes
```