### PR TITLE
nfs_opendir_cb should not queue a READDIR on error

### DIFF
--- a/lib/nfs_v3.c
+++ b/lib/nfs_v3.c
@@ -2714,8 +2714,14 @@ nfs3_opendir_cb(struct rpc_context *rpc, int status, void *command_data,
 
 	assert(rpc->magic == RPC_CONTEXT_MAGIC);
 
-	if (status == RPC_STATUS_ERROR ||
-	    (status == RPC_STATUS_SUCCESS && res->status == NFS3ERR_NOTSUPP)) {
+    if (check_nfs3_error(nfs, status, data, command_data)) {
+		nfs_free_nfsdir(nfsdir);
+		data->continue_data = NULL;
+		free_nfs_cb_data(data);
+		return;
+	}
+
+	if (status == RPC_STATUS_SUCCESS && res->status == NFS3ERR_NOTSUPP) {
 		READDIR3args args;
 
 		args.dir.data.data_len = data->fh.len;
@@ -2735,15 +2741,6 @@ nfs3_opendir_cb(struct rpc_context *rpc, int status, void *command_data,
 			free_nfs_cb_data(data);
 			return;
 		}
-		return;
-	}
-
-	if (status == RPC_STATUS_CANCEL) {
-		data->cb(-EINTR, nfs, "Command was cancelled",
-                         data->private_data);
-		nfs_free_nfsdir(nfsdir);
-		data->continue_data = NULL;
-		free_nfs_cb_data(data);
 		return;
 	}
 


### PR DESCRIPTION
Explanation of the bug:
- nfs_opendir_cb() queues a READDIR when it receives RPC_STATUS_ERROR.
- rpc_purge_all_pdus() explicitly says that no further pdus should be
  queued when rpc_purge_all_pdus() is invoked and the outqueue is being
  cleared.
- Since nfs_opendir_cb() is called in rpc_purge_all_pdus() with
  status=RPC_STATUS_ERROR, this invariant is broken.

Fix:
- Invoke check_nfs3_error() which will invoke the appropriate
  callback with the right error.
- Disallow queueing a request in the if block