### PR TITLE
Fix NFS4 behavior of chmod/chown/utimes

### DIFF
--- a/tests/test_0370_chmod.sh
+++ b/tests/test_0370_chmod.sh
@@ -6,7 +6,7 @@ echo "NFSv${VERS} Basic chmod tests."
 
 start_share
 
-dd if=/dev/zero of=testdata/testfile count=1 bs=32768 2>/dev/null
+dd if=/dev/zero of=${TESTDIR}/testfile count=1 bs=32768 2>/dev/null
 
 echo -n "test chmod(0600) ... "
 ./prog_chmod "${TESTURL}/?version=${VERS}" "." /testfile 0600 || failure
@@ -32,6 +32,31 @@ echo -n "Verifying the mode is 0755 ... "
 grep "nfs_mode:100755" "${TESTDIR}/output" >/dev/null || failure
 success
 
+mkdir ${TESTDIR}/testdir
+
+echo -n "test chmod(0600) on dir ... "
+./prog_chmod "${TESTURL}/?version=${VERS}" "." /testdir 0600 || failure
+success
+
+echo -n "Stat the dir ... "
+./prog_stat "${TESTURL}/?version=${VERS}" "." testdir > "${TESTDIR}/output" || failure
+success
+
+echo -n "Verifying the mode is 0600 on dir ... "
+grep "nfs_mode:40600" "${TESTDIR}/output" >/dev/null || failure
+success
+
+echo -n "test chmod(0755) on dir ... "
+./prog_chmod "${TESTURL}/?version=${VERS}" "." /testdir 0755 || failure
+success
+
+echo -n "Stat the dir ... "
+./prog_stat "${TESTURL}/?version={VERS}" "." testdir > "${TESTDIR}/output" || failure
+success
+
+echo -n "Verifying the mode is 0755 on dir ... "
+grep "nfs_mode:40755" "${TESTDIR}/output" >/dev/null || failure
+success
 
 stop_share
 

--- a/tests/test_0400_chown.sh
+++ b/tests/test_0400_chown.sh
@@ -6,7 +6,7 @@ echo "NFSv${VERS} Basic chown tests."
 
 start_share
 
-dd if=/dev/zero of=testdata/testfile count=1 bs=32768 2>/dev/null
+dd if=/dev/zero of=${TESTDIR}/testfile count=1 bs=32768 2>/dev/null
 
 echo -n "test chown(1000, 2000) ... "
 ./prog_chown "${TESTURL}/?uid=0&version=${VERS}" "." /testfile 1000 2000 || failure
@@ -40,6 +40,39 @@ echo -n "Verifying the gid is 3000 ... "
 grep "nfs_gid:3000" "${TESTDIR}/output" >/dev/null || failure
 success
 
+mkdir ${TESTDIR}/testdir
+
+echo -n "test chown(1000, 2000) on dir ... "
+./prog_chown "${TESTURL}/?uid=0&version=${VERS}" "." /testdir 1000 2000 || failure
+success
+
+echo -n "Stat the dir ... "
+./prog_stat "${TESTURL}/?version=${VERS}" "." testdir > "${TESTDIR}/output" || failure
+success
+
+echo -n "Verifying the uid is 1000 on dir ... "
+grep "nfs_uid:1000" "${TESTDIR}/output" >/dev/null || failure
+success
+
+echo -n "Verifying the gid is 2000 on dir ... "
+grep "nfs_gid:2000" "${TESTDIR}/output" >/dev/null || failure
+success
+
+echo -n "test chown(2000, 3000) on dir ... "
+./prog_chown "${TESTURL}/?uid=0&version=${VERS}" "." /testdir 2000 3000 || failure
+success
+
+echo -n "Stat the dir ... "
+./prog_stat "${TESTURL}/?version=${VERS}" "." testdir > "${TESTDIR}/output" || failure
+success
+
+echo -n "Verifying the uid is 2000 on dir ... "
+grep "nfs_uid:2000" "${TESTDIR}/output" >/dev/null || failure
+success
+
+echo -n "Verifying the gid is 3000 on dir ... "
+grep "nfs_gid:3000" "${TESTDIR}/output" >/dev/null || failure
+success
 
 stop_share
 

--- a/tests/test_0450_utimes.sh
+++ b/tests/test_0450_utimes.sh
@@ -6,7 +6,7 @@ echo "NFSv${VERS} Basic nfs_utimes() tests."
 
 start_share
 
-dd if=/dev/zero of=testdata/testfile count=1 bs=32768 2>/dev/null
+dd if=/dev/zero of=${TESTDIR}/testfile count=1 bs=32768 2>/dev/null
 chmod 644 "${TESTDIR}/testfile"
 
 echo -n "test nfs_utimes() ... "
@@ -22,6 +22,25 @@ grep "nfs_atime:12345" "${TESTDIR}/output" >/dev/null || failure
 success
 
 echo -n "test nfs_mtime ... "
+grep "nfs_mtime:23456" "${TESTDIR}/output" >/dev/null || failure
+success
+
+mkdir ${TESTDIR}/testdir
+chmod 644 "${TESTDIR}/testdir"
+
+echo -n "test nfs_utimes() on dir ... "
+./prog_utimes "${TESTURL}/?version=${VERS}" "." /testdir 12345 23456 || failure
+success
+
+echo -n "test nfs_stat64() on dir ... "
+./prog_stat "${TESTURL}/?version=${VERS}" "." /testdir > "${TESTDIR}/output" || failure
+success
+
+echo -n "test nfs_atime on dir ... "
+grep "nfs_atime:12345" "${TESTDIR}/output" >/dev/null || failure
+success
+
+echo -n "test nfs_mtime on dir ... "
 grep "nfs_mtime:23456" "${TESTDIR}/output" >/dev/null || failure
 success
 


### PR DESCRIPTION
This patch fixes various issues around chmod/chown/utimes:
- The chmod/chown/utimes approach uses open_async_internal, which only works
  for files. This patch uses lookup_path so that chmod/chown is also
  possible on directories.
- Implements SET_TO_SERVER for utimes

I never succeeded in getting all tests passing even without
these changes. Nor did I succeed in getting the CMake compilation to
work. Sorry. The patch includes extra unit tests for these calls.
We use the libary as part of a test harness to test an NFS server
implementation, so I am reasonably confident that the changes work.
They are also manually tested against the Linux Kernel NFS Server.