### PR TITLE
Wrap use of SOCK_CLOEXEC with __linux__

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -93,12 +93,14 @@ static int
 create_socket(int domain, int type, int protocol)
 {
 #ifdef SOCK_CLOEXEC
-	/* Linux-specific extension (since 2.6.27): set the
+#ifdef __linux__
+    /* Linux-specific extension (since 2.6.27): set the
 	   close-on-exec flag on all sockets to avoid leaking file
 	   descriptors to child processes */
 	int fd = socket(domain, type|SOCK_CLOEXEC, protocol);
 	if (fd >= 0 || errno != EINVAL)
 		return fd;
+#endif
 #endif
 
 	return socket(domain, type, protocol);


### PR DESCRIPTION
This guards against the case where your clibrary defines SOCK_CLOEXEC
but the underlying network library does not support it.

I'm not sure this is the ideal solution, for context: I'm trying to use libnfs in an embedded context with musl libc and picotcp. Musl libc defines SOCK_CLOEXEC, but picotcp does not support the option. 