### PR TITLE
Modify LD_PRELOAD toy doc

### DIFF
--- a/README
+++ b/README
@@ -168,14 +168,14 @@ Compile with :
 gcc -fPIC -shared -o ld_nfs.so examples/ld_nfs.c -ldl -lnfs
 
 Then try things like
-LD_NFS_DEBUG=9 LD_PRELOAD=./ld_nfs.so cat nfs://127.0.0.1/data/tmp/foo123
+LD_NFS_DEBUG=9 LD_PRELOAD=./ld_nfs.so cat nfs://127.0.0.1//data/tmp/foo123
 
-LD_NFS_DEBUG=9 LD_PRELOAD=./ld_nfs.so cp nfs://127.0.0.1/data/tmp/foo123 nfs://127.0.0.1/data/tmp/foo123.copy
+LD_NFS_DEBUG=9 LD_PRELOAD=./ld_nfs.so cp nfs://127.0.0.1//data/tmp/foo123 nfs://127.0.0.1//data/tmp/foo123.copy
 
-LD_NFS_UID and LD_NFS_GID can be used to fake the uid andthe gid in the nfs context.
+LD_NFS_UID and LD_NFS_GID can be used to fake the uid and the gid in the nfs context.
 This can be useful on "insecure" enabled NFS share to make the server trust you as a root.
 You can try to run as a normal user things like :
-LD_NFS_DEBUG=9 LD_NFS_UID=0 LD_NFS_GID=0 LD_PRELOAD=./ld_nfs.so chown root:root nfs://127.0.0.1/data/tmp/foo123
+LD_NFS_DEBUG=9 LD_NFS_UID=0 LD_NFS_GID=0 LD_PRELOAD=./ld_nfs.so chown root:root nfs://127.0.0.1//data/tmp/foo123
 
 This is just a toy preload module. Don't open bugs if it does not work. Send
 patches to make it better instead.


### PR DESCRIPTION
```
NAME="Ubuntu"
VERSION="18.04.6 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.6 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
```

i built a ld_nfs.so with tag libnfs-libnfs-5.0.2.zip, but found that the demo seems missing the leading root path `/`

```
df -h .
Filesystem      Size  Used Avail Use% Mounted on
10.100.0.249:/  500G  258G  243G  52% /tmp

ls | grep hello-world.txt
hello-world.txt
```

`hello-world.txt` does not work

```
LD_NFS_DEBUG=9 LD_PRELOAD=./ld_nfs.so cat nfs://10.100.0.249/hello-world.txt
ld_nfs: open(nfs://10.100.0.249/hello-world.txt, 0, 37777402000)
ld_nfs: Failed to mount nfs share : mount/mnt call failed with "RPC error: Mount failed with error MNT3ERR_INVAL(22) Invalid argument(22)"

cat: 'nfs://10.100.0.249/hello-world.txt': Invalid argument
```

`/hello-world.txt` is ok

```
LD_NFS_DEBUG=9 LD_PRELOAD=./ld_nfs.so cat nfs://10.100.0.249//hello-world.txt
ld_nfs: open(nfs://10.100.0.249//hello-world.txt, 0, 37777402000)
ld_nfs: open(nfs://10.100.0.249//hello-world.txt) == 3
ld_nfs: __fxstat(3)
ld_nfs: __fxstat(3) success
ld_nfs: read(fd:3 count:131072)
hello world
ld_nfs: read(fd:3 count:131072)
ld_nfs: close(3)
```
