### PR TITLE
Fix mingw build: add strndup implementation to win32_compat.c

### DIFF
--- a/include/win32/win32_compat.h
+++ b/include/win32/win32_compat.h
@@ -33,6 +33,7 @@ THE SOFTWARE.
 #include <io.h>
 #include <sys/stat.h>
 #include <time.h>
+#include <stddef.h> // For size_t type
 
 typedef unsigned long fsblkcnt_t;
 typedef unsigned long fsfilcnt_t;
@@ -150,5 +151,9 @@ int     win32_gettimeofday(struct timeval *tv, struct timezone *tz);
 #endif
 
 #define DllExport
+
+#ifdef __MINGW32__
+char* strndup(const char *s, size_t n);
+#endif
 
 #endif//win32_COMPAT_H_

--- a/win32/win32_compat.c
+++ b/win32/win32_compat.c
@@ -197,6 +197,23 @@ int win32_gettimeofday(struct timeval *tv, struct timezone *tz)
  
   return 0;
 }
-
 #endif
+
+#ifdef __MINGW32__
+char* strndup(const char* s, size_t n)
+{
+  size_t len;
+  for(len=0; len<n && s[len]; len++);
+  len += 1;
+  if(!len)
+    return 0;
+  char* copy = malloc(len);
+  if(!copy)
+    return 0;
+  memcpy(copy, s, len-1);
+  copy[len-1] = 0;
+  return copy;
+}
+#endif
+
 #endif


### PR DESCRIPTION
strndup isn't implemented in mingw, so let's add it to win32_compat.c to make it build again on mingw.
