### PR TITLE
Define u_int in libnfs-zdr.h for mingw again

### DIFF
--- a/include/nfsc/libnfs-zdr.h
+++ b/include/nfsc/libnfs-zdr.h
@@ -92,6 +92,9 @@ struct ZDR {
 typedef struct ZDR ZDR;
 
 
+#ifdef __MINGW32__
+typedef uint32_t u_int;
+#endif
 typedef uint32_t enum_t;
 typedef uint32_t bool_t;
 


### PR DESCRIPTION
The typedef for u_int was removed in 172f46756e7278a42ad78799cf6d8d34602f96bc,
assuming that sys/types.h defines it. This doesn't seam to be the case on mingw.