### PR TITLE
Add options to set dircount/maxcount for readdir()

### DIFF
--- a/README
+++ b/README
@@ -81,6 +81,13 @@ Arguments supported by libnfs are :
  mountport=<port>  : Use this port for the MOUNT protocol instead of
                      using portmapper. This argument is ignored for NFSv4
                      as it does not use the MOUNT protocol.
+ readdir-buffer=<count> | readdir-buffer=<dircount>,<maxcount>
+                   : Set the buffer size for READDIRPLUS, where dircount is
+                     the maximum amount of bytes the server should use to
+                     retrieve the entry names and maxcount is the maximum
+                     size of the response buffer (including attributes).
+                     If only one <count> is given it will be used for both.
+                     Default is 8192 for both.
 
 Auto_traverse_mounts
 ====================

--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -328,6 +328,8 @@ struct nfs_context_internal {
        int version;
        int nfsport;
        int mountport;
+       uint64_t readdir_dircount;
+       uint64_t readdir_maxcount;
 
        /* NFSv4 specific fields */
        verifier4 verifier;

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -236,6 +236,13 @@ EXTERN int nfs_set_hash_size(struct nfs_context *nfs, int hashes);
  * mountport=<port>  : Use this port for the MOUNT protocol instead of
  *                     using portmapper. This argument is ignored for NFSv4
  *                     as it does not use the MOUNT protocol.
+ * readdir-buffer=<count> | readdir-buffer=<dircount>,<maxcount>
+ *                   : Set the buffer size for READDIRPLUS, where dircount is
+ *                     the maximum amount of bytes the server should use to
+ *                     retrieve the entry names and maxcount is the maximum
+ *                     size of the response buffer (including attributes).
+ *                     If only one <count> is given it will be used for both.
+ *                     Default is 8192 for both.
  */
 /*
  * Parse a complete NFS URL including, server, path and
@@ -304,6 +311,7 @@ EXTERN void nfs_set_dircache(struct nfs_context *nfs, int enabled);
 EXTERN void nfs_set_autoreconnect(struct nfs_context *nfs, int num_retries);
 EXTERN void nfs_set_nfsport(struct nfs_context *nfs, int port);
 EXTERN void nfs_set_mountport(struct nfs_context *nfs, int port);
+EXTERN void nfs_set_readdir_max_buffer_size(struct nfs_context *nfs, uint64_t dircount, uint64_t maxcount);
 
 /*
  * Set NFS version. Supported versions are

--- a/lib/libnfs-win32.def
+++ b/lib/libnfs-win32.def
@@ -97,6 +97,7 @@ nfs_set_nfsport
 nfs_set_pagecache
 nfs_set_pagecache_ttl
 nfs_set_readahead
+nfs_set_readdir_max_buffer_size
 nfs_set_readmax
 nfs_set_tcp_syncnt
 nfs_set_timeout

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -335,6 +335,15 @@ nfs_set_context_args(struct nfs_context *nfs, const char *arg, const char *val)
 		nfs_set_nfsport(nfs, atoi(val));
 	} else if (!strcmp(arg, "mountport")) {
 		nfs_set_mountport(nfs, atoi(val));
+	} else if (!strcmp(arg, "readdir-buffer")) {
+		char *strp = strchr(val, ',');
+		if (strp) {
+			*strp = 0;
+			strp++;
+			nfs_set_readdir_max_buffer_size(nfs, atoi(val), atoi(strp));
+		} else {
+			nfs_set_readdir_max_buffer_size(nfs, atoi(val), atoi(val));
+		}
 	}
 	return 0;
 }
@@ -569,6 +578,8 @@ nfs_init_context(void)
 	/* Default is never give up, never surrender */
 	nfs->nfsi->auto_reconnect = -1;
 	nfs->nfsi->version = NFS_V3;
+	nfs->nfsi->readdir_dircount = 8192;
+	nfs->nfsi->readdir_maxcount = 8192;
 
         /* NFSv4 parameters */
         /* We need a "random" initial verifier */
@@ -1980,6 +1991,12 @@ nfs_set_nfsport(struct nfs_context *nfs, int port) {
 void
 nfs_set_mountport(struct nfs_context *nfs, int port) {
 	nfs->nfsi->mountport = port;
+}
+
+void
+nfs_set_readdir_max_buffer_size(struct nfs_context *nfs, uint64_t dircount, uint64_t maxcount) {
+	nfs->nfsi->readdir_dircount = dircount;
+	nfs->nfsi->readdir_maxcount = maxcount;
 }
 
 void

--- a/lib/nfs_v3.c
+++ b/lib/nfs_v3.c
@@ -2802,7 +2802,7 @@ nfs3_opendir_2_cb(struct rpc_context *rpc, int status, void *command_data,
 		args.cookie = cookie;
 		memcpy(&args.cookieverf, res->READDIR3res_u.resok.cookieverf,
                        sizeof(cookieverf3));
-		args.count = 8192;
+		args.count = nfs->nfsi->readdir_dircount;
 
 	     	if (rpc_nfs3_readdir_async(nfs->rpc, nfs3_opendir_2_cb,
                                            &args, data) != 0) {
@@ -2859,7 +2859,7 @@ nfs3_opendir_cb(struct rpc_context *rpc, int status, void *command_data,
 		args.dir.data.data_val = data->fh.val;
 		args.cookie = cookie;
 		memset(&args.cookieverf, 0, sizeof(cookieverf3));
-		args.count = 8192;
+		args.count = nfs->nfsi->readdir_dircount;
 
 		if (rpc_nfs3_readdir_async(nfs->rpc, nfs3_opendir_2_cb,
                                            &args, data) != 0) {
@@ -2997,8 +2997,8 @@ nfs3_opendir_cb(struct rpc_context *rpc, int status, void *command_data,
 		memcpy(&args.cookieverf,
                        res->READDIRPLUS3res_u.resok.cookieverf,
                        sizeof(cookieverf3));
-		args.dircount = 8192;
-		args.maxcount = 8192;
+		args.dircount = nfs->nfsi->readdir_dircount;
+		args.maxcount = nfs->nfsi->readdir_maxcount;
 
 	     	if (rpc_nfs3_readdirplus_async(nfs->rpc, nfs3_opendir_cb,
                                                &args, data) != 0) {
@@ -3068,8 +3068,8 @@ nfs3_opendir_continue_internal(struct nfs_context *nfs,
 	args.dir.data.data_val = data->fh.val;
 	args.cookie = 0;
 	memset(&args.cookieverf, 0, sizeof(cookieverf3));
-	args.dircount = 8192;
-	args.maxcount = 8192;
+	args.dircount = nfs->nfsi->readdir_dircount;
+	args.maxcount = nfs->nfsi->readdir_maxcount;
 	if (rpc_nfs3_readdirplus_async(nfs->rpc, nfs3_opendir_cb,
                                        &args, data) != 0) {
 		nfs_set_error(nfs, "RPC error: Failed to send "

--- a/lib/nfs_v4.c
+++ b/lib/nfs_v4.c
@@ -828,8 +828,8 @@ nfs4_op_readdir(struct nfs_context *nfs, nfs_argop4 *op, uint64_t cookie)
         memset(rdargs, 0, sizeof(*rdargs));
 
         rdargs->cookie = cookie;
-        rdargs->dircount = 8192;
-        rdargs->maxcount = 8192;
+        rdargs->dircount = nfs->nfsi->readdir_dircount;
+        rdargs->maxcount = nfs->nfsi->readdir_maxcount;
         rdargs->attr_request.bitmap4_len = 2;
         rdargs->attr_request.bitmap4_val = standard_attributes;
 


### PR DESCRIPTION
I did more tests and think that both dircount and maxcount should be configurable separately (although there is a shortcut to set both to the same value). Some servers seem to ignore dircount completely, on others the ratio is more like 1:3 than 1:8, so this enables fine-tuning depending on the actual scenario.