### PR TITLE
multithreading.c: wait until poll signals an event

### DIFF
--- a/lib/multithreading.c
+++ b/lib/multithreading.c
@@ -81,7 +81,8 @@ static void *nfs_mt_service_thread(void *arg)
 		pfd.events = nfs_which_events(nfs);
 		pfd.revents = 0;
 
-		ret = poll(&pfd, 1, 0);
+		// Wake up at least every 100ms to process timeouts.
+		ret = poll(&pfd, 1, 100);
 		if (ret < 0) {
 			nfs_set_error(nfs, "Poll failed");
 			revents = -1;


### PR DESCRIPTION
0 as timeout makes poll() return as soon as possible, even if there are no events to process. This, in turn, results in the service thread consuming the whole CPU doing nothing.

Fix by allowing poll() to sleep until there is an event to signal.