### PR TITLE
Define MSG_NOSIGNAL in windows if it doesn't exist

### DIFF
--- a/include/win32/win32_compat.h
+++ b/include/win32/win32_compat.h
@@ -56,6 +56,10 @@ typedef int socklen_t;
 #define S_IXOTH 0000001
 #endif
 
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
 #define F_GETFL  3
 #define F_SETFL  4
 


### PR DESCRIPTION
Windows doesn't have signals like SIGPIPE, so defining the flag as 0 if it doesn't exist is probably fine there. MSG_NOSIGNAL was first used in commit e8a200483f54f29eb3cd3311335c35df9fd755a4.  