### PR TITLE
libnfs.c: include <time.h> in libnfs.c

### DIFF
--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -74,6 +74,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include "slist.h"
 #include "libnfs.h"
 #include "libnfs-raw.h"


### PR DESCRIPTION
time() is used in this file, which is from time.h. Fixes a warning.