### PR TITLE
fix for find_package from downstream clients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,14 +82,35 @@ if(ENABLE_UTILS)
   add_subdirectory(utils)
 endif()
 
+# this will create build-tree-specific config file (so downstream client can use this specific build without having to install package)
+export(EXPORT libnfs
+       NAMESPACE libnfs::
+       FILE "${CMAKE_CURRENT_BINARY_DIR}/libnfs-config.cmake")
+
+# this will create relocatable config file in installation directory
+install(EXPORT libnfs
+        DESTINATION "${INSTALL_CMAKE_DIR}"
+        NAMESPACE libnfs::
+        FILE libnfs-config.cmake)
+
+# handle version file
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/libnfs-config-version.cmake
                                  VERSION ${PROJECT_VERSION}
                                  COMPATIBILITY AnyNewerVersion)
 
+install(FILES cmake/FindNFS.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/libnfs-config-version.cmake
+        DESTINATION ${INSTALL_CMAKE_DIR})
+
+# handle pc-config files
 configure_file(cmake/libnfs.pc.cmake
                ${CMAKE_CURRENT_BINARY_DIR}/libnfs.pc @ONLY)
 
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libnfs.pc
+        DESTINATION ${INSTALL_PKGCONFIG_DIR})
+
+# handle headers installation
 install(DIRECTORY include/nfsc
         DESTINATION ${INSTALL_INC_DIR})
 
@@ -100,10 +121,3 @@ install(FILES mount/libnfs-raw-mount.h
               portmap/libnfs-raw-portmap.h
               rquota/libnfs-raw-rquota.h
         DESTINATION ${INSTALL_INC_DIR}/nfsc)
-
-install(FILES cmake/FindNFS.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/libnfs-config-version.cmake
-        DESTINATION ${INSTALL_CMAKE_DIR})
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libnfs.pc
-        DESTINATION ${INSTALL_PKGCONFIG_DIR})

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -7,9 +7,17 @@
 # On return:
 #   Library will be built and added to ${CORE_LIBRARIES}
 function(core_add_library name)
-  set(name core_${name})
+  set(name nfs_${name})
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   add_library(${name} STATIC ${SOURCES} ${HEADERS})
-  target_include_directories(${name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+  target_include_directories(${name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
   set(CORE_LIBRARIES "${name};${CORE_LIBRARIES}" CACHE INTERNAL "")
+
+  # no need to install core libs if we build shared library
+  if(NOT BUILD_SHARED_LIBS)
+    install(TARGETS ${name} EXPORT libnfs
+            RUNTIME DESTINATION bin
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib)
+  endif()
 endfunction()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,13 +15,12 @@ if(WIN32 AND BUILD_SHARED_LIBS)
 endif()
 
 add_library(nfs ${SOURCES})
-target_include_directories(nfs PUBLIC ../include)
-target_link_libraries(nfs PUBLIC ${CORE_LIBRARIES} ${SYSTEM_LIBRARIES})
+target_link_libraries(nfs PRIVATE ${CORE_LIBRARIES} PUBLIC ${SYSTEM_LIBRARIES})
 set_target_properties(nfs PROPERTIES
                           VERSION ${PROJECT_VERSION}
                           SOVERSION ${SOVERSION})
 
-install(TARGETS nfs EXPORT nfs
+install(TARGETS nfs EXPORT libnfs
                     RUNTIME DESTINATION bin
                     ARCHIVE DESTINATION lib
                     LIBRARY DESTINATION lib)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -6,5 +6,5 @@ endif()
 
 foreach(TARGET ${UTILITIES})
   add_executable(${TARGET} ${TARGET}.c)
-  target_link_libraries(${TARGET} nfs)
+  target_link_libraries(${TARGET} nfs nfs_mount)
 endforeach()


### PR DESCRIPTION
- now downstream clients can refer to `libnfs` package like this:
```
    find_package(libnfs CONFIG REQUIRED)
    target_link_libraries(<mylib> PRIVATE libnfs::nfs)
```
(tested on Windows/Linux, both shared and static lib builds)

- `FindNFS.cmake` is no longer needed (but I left it just in case)

- updated vcpkg port files are: [vcpkg-port.zip](https://github.com/sahlberg/libnfs/files/3719258/vcpkg-port.zip)
