### PR TITLE
libnfs.h: remove comment about non-functional nfsv4 support

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -214,7 +214,6 @@ EXTERN void nfs_destroy_context(struct nfs_context *nfs);
  *                         times before failing and returing an error back
  *                         to the application.
  * version=<3|4>     : NFS version. Default is 3.
- *                     Version 4 is not yet functional. Do not use.
  * nfsport=<port>    : Use this port for NFS instead of using the portmapper.
  * mountport=<port>  : Use this port for the MOUNT protocol instead of
  *                     using portmapper. This argument is ignored for NFSv4


### PR DESCRIPTION
Just something I noticed. I saw that a similar comment was dropped in d86d5d18514a25da0347f5bc84aabac65302852e