### PR TITLE
fixing cmake build on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ set(SYSTEM_LIBRARIES "")
 # list of core (static) libraries built in current configuration (used by lib/CMakeLists.txt)
 set(CORE_LIBRARIES "" CACHE INTERNAL "")
 
+# make sure related functions are exported in final dll
+if(WIN32 AND BUILD_SHARED_LIBS)
+  add_definitions(-Dlibnfs_EXPORTS)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   add_definitions("-D_U_=" -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
   list(APPEND SYSTEM_LIBRARIES ws2_32)
@@ -58,7 +63,7 @@ add_subdirectory(nlm)
 add_subdirectory(nsm)
 add_subdirectory(portmap)
 add_subdirectory(rquota)
-add_subdirectory(lib)
+add_subdirectory(lib)   # this has to be last (it links all static libs mentioned in CORE_LIBRARIES)
 
 if(ENABLE_DOCUMENTATION)
   add_subdirectory(doc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL aros)
   add_definitions("-D_U_=__attribute__((unused))")
   add_definitions(-DAROS)
   add_subdirectory(aros)
+else()
+  add_definitions("-D_U_=__attribute__((unused))")
 endif()
 
 add_subdirectory(mount)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.2)
 
 project(libnfs
         LANGUAGES C
-        VERSION 2.0.0)
+        VERSION 4.0.0)
 
 set(SOVERSION 11.0.0 CACHE STRING "" FORCE)
 
@@ -29,20 +29,34 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}
                     include
                     include/nfsc)
 
-set(CORE_LIBRARIES nfs)
-set(core_DEPENDS "" CACHE STRING "" FORCE)
+# list of system libs (sockets/etc) to be linked on this system
+set(SYSTEM_LIBRARIES "")
+# list of core (static) libraries built in current configuration (used by lib/CMakeLists.txt)
+set(CORE_LIBRARIES "" CACHE INTERNAL "")
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-  list(APPEND CORE_LIBRARIES -lws2_32.lib)
+  add_definitions("-D_U_=" -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
+  list(APPEND SYSTEM_LIBRARIES ws2_32)
   add_subdirectory(win32)
 elseif(CMAKE_SYSTEM_NAME STREQUAL Solaris)
+  add_definitions("-D_U_=__attribute__((unused))")
   find_library(SOCKET_LIBRARY socket)
   find_library(NSL_LIBRARY nsl)
-  list(APPEND CORE_LIBRARIES ${SOCKET_LIBRARY} ${NSL_LIBRARY})
+  list(APPEND SYSTEM_LIBRARIES ${SOCKET_LIBRARY} ${NSL_LIBRARY})
 elseif(CMAKE_SYSTEM_NAME STREQUAL aros)
+  add_definitions("-D_U_=__attribute__((unused))")
   add_definitions(-DAROS)
   add_subdirectory(aros)
 endif()
+
+add_subdirectory(mount)
+add_subdirectory(nfs)
+add_subdirectory(nfs4)
+add_subdirectory(nlm)
+add_subdirectory(nsm)
+add_subdirectory(portmap)
+add_subdirectory(rquota)
+add_subdirectory(lib)
 
 if(ENABLE_DOCUMENTATION)
   add_subdirectory(doc)
@@ -60,15 +74,6 @@ endif()
 if(ENABLE_UTILS)
   add_subdirectory(utils)
 endif()
-
-add_subdirectory(mount)
-add_subdirectory(nfs)
-add_subdirectory(nfs4)
-add_subdirectory(nlm)
-add_subdirectory(nsm)
-add_subdirectory(portmap)
-add_subdirectory(rquota)
-add_subdirectory(lib)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/libnfs-config-version.cmake

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -5,11 +5,11 @@
 #   SOURCES the sources of the library
 #   HEADERS the headers of the library (only for IDE support)
 # On return:
-#   Library will be built and added to ${core_DEPENDS}
+#   Library will be built and added to ${CORE_LIBRARIES}
 function(core_add_library name)
   set(name core_${name})
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   add_library(${name} STATIC ${SOURCES} ${HEADERS})
   target_include_directories(${name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-  set(core_DEPENDS ${name} ${core_DEPENDS} CACHE STRING "" FORCE)
+  set(CORE_LIBRARIES "${name};${CORE_LIBRARIES}" CACHE INTERNAL "")
 endfunction()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,11 +1,10 @@
 find_library(TALLOC_LIBRARY talloc)
 find_library(TALLOC_EVENT_LIBRARY tevent)
 find_library(EVENT_LIBARY event)
-find_library(POPT_LIBRARY popt)
 
-list(APPEND CORE_LIBRARIES ${POPT_LIBRARY})
+set(EXTRA_LIBRARIES "")
 
-set(SOURCES nfsclient-async
+set(EXAMPLES nfsclient-async
             nfsclient-raw
             nfsclient-sync
             nfsclient-bcast
@@ -15,20 +14,17 @@ set(SOURCES nfsclient-async
             portmap-client)
 
 if(HAVE_TALLOC_TEVENT)
-  list(APPEND SOURCES nfs4-cat-talloc)
-  list(APPEND CORE_LIBRARIES ${TALLOC_EVENT_LIBRARY} ${TALLOC_LIBRARY})
+  list(APPEND EXAMPLES nfs4-cat-talloc)
+  list(APPEND EXTRA_LIBRARIES ${TALLOC_EVENT_LIBRARY} ${TALLOC_LIBRARY})
 endif()
 
 if(EVENT_LIBARY)
-  list(APPEND SOURCES nfs4-cat
-                      portmap-server)
-  list(APPEND CORE_LIBRARIES ${EVENT_LIBARY})
+  list(APPEND EXAMPLES nfs4-cat
+                       portmap-server)
+  list(APPEND EXTRA_LIBRARIES ${EVENT_LIBARY})
 endif()
 
-foreach(TARGET ${SOURCES})
+foreach(TARGET ${EXAMPLES})
   add_executable(${TARGET} ${TARGET}.c)
-  target_link_libraries(${TARGET} ${CORE_LIBRARIES})
-  add_dependencies(${TARGET} nfs)
+  target_link_libraries(${TARGET} nfs ${EXTRA_LIBRARIES})
 endforeach()
-
-add_definitions("-D_U_=__attribute__((unused))")

--- a/examples/portmap-client.c
+++ b/examples/portmap-client.c
@@ -36,11 +36,24 @@ WSADATA wsaData;
 #include <netinet/in.h>
 #endif
 
+#ifdef HAVE_NETDB_H
 #include <netdb.h>
+#endif
+
 #include <stdio.h>
+
+#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
+#endif
+
+#ifdef HAVE_STRING_H
 #include <string.h>
+#endif
+
+#ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
+#endif
+
 #include <time.h>
 #include "libnfs.h"
 #include "libnfs-raw.h"

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -52,7 +52,7 @@ struct nfs_url {
 	char *file;
 };
 
-#if defined(WIN32) && defined(nfs_EXPORTS)
+#if defined(WIN32) && defined(libnfs_EXPORTS)
 #define EXTERN __declspec( dllexport )
 #else
 #ifndef EXTERN

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -52,7 +52,7 @@ struct nfs_url {
 	char *file;
 };
 
-#if defined(WIN32)
+#if defined(WIN32) && defined(nfs_EXPORTS)
 #define EXTERN __declspec( dllexport )
 #else
 #ifndef EXTERN

--- a/include/win32/win32_compat.h
+++ b/include/win32/win32_compat.h
@@ -133,7 +133,7 @@ struct pollfd {
 
 /* Wrapper macros to call misc. functions win32 is missing */
 #define poll(x, y, z)        win32_poll(x, y, z)
-#define snprintf             sprintf_s
+//#define snprintf             sprintf_s
 #define inet_pton(x,y,z)     win32_inet_pton(x,y,z)
 #define open(x, y, z)        _open(x, y, z)
 #ifndef lseek

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,12 +1,20 @@
-add_library(nfs init.c
-                libnfs.c
-                libnfs-sync.c
-                libnfs-zdr.c
-                nfs_v3.c
-                nfs_v4.c
-                pdu.c
-                socket.c)
+set(SOURCES init.c
+            libnfs.c
+            libnfs-sync.c
+            libnfs-zdr.c
+            nfs_v3.c
+            nfs_v4.c
+            pdu.c
+            socket.c
+)
 
+# deal with version info in "dll" case
+if(WIN32 AND BUILD_SHARED_LIBS)
+  configure_file(../win32/version.rc.template version.rc @ONLY)
+  list(APPEND SOURCES ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+endif()
+
+add_library(nfs ${SOURCES})
 target_include_directories(nfs PUBLIC ../include)
 target_link_libraries(nfs PUBLIC ${CORE_LIBRARIES} ${SYSTEM_LIBRARIES})
 set_target_properties(nfs PROPERTIES

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,20 +1,17 @@
-set(SOURCES init.c
-            libnfs.c
-            libnfs-sync.c
-            libnfs-zdr.c
-            nfs_v3.c
-            nfs_v4.c
-            pdu.c
-            socket.c)
+add_library(nfs init.c
+                libnfs.c
+                libnfs-sync.c
+                libnfs-zdr.c
+                nfs_v3.c
+                nfs_v4.c
+                pdu.c
+                socket.c)
 
-add_library(nfs ${SOURCES})
-target_link_libraries(nfs PUBLIC ${core_DEPENDS})
 target_include_directories(nfs PUBLIC ../include)
+target_link_libraries(nfs PUBLIC ${CORE_LIBRARIES} ${SYSTEM_LIBRARIES})
 set_target_properties(nfs PROPERTIES
                           VERSION ${PROJECT_VERSION}
                           SOVERSION ${SOVERSION})
-add_dependencies(nfs ${core_DEPENDS})
-add_definitions("-D_U_=__attribute__((unused))")
 
 install(TARGETS nfs EXPORT nfs
                     RUNTIME DESTINATION bin

--- a/lib/init.c
+++ b/lib/init.c
@@ -83,7 +83,7 @@ struct rpc_context *rpc_init_context(void)
 	}
 	// Add PID to rpc->xid for easier debugging, making sure to cast
 	// pid to 32-bit type to avoid invalid left-shifts.
-	rpc->xid = salt + rpc_current_time() + ((uint32_t)getpid() << 16);
+	rpc->xid = salt + (uint32_t)rpc_current_time() + ((uint32_t)getpid() << 16);
 	salt += 0x01000000;
 	rpc->fd = -1;
 	rpc->tcp_syncnt = RPC_PARAM_UNDEFINED;

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -889,7 +889,7 @@ int
 nfs_normalize_path(struct nfs_context *nfs, char *path)
 {
 	char *str;
-	int len;
+	size_t len;
 
 	/* // -> / */
 	while ((str = strstr(path, "//"))) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,45 +1,43 @@
 find_library(DL_LIBRARY dl)
 
-set(SOURCES prog_access
-            prog_access2
-            prog_chmod
-            prog_chown
-            prog_create
-            prog_fchmod
-            prog_fchown
-            prog_fstat
-            prog_ftruncate
-            prog_lchmod
-            prog_lchown
-            prog_link
-            prog_lseek
-            prog_lstat
-            prog_mkdir
-            prog_mknod
-            prog_mount
-            prog_open_read
-            prog_open_write
-            prog_opendir
-            prog_rename
-            prog_rmdir
-            prog_stat
-            prog_statvfs
-            prog_symlink
-            prog_timeout
-            prog_truncate
-            prog_unlink
-            prog_utimes)
+set(TEST_PROGS prog_access
+               prog_access2
+               prog_chmod
+               prog_chown
+               prog_create
+               prog_fchmod
+               prog_fchown
+               prog_fstat
+               prog_ftruncate
+               prog_lchmod
+               prog_lchown
+               prog_link
+               prog_lseek
+               prog_lstat
+               prog_mkdir
+               prog_mknod
+               prog_mount
+               prog_open_read
+               prog_open_write
+               prog_opendir
+               prog_rename
+               prog_rmdir
+               prog_stat
+               prog_statvfs
+               prog_symlink
+               prog_timeout
+               prog_truncate
+               prog_unlink
+               prog_utimes)
 
-foreach(TARGET ${SOURCES})
+foreach(TARGET ${TEST_PROGS})
   add_executable(${TARGET} ${TARGET}.c)
-  target_link_libraries(${TARGET} ${CORE_LIBRARIES})
-  add_dependencies(${TARGET} nfs)
+  target_link_libraries(${TARGET} nfs)
 endforeach()
 
 add_library(ld_timeout SHARED ld_timeout.c)
 set_target_properties(ld_timeout PROPERTIES PREFIX "")
-target_link_libraries(ld_timeout ${CORE_LIBRARIES} ${DL_LIBRARY})
-add_dependencies(ld_timeout nfs)
+target_link_libraries(ld_timeout nfs ${DL_LIBRARY})
 
 file(GLOB TESTS test_*.sh)
 
@@ -51,5 +49,3 @@ foreach(TEST ${TESTS})
            COMMAND ${TEST}
            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endforeach()
-
-add_definitions("-D_U_=__attribute__((unused))")

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,16 +1,10 @@
-list(APPEND CORE_LIBRARIES ${SOCKET_LIBRARY})
-
-set(SOURCES nfs-cat
-            nfs-ls)
+set(UTILITIES nfs-cat nfs-ls)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
-  list(APPEND SOURCES nfs-cp)
+  list(APPEND UTILITIES nfs-cp)
 endif()
 
-foreach(TARGET ${SOURCES})
+foreach(TARGET ${UTILITIES})
   add_executable(${TARGET} ${TARGET}.c)
-  target_link_libraries(${TARGET} ${CORE_LIBRARIES})
-  add_dependencies(${TARGET} nfs)
+  target_link_libraries(${TARGET} nfs)
 endforeach()
-
-add_definitions("-D_U_=__attribute__((unused))")

--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(SOURCES win32_compat.c)
-set(HEADERS win32_compat.h
+set(HEADERS ../include/win32/win32_compat.h
             win32_errnowrapper.h)
 
 core_add_library(win32)

--- a/win32/version.rc.template
+++ b/win32/version.rc.template
@@ -1,0 +1,54 @@
+#include <winver.h>
+
+#define VER_FILEVERSION             @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,0
+#define VER_FILEVERSION_STR         "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@.0\0"
+
+#define VER_PRODUCTVERSION          @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,0
+#define VER_PRODUCTVERSION_STR      "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@.0\0"
+
+#define VER_PRIVATEBUILD 0
+#define VER_PRERELEASE 0
+
+#ifndef DEBUG
+#define VER_DEBUG                   0
+#else
+#define VER_DEBUG                   VS_FF_DEBUG
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     VER_FILEVERSION
+PRODUCTVERSION  VER_PRODUCTVERSION
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+FILEFLAGS       (VER_PRIVATEBUILD|VER_PRERELEASE|VER_DEBUG)
+FILEOS          VOS__WINDOWS32
+FILETYPE        VFT_DLL
+FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4"
+        BEGIN
+            VALUE "CompanyName",      "https://github.com/sahlberg/libnfs"
+            VALUE "FileDescription",  "LIBNFS is a client library for accessing NFS shares over a network."
+            VALUE "FileVersion",      VER_FILEVERSION_STR
+            VALUE "InternalName",     "libnfs.dll"
+            VALUE "LegalCopyright",   "Copyright (C) 2019"
+            VALUE "OriginalFilename", "libnfs.dll"
+            VALUE "ProductName",      "libnfs"
+            VALUE "ProductVersion",   VER_PRODUCTVERSION_STR
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        /* The following line should only be modified for localized versions.     */
+        /* It consists of any number of WORD,WORD pairs, with each pair           */
+        /* describing a language,codepage combination supported by the file.      */
+        /*                                                                        */
+        /* For example, a file might have values "0x409,1252" indicating that it  */
+        /* supports English language (0x409) in the Windows ANSI codepage (1252). */
+
+        VALUE "Translation", 0x409, 1252
+
+    END
+END

--- a/win32/win32_compat.c
+++ b/win32/win32_compat.c
@@ -132,7 +132,7 @@ int win32_poll(struct pollfd *fds, unsigned int nfds, int timo)
   {
     for (i = 0; i < nfds; ++i) 
     {
-      int fd = fds[i].fd;
+      SOCKET fd = fds[i].fd;
       if(fds[i].events & (POLLIN|POLLPRI) && FD_ISSET(fd, &ifds))
         fds[i].revents |= POLLIN;
       if(fds[i].events & POLLOUT && FD_ISSET(fd, &ofds))

--- a/win32/win32_compat.c
+++ b/win32/win32_compat.c
@@ -50,7 +50,7 @@ int win32_inet_pton(int af, const char * src, void * dst)
   struct sockaddr_in sa;
   int len = sizeof(SOCKADDR);
   int ret = -1;
-  int strLen = strlen(src) + 1;
+  size_t strLen = strlen(src) + 1;
 #ifdef UNICODE
   wchar_t *srcNonConst = (wchar_t *)malloc(strLen*sizeof(wchar_t));
   memset(srcNonConst, 0, strLen);


### PR DESCRIPTION
I've got cmake build to work on Windows x64. Notes:
- tidied up cmake files a bit
- fixed one problem where `SOCKET` was truncated to `int`; there is another one (see what happens to handle returned by `create_socket()`), but it has to be fixed another time
- there are other warnings that need to be addressed at some point, but they seem to be minor
- dll version info is generated properly
- with this change it is trivial to add `libnfs` to [vcpkg](https://github.com/microsoft/vcpkg). See [libnfs.zip](https://github.com/sahlberg/libnfs/files/3611252/libnfs.zip)
