### PR TITLE
Don't define u_int

### DIFF
--- a/include/nfsc/libnfs-zdr.h
+++ b/include/nfsc/libnfs-zdr.h
@@ -92,7 +92,6 @@ struct ZDR {
 typedef struct ZDR ZDR;
 
 
-typedef uint32_t u_int;
 typedef uint32_t enum_t;
 typedef uint32_t bool_t;
 


### PR DESCRIPTION
It's usually defined by the platform in types.h or sys/types.h.
The compiler complains if libnfs redefines it.