### PR TITLE
Don't try to ZDR_DECODE strings into a pre-existing pointer

### DIFF
--- a/lib/libnfs-zdr.c
+++ b/lib/libnfs-zdr.c
@@ -297,15 +297,11 @@ bool_t libnfs_zdr_string(ZDR *zdrs, char **strp, uint32_t maxsize)
 		 * in place.
 		 */
 	  if (zdrs->size > zdrs->pos + (int)size && zdrs->buf[zdrs->pos + size] == 0) {
-			if (*strp == NULL) {
-				*strp = &zdrs->buf[zdrs->pos];
-                                (*strp)[size] = 0;
-                                zdrs->pos += size;
-                                zdrs->pos = (zdrs->pos + 3) & ~3;
-                                return TRUE;
-			}
+			*strp = &zdrs->buf[zdrs->pos];
 			(*strp)[size] = 0;
-			return libnfs_zdr_opaque(zdrs, *strp, size);
+			zdrs->pos += size;
+			zdrs->pos = (zdrs->pos + 3) & ~3;
+			return TRUE;
 		}
 
 		/* Crap. The string is not null terminated in the rx buffer.


### PR DESCRIPTION
Otherwise it segfaults inside any string decoding inside rpc_process_call() as it doesn't zero the allocated memory, so libnfs_zdr_string() may receive non-zero *strp which is very easy to reproduce by writing a simple NFS server example using libnfs :-)