### PR TITLE
sys/time.h include clean-up (PS3 PPU)

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -24,7 +24,7 @@
 #define _LIBNFS_H_
 
 #include <stdint.h>
-#if defined(__ANDROID__) || defined(AROS) \
+#if defined(__ANDROID__) || defined(AROS) || defined(__PPU__) \
  || ( defined(__APPLE__) && defined(__MACH__) )
 #include <sys/time.h>
 #else

--- a/mount/mount.c
+++ b/mount/mount.c
@@ -19,10 +19,6 @@
 #include <win32/win32_compat.h>
 #endif/*WIN32*/
 
-#ifdef PS3_PPU
-#include <sys/time.h>
-#endif
-
 #include <stdio.h>
 #include <errno.h>
 #include "libnfs-zdr.h"

--- a/nfs/nfs.c
+++ b/nfs/nfs.c
@@ -21,10 +21,6 @@
 #include <sys/stat.h>
 #endif/*WIN32*/
 
-#ifdef PS3_PPU
-#include <sys/time.h>
-#endif
-
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>

--- a/nfs/nfsacl.c
+++ b/nfs/nfsacl.c
@@ -20,10 +20,6 @@
 #include <sys/stat.h>
 #endif/*WIN32*/
 
-#ifdef PS3_PPU
-#include <sys/time.h>
-#endif
-
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>

--- a/nfs4/nfs4.c
+++ b/nfs4/nfs4.c
@@ -22,10 +22,6 @@
 #include <sys/stat.h>
 #endif/*WIN32*/
 
-#ifdef PS3_PPU
-#include <sys/time.h>
-#endif
-
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>

--- a/nlm/nlm.c
+++ b/nlm/nlm.c
@@ -19,10 +19,6 @@
 #include <win32/win32_compat.h>
 #endif/*WIN32*/
 
-#ifdef PS3_PPU
-#include <sys/time.h>
-#endif
-
 #include <stdio.h>
 #include <errno.h>
 #include "libnfs-zdr.h"

--- a/nsm/nsm.c
+++ b/nsm/nsm.c
@@ -19,10 +19,6 @@
 #include <win32/win32_compat.h>
 #endif/*WIN32*/
 
-#ifdef PS3_PPU
-#include <sys/time.h>
-#endif
-
 #include <stdio.h>
 #include <errno.h>
 #include "libnfs-zdr.h"

--- a/portmap/portmap.c
+++ b/portmap/portmap.c
@@ -18,10 +18,6 @@
 #include <win32/win32_compat.h>
 #endif/*WIN32*/
 
-#ifdef PS3_PPU
-#include <sys/time.h>
-#endif
-
 #include <stdio.h>
 #include "libnfs-zdr.h"
 #include "libnfs.h"

--- a/rquota/rquota.c
+++ b/rquota/rquota.c
@@ -18,10 +18,6 @@
 #include <win32/win32_compat.h>
 #endif/*WIN32*/
 
-#ifdef PS3_PPU
-#include <sys/time.h>
-#endif
-
 #include <stdio.h>
 #include <errno.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Similar to #272 , the PS3 build needs `sys/time.h` to be included.

I was including it manually on each file, but I realized that it would be much nicer to do it directly on `libnfs.h`. 😄 
