### PR TITLE
Add & export a call to initialize the pagecache

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -279,6 +279,12 @@ EXTERN void nfs_pagecache_invalidate(struct nfs_context *nfs,
                                      struct nfsfh *nfsfh);
 
 /*
+ * Initialize the pagecache
+ */
+EXTERN  void nfs_pagecache_init(struct nfs_context *nfs,
+                                struct nfsfh *nfsfh);
+
+/*
  * MOUNT THE EXPORT
  */
 /*

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -199,6 +199,18 @@ nfs_pagecache_get(struct nfs_pagecache *pagecache, uint64_t offset)
 	return e->buf;
 }
 
+void nfs_pagecache_init(struct nfs_context *nfs, struct nfsfh *nfsfh) {
+	/* init page cache */
+	if (nfs->rpc->pagecache) {
+		nfsfh->pagecache.num_entries = nfs->rpc->pagecache;
+		nfsfh->pagecache.ttl = nfs->rpc->pagecache_ttl;
+		nfsfh->pagecache.entries = malloc(sizeof(struct nfs_pagecache_entry) * nfsfh->pagecache.num_entries);
+		nfs_pagecache_invalidate(nfs, nfsfh);
+		RPC_LOG(nfs->rpc, 2, "init pagecache entries %d pagesize %d\n",
+                        nfsfh->pagecache.num_entries, NFS_BLKSIZE);
+	}
+}
+
 void
 nfs_set_auth(struct nfs_context *nfs, struct AUTH *auth)
 {

--- a/lib/nfs_v3.c
+++ b/lib/nfs_v3.c
@@ -4917,19 +4917,12 @@ nfs3_open_cb(struct rpc_context *rpc, int status, void *command_data,
 		nfsfh->is_append = 1;
 	}
 
+    /* init the pagecache */
+    nfs_pagecache_init(nfs, nfsfh);
+
 	/* steal the filehandle */
 	nfsfh->fh = data->fh;
 	data->fh.val = NULL;
-
-	/* init page cache */
-	if (rpc->pagecache) {
-		nfsfh->pagecache.num_entries = rpc->pagecache;
-		nfsfh->pagecache.ttl = rpc->pagecache_ttl;
-		nfsfh->pagecache.entries = malloc(sizeof(struct nfs_pagecache_entry) * nfsfh->pagecache.num_entries);
-		nfs_pagecache_invalidate(nfs, nfsfh);
-		RPC_LOG(nfs->rpc, 2, "init pagecache entries %d pagesize %d\n",
-                        nfsfh->pagecache.num_entries, NFS_BLKSIZE);
-	}
 
 	data->cb(0, nfs, nfsfh, data->private_data);
 	free_nfs_cb_data(data);


### PR DESCRIPTION
For filehandles that are managed outside of the libnfs "high-level" API (i.e., if we don't use nfs3_open()), sometimes we want to initialize the pagecache manually.