### PR TITLE
fix libnfs cmake build as static

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -9,15 +9,7 @@
 function(core_add_library name)
   set(name nfs_${name})
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-  add_library(${name} STATIC ${SOURCES} ${HEADERS})
+  add_library(${name} OBJECT ${SOURCES} ${HEADERS})
   target_include_directories(${name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
   set(CORE_LIBRARIES "${name};${CORE_LIBRARIES}" CACHE INTERNAL "")
-
-  # no need to install core libs if we build shared library
-  if(NOT BUILD_SHARED_LIBS)
-    install(TARGETS ${name} EXPORT libnfs
-            RUNTIME DESTINATION bin
-            ARCHIVE DESTINATION lib
-            LIBRARY DESTINATION lib)
-  endif()
 endfunction()


### PR DESCRIPTION
Before was by them as static all other parts not included, as they also
static libraries.

This change to create them as objects where then also included in a static and only `nfs.lib` is present.

I'm not sure if it was wanted and that everything should be static, but I thought to send a request.

Is to use on this Kodi addon https://github.com/notspiff/vfs.nfs where the depends need all as static.

Brought before on install by Windows:
```
  Performing install step for 'nfs'
  Microsoft (R)-Build-Engine, Version 15.9.21+g9802d43bc3 für .NET Framework
  Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.

    nfs_mount.vcxproj -> D:\Dev\Kodi64-UWP\vfs.nfs\build\build\nfs\src\nfs-build\mount\Release\nfs_mount.lib
    nfs_nfs.vcxproj -> D:\Dev\Kodi64-UWP\vfs.nfs\build\build\nfs\src\nfs-build\nfs\Release\nfs_nfs.lib
    nfs_nfs4.vcxproj -> D:\Dev\Kodi64-UWP\vfs.nfs\build\build\nfs\src\nfs-build\nfs4\Release\nfs_nfs4.lib
    nfs_nlm.vcxproj -> D:\Dev\Kodi64-UWP\vfs.nfs\build\build\nfs\src\nfs-build\nlm\Release\nfs_nlm.lib
    nfs_nsm.vcxproj -> D:\Dev\Kodi64-UWP\vfs.nfs\build\build\nfs\src\nfs-build\nsm\Release\nfs_nsm.lib
    nfs_portmap.vcxproj -> D:\Dev\Kodi64-UWP\vfs.nfs\build\build\nfs\src\nfs-build\portmap\Release\nfs_portmap.lib
    nfs_rquota.vcxproj -> D:\Dev\Kodi64-UWP\vfs.nfs\build\build\nfs\src\nfs-build\rquota\Release\nfs_rquota.lib
    nfs_win32.vcxproj -> D:\Dev\Kodi64-UWP\vfs.nfs\build\build\nfs\src\nfs-build\win32\Release\nfs_win32.lib
    nfs.vcxproj -> D:\Dev\Kodi64-UWP\vfs.nfs\build\build\nfs\src\nfs-build\lib\Release\nfs.lib
    -- Install configuration: "Release"
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/cmake/libnfs/libnfs-config.cmake
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/cmake/libnfs/libnfs-config-release.cmake
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/cmake/libnfs/FindNFS.cmake
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/cmake/libnfs/libnfs-config-version.cmake
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/pkgconfig/libnfs.pc
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/include/nfsc
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/include/nfsc/libnfs-raw.h
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/include/nfsc/libnfs-zdr.h
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/include/nfsc/libnfs.h
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/include/nfsc/libnfs.h.orig
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/include/nfsc/libnfs-raw-mount.h
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/include/nfsc/libnfs-raw-nfs.h
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/include/nfsc/libnfs-raw-nlm.h
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/include/nfsc/libnfs-raw-nsm.h
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/include/nfsc/libnfs-raw-portmap.h
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/include/nfsc/libnfs-raw-rquota.h
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/nfs_win32.lib
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/nfs_mount.lib
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/nfs_nfs.lib
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/nfs_nfs4.lib
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/nfs_nlm.lib
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/nfs_nsm.lib
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/nfs_portmap.lib
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/nfs_rquota.lib
    -- Installing: D:/Dev/Kodi64-UWP/vfs.nfs/build/build/depends/lib/nfs.lib
```