### PR TITLE
Consistently use higher `maxcount` for READDIRPLUS

### DIFF
--- a/lib/nfs_v3.c
+++ b/lib/nfs_v3.c
@@ -2998,7 +2998,7 @@ nfs3_opendir_cb(struct rpc_context *rpc, int status, void *command_data,
                        res->READDIRPLUS3res_u.resok.cookieverf,
                        sizeof(cookieverf3));
 		args.dircount = 8192;
-		args.maxcount = 8192;
+		args.maxcount = 65536;
 
 	     	if (rpc_nfs3_readdirplus_async(nfs->rpc, nfs3_opendir_cb,
                                                &args, data) != 0) {
@@ -3069,7 +3069,7 @@ nfs3_opendir_continue_internal(struct nfs_context *nfs,
 	args.cookie = 0;
 	memset(&args.cookieverf, 0, sizeof(cookieverf3));
 	args.dircount = 8192;
-	args.maxcount = 8192;
+	args.maxcount = 65536;
 	if (rpc_nfs3_readdirplus_async(nfs->rpc, nfs3_opendir_cb,
                                        &args, data) != 0) {
 		nfs_set_error(nfs, "RPC error: Failed to send "

--- a/lib/nfs_v4.c
+++ b/lib/nfs_v4.c
@@ -829,7 +829,7 @@ nfs4_op_readdir(struct nfs_context *nfs, nfs_argop4 *op, uint64_t cookie)
 
         rdargs->cookie = cookie;
         rdargs->dircount = 8192;
-        rdargs->maxcount = 8192;
+        rdargs->maxcount = 65536;
         rdargs->attr_request.bitmap4_len = 2;
         rdargs->attr_request.bitmap4_val = standard_attributes;
 


### PR DESCRIPTION
The explanation is the same as in 4a58e6145568fd21ef956ae6ac3d3c37ef209a57, i.e. the server would gather 8192 bytes (`dircount`) of directory entries, fetch attributes for them and try to fit the extended entries into a 8192 bytes (`maxcount`) response. Obviously the attributes need quite some additional space, so only a small subset of the information can actually be sent back to the client, the rest is wasted.

Let's use the typical 8 to 1 ratio to allow more space for the response.

Benchmark with `nfs-ls` for different directories on a NetApp NFSv3 share:
```
    Files   Before    After
 -----------------------------------
    6,650   0.28s --> 0.14s  (-50%)
  163,128    4.8s -->  1.7s  (-65%)
  330,602    9.6s -->  3.2s  (-67%)
```

A significant improvement from ~34k to ~100k entries/s. Further increasing `dircount`/`maxcount` didn't lead to higher performance.