### PR TITLE
cmake: add include headers to libnfs

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES init.c
 
 add_library(nfs ${SOURCES})
 target_link_libraries(nfs PUBLIC ${core_DEPENDS})
+target_include_directories(nfs PUBLIC ../include)
 set_target_properties(nfs PROPERTIES
                           VERSION ${PROJECT_VERSION}
                           SOVERSION ${SOVERSION})


### PR DESCRIPTION
This change adds the main include dir to the include directories for
cmake such that when integrating libnfs with another project, this dir
is added to the include list.