### PR TITLE
Reduced memory allocations.

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -139,7 +139,7 @@ struct rpc_context {
 #endif /* HAVE_MULTITHREADING */
 
 	uint32_t inpos;
-	char rm_buf[4];
+	uint32_t inbuf_size;
 	char *inbuf;
 
 	/* special fields for UDP, which can sometimes be BROADCASTed */


### PR DESCRIPTION
Removed one memory allocation per PDU creation. The output data memory block is now behind the header block.

Removed one memory allocation per response. The input buffer is now kept and reused, automatically growing to whatever size is required.