### PR TITLE
configure.ac: fix --enable-utils

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,11 +25,13 @@ fi
 AC_SYS_LARGEFILE
 
 #option: utils
+MAYBE_UTILS="utils"
 AC_ARG_ENABLE([utils],
               [AC_HELP_STRING([--enable-utils],
                               [Build util programs])],
-	      [MAYBE_UTILS=""],
-	      [MAYBE_UTILS="utils"])
+	      [if test $enableval = no ; then
+	    	    MAYBE_UTILS=""
+	       fi])
 AC_SUBST(MAYBE_UTILS)
 
 #option: examples


### PR DESCRIPTION
Running "configure --enable-utils" _disables_ compilation/installation of
utils (and vice versa) while omitting the --(en|dis)able-utils option auto-
enables utils.
This patch fixes the logic when the option is given on command line but
keeps utils build enabled when the option was omitted.