### PR TITLE
Partial revert https://github.com/sahlberg/libnfs/pull/312

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -12,4 +12,12 @@ function(core_add_library name)
   add_library(${name} OBJECT ${SOURCES} ${HEADERS})
   target_include_directories(${name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
   set(CORE_LIBRARIES "${name};${CORE_LIBRARIES}" CACHE INTERNAL "")
+
+  # no need to install core libs if we build shared library
+  if(NOT BUILD_SHARED_LIBS)
+    install(TARGETS ${name} EXPORT libnfs
+            RUNTIME DESTINATION bin
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib)
+  endif()
 endfunction()


### PR DESCRIPTION
Partial revert of #312 

Fixes #351 

@AlwinEsch went a bit overboard. The install target export causes failure as seen https://github.com/sahlberg/libnfs/issues/351

We still want to add_library(.. OBJECT ..) to resolve @AlwinEsch 's issue regarding windows and the superfluous .lib files.

Tested build libnfs cmake Macos, win x64. Both were failing, now both build correctly.

Windows cmake build with this patch. Showing correctly only installing the single nfs.lib
```
  Microsoft (R) Build Engine version 17.1.0+ae57d105c for .NET Framework
  Copyright (C) Microsoft Corporation. All rights reserved.

    nfs_mount.vcxproj -> C:\Users\brent\source\repos\xbmc\build\build\libnfs\src\libnfs-build\mount\nfs_mount.dir\RelWi
  thDebInfo\nfs_mount.lib
    nfs_nfs.vcxproj -> C:\Users\brent\source\repos\xbmc\build\build\libnfs\src\libnfs-build\nfs\nfs_nfs.dir\RelWithDebI
  nfo\nfs_nfs.lib
    nfs_nfs4.vcxproj -> C:\Users\brent\source\repos\xbmc\build\build\libnfs\src\libnfs-build\nfs4\nfs_nfs4.dir\RelWithD
  ebInfo\nfs_nfs4.lib
    nfs_nlm.vcxproj -> C:\Users\brent\source\repos\xbmc\build\build\libnfs\src\libnfs-build\nlm\nfs_nlm.dir\RelWithDebI
  nfo\nfs_nlm.lib
    nfs_nsm.vcxproj -> C:\Users\brent\source\repos\xbmc\build\build\libnfs\src\libnfs-build\nsm\nfs_nsm.dir\RelWithDebI
  nfo\nfs_nsm.lib
    nfs_portmap.vcxproj -> C:\Users\brent\source\repos\xbmc\build\build\libnfs\src\libnfs-build\portmap\nfs_portmap.dir
  \RelWithDebInfo\nfs_portmap.lib
    nfs_rquota.vcxproj -> C:\Users\brent\source\repos\xbmc\build\build\libnfs\src\libnfs-build\rquota\nfs_rquota.dir\Re
  lWithDebInfo\nfs_rquota.lib
    nfs_win32.vcxproj -> C:\Users\brent\source\repos\xbmc\build\build\libnfs\src\libnfs-build\win32\nfs_win32.dir\RelWi
  thDebInfo\nfs_win32.lib
    nfs.vcxproj -> C:\Users\brent\source\repos\xbmc\build\build\libnfs\src\libnfs-build\lib\RelWithDebInfo\nfs.lib
    -- Install configuration: "RelWithDebInfo"
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/lib/cmake/libnfs/libnfs-config.cmake
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/lib/cmake/libnfs/libnfs-config-relwithdebinfo.cmake
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/lib/cmake/libnfs/FindNFS.cmake
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/lib/cmake/libnfs/libnfs-config-version.cmake
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/lib/pkgconfig/libnfs.pc
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/include/nfsc
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/include/nfsc/libnfs-raw.h
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/include/nfsc/libnfs-zdr.h
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/include/nfsc/libnfs.h
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/include/nfsc/libnfs-raw-mount.h
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/include/nfsc/libnfs-raw-nfs.h
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/include/nfsc/libnfs-raw-nlm.h
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/include/nfsc/libnfs-raw-nsm.h
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/include/nfsc/libnfs-raw-portmap.h
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/include/nfsc/libnfs-raw-rquota.h
    -- Installing: C:/Users/brent/source/repos/xbmc/build/build/lib/nfs.lib
  Completed 'libnfs'
```

Macos cmake x64 target with patch
```
[100%] Built target nfs
/Users/Shared/xbmc-depends/arm-darwin21.2.0-native/bin/cmake -E cmake_progress_start /Users/brent/Dev/macos/build/build/libnfs/src/libnfs-build/CMakeFiles 0
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f CMakeFiles/Makefile2 preinstall
make[5]: Nothing to be done for `preinstall'.
Install the project...
/Users/Shared/xbmc-depends/arm-darwin21.2.0-native/bin/cmake -P cmake_install.cmake
-- Install configuration: ""
-- Installing: /Users/brent/Dev/macos/build/build/lib/cmake/libnfs/libnfs-config.cmake
-- Installing: /Users/brent/Dev/macos/build/build/lib/cmake/libnfs/libnfs-config-noconfig.cmake
-- Installing: /Users/brent/Dev/macos/build/build/lib/cmake/libnfs/FindNFS.cmake
-- Installing: /Users/brent/Dev/macos/build/build/lib/cmake/libnfs/libnfs-config-version.cmake
-- Installing: /Users/brent/Dev/macos/build/build/lib/pkgconfig/libnfs.pc
-- Installing: /Users/brent/Dev/macos/build/build/include/nfsc
-- Installing: /Users/brent/Dev/macos/build/build/include/nfsc/libnfs-zdr.h
-- Installing: /Users/brent/Dev/macos/build/build/include/nfsc/libnfs-raw.h
-- Installing: /Users/brent/Dev/macos/build/build/include/nfsc/libnfs.h
-- Installing: /Users/brent/Dev/macos/build/build/include/nfsc/libnfs-raw-mount.h
-- Installing: /Users/brent/Dev/macos/build/build/include/nfsc/libnfs-raw-nfs.h
-- Installing: /Users/brent/Dev/macos/build/build/include/nfsc/libnfs-raw-nlm.h
-- Installing: /Users/brent/Dev/macos/build/build/include/nfsc/libnfs-raw-nsm.h
-- Installing: /Users/brent/Dev/macos/build/build/include/nfsc/libnfs-raw-portmap.h
-- Installing: /Users/brent/Dev/macos/build/build/include/nfsc/libnfs-raw-rquota.h
-- Installing: /Users/brent/Dev/macos/build/build/lib/libnfs.a
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: /Users/brent/Dev/macos/build/build/lib/libnfs.a(multithreading.c.o) has no symbols
cd /Users/brent/Dev/macos/build/build/libnfs/src/libnfs-build && /Users/Shared/xbmc-depends/arm-darwin21.2.0-native/bin/cmake -E touch /Users/brent/Dev/macos/build/build/libnfs/src/libnfs-stamp/libnfs-install
[100%] Completed 'libnfs'

```