### PR TITLE
Avoid redefinition of EXTERN macro

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -53,7 +53,9 @@ struct nfs_url {
 #if defined(WIN32)
 #define EXTERN __declspec( dllexport )
 #else
+#ifndef EXTERN
 #define EXTERN
+#endif
 #endif
 
 #ifdef WIN32


### PR DESCRIPTION
If an EXTERN macro is present then use it. Assume that the person defining EXTERN knows what they need on Linux et al.  Avoids redefinition warning nags in compiles.