### PR TITLE
Expose further configuration options

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -299,8 +299,11 @@ EXTERN void nfs_set_pagecache(struct nfs_context *nfs, uint32_t v);
 EXTERN void nfs_set_pagecache_ttl(struct nfs_context *nfs, uint32_t v);
 EXTERN void nfs_set_readahead(struct nfs_context *nfs, uint32_t v);
 EXTERN void nfs_set_debug(struct nfs_context *nfs, int level);
+EXTERN void nfs_set_auto_traverse_mounts(struct nfs_context *nfs, int enabled);
 EXTERN void nfs_set_dircache(struct nfs_context *nfs, int enabled);
 EXTERN void nfs_set_autoreconnect(struct nfs_context *nfs, int num_retries);
+EXTERN void nfs_set_nfsport(struct nfs_context *nfs, int port);
+EXTERN void nfs_set_mountport(struct nfs_context *nfs, int port);
 
 /*
  * Set NFS version. Supported versions are

--- a/lib/libnfs-win32.def
+++ b/lib/libnfs-win32.def
@@ -88,9 +88,12 @@ nfs_set_auth
 nfs_set_autoreconnect
 rpc_set_auxiliary_gids
 nfs_set_debug
+nfs_set_auto_traverse_mounts
 nfs_set_dircache
 nfs_set_gid
 nfs_set_hash_size
+nfs_set_mountport
+nfs_set_nfsport
 nfs_set_pagecache
 nfs_set_pagecache_ttl
 nfs_set_readahead

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -316,7 +316,7 @@ nfs_set_context_args(struct nfs_context *nfs, const char *arg, const char *val)
 	} else if (!strcmp(arg, "debug")) {
 		rpc_set_debug(nfs_get_rpc_context(nfs), atoi(val));
 	} else if (!strcmp(arg, "auto-traverse-mounts")) {
-		nfs->nfsi->auto_traverse_mounts = atoi(val);
+		nfs_set_auto_traverse_mounts(nfs, atoi(val));
 	} else if (!strcmp(arg, "dircache")) {
 		nfs_set_dircache(nfs, atoi(val));
 	} else if (!strcmp(arg, "autoreconnect")) {
@@ -332,9 +332,9 @@ nfs_set_context_args(struct nfs_context *nfs, const char *arg, const char *val)
 			return -1;
 		}
 	} else if (!strcmp(arg, "nfsport")) {
-		nfs->nfsi->nfsport =  atoi(val);
+		nfs_set_nfsport(nfs, atoi(val));
 	} else if (!strcmp(arg, "mountport")) {
-		nfs->nfsi->mountport =  atoi(val);
+		nfs_set_mountport(nfs, atoi(val));
 	}
 	return 0;
 }
@@ -1939,6 +1939,11 @@ nfs_set_debug(struct nfs_context *nfs, int level) {
 }
 
 void
+nfs_set_auto_traverse_mounts(struct nfs_context *nfs, int enabled) {
+	nfs->nfsi->auto_traverse_mounts = enabled;
+}
+
+void
 nfs_set_dircache(struct nfs_context *nfs, int enabled) {
 	nfs->nfsi->dircache_enabled = enabled;
 }
@@ -1965,6 +1970,16 @@ nfs_set_version(struct nfs_context *nfs, int version) {
 int
 nfs_get_version(struct nfs_context *nfs) {
         return nfs->nfsi->version;
+}
+
+void
+nfs_set_nfsport(struct nfs_context *nfs, int port) {
+	nfs->nfsi->nfsport = port;
+}
+
+void
+nfs_set_mountport(struct nfs_context *nfs, int port) {
+	nfs->nfsi->mountport = port;
 }
 
 void


### PR DESCRIPTION
The options auto-traverse-mounts, nfsport and mountport could be set via URL, but not from libaries.