### PR TITLE
fix for dup2 on windows

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -591,11 +591,18 @@ rpc_connect_sockaddr_async(struct rpc_context *rpc)
 	}
 
 	if (rpc->old_fd) {
+#if !defined(WIN32)
 		if (dup2(rpc->fd, rpc->old_fd) == -1) {
 			return -1;
 		}
 		close(rpc->fd);
 		rpc->fd = rpc->old_fd;
+#else
+		/* On Windows dup2 does not work on sockets
+		 * instead just close the old socket */
+		close(rpc->old_fd);
+		rpc->old_fd = 0;
+#endif
 	}
 
 	/* Some systems allow you to set capabilities on an executable


### PR DESCRIPTION
dup2 doesn't work with sockets on windows.  It seems like we can just close out the old socket and start using the newly connected one instead.