### PR TITLE
Fix integer size for readdir's dircount/maxcount

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -328,8 +328,8 @@ struct nfs_context_internal {
        int version;
        int nfsport;
        int mountport;
-       uint64_t readdir_dircount;
-       uint64_t readdir_maxcount;
+       uint32_t readdir_dircount;
+       uint32_t readdir_maxcount;
 
        /* NFSv4 specific fields */
        verifier4 verifier;

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -311,7 +311,7 @@ EXTERN void nfs_set_dircache(struct nfs_context *nfs, int enabled);
 EXTERN void nfs_set_autoreconnect(struct nfs_context *nfs, int num_retries);
 EXTERN void nfs_set_nfsport(struct nfs_context *nfs, int port);
 EXTERN void nfs_set_mountport(struct nfs_context *nfs, int port);
-EXTERN void nfs_set_readdir_max_buffer_size(struct nfs_context *nfs, uint64_t dircount, uint64_t maxcount);
+EXTERN void nfs_set_readdir_max_buffer_size(struct nfs_context *nfs, uint32_t dircount, uint32_t maxcount);
 
 /*
  * Set NFS version. Supported versions are

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -1994,7 +1994,7 @@ nfs_set_mountport(struct nfs_context *nfs, int port) {
 }
 
 void
-nfs_set_readdir_max_buffer_size(struct nfs_context *nfs, uint64_t dircount, uint64_t maxcount) {
+nfs_set_readdir_max_buffer_size(struct nfs_context *nfs, uint32_t dircount, uint32_t maxcount) {
 	nfs->nfsi->readdir_dircount = dircount;
 	nfs->nfsi->readdir_maxcount = maxcount;
 }


### PR DESCRIPTION
I had misinterpreted the types, the NFS protocol has only 4 bytes for these fields.