### PR TITLE
Use uint32_t for uid/gid in authentication and chown

### DIFF
--- a/examples/nfs-io.c
+++ b/examples/nfs-io.c
@@ -154,8 +154,8 @@ int main(int argc, char *argv[])
 			fprintf(stderr, "Invalid arguments for chown");
 			goto finished;
 		}
-		int uid = strtol(argv[2], NULL, 10);
-		int gid = strtol(argv[3], NULL, 10);
+		uint32_t uid = strtol(argv[2], NULL, 10);
+		uint32_t gid = strtol(argv[3], NULL, 10);
 		ret = nfs_chown(nfs, url->file, uid, gid);
 	} else if (!strncmp(argv[1], "stat", 4)) {
 		struct nfs_stat_64 st;

--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -157,8 +157,8 @@ struct rpc_context {
 
 	/* parameters passable via URL */
 	int tcp_syncnt;
-	int uid;
-	int gid;
+	uint32_t uid;
+	uint32_t gid;
 	uint32_t readahead;
 	uint32_t pagecache;
 	uint32_t pagecache_ttl;
@@ -483,7 +483,7 @@ int nfs3_chmod_async_internal(struct nfs_context *nfs, const char *path,
                               int no_follow, int mode, nfs_cb cb,
                               void *private_data);
 int nfs3_chown_async_internal(struct nfs_context *nfs, const char *path,
-                              int no_follow, int uid, int gid,
+                              int no_follow, uint32_t uid, uint32_t gid,
                               nfs_cb cb, void *private_data);
 int nfs3_close_async(struct nfs_context *nfs, struct nfsfh *nfsfh, nfs_cb cb,
                      void *private_data);
@@ -491,8 +491,8 @@ int nfs3_create_async(struct nfs_context *nfs, const char *path, int flags,
                       int mode, nfs_cb cb, void *private_data);
 int nfs3_fchmod_async(struct nfs_context *nfs, struct nfsfh *nfsfh, int mode,
                       nfs_cb cb, void *private_data);
-int nfs3_fchown_async(struct nfs_context *nfs, struct nfsfh *nfsfh, int uid,
-                      int gid, nfs_cb cb, void *private_data);
+int nfs3_fchown_async(struct nfs_context *nfs, struct nfsfh *nfsfh, uint32_t uid,
+                      uint32_t gid, nfs_cb cb, void *private_data);
 int nfs3_fstat_async(struct nfs_context *nfs, struct nfsfh *nfsfh, nfs_cb cb,
                      void *private_data);
 int nfs3_fstat64_async(struct nfs_context *nfs, struct nfsfh *nfsfh, nfs_cb cb,
@@ -561,7 +561,7 @@ int nfs4_chmod_async_internal(struct nfs_context *nfs, const char *path,
                               int no_follow, int mode, nfs_cb cb,
                               void *private_data);
 int nfs4_chown_async_internal(struct nfs_context *nfs, const char *path,
-                              int no_follow, int uid, int gid,
+                              int no_follow, uint32_t uid, uint32_t gid,
                               nfs_cb cb, void *private_data);
 int nfs4_close_async(struct nfs_context *nfs, struct nfsfh *nfsfh, nfs_cb cb,
                      void *private_data);
@@ -569,8 +569,8 @@ int nfs4_create_async(struct nfs_context *nfs, const char *path, int flags,
                       int mode, nfs_cb cb, void *private_data);
 int nfs4_fchmod_async(struct nfs_context *nfs, struct nfsfh *nfsfh, int mode,
                       nfs_cb cb, void *private_data);
-int nfs4_fchown_async(struct nfs_context *nfs, struct nfsfh *nfsfh, int uid,
-                      int gid, nfs_cb cb, void *private_data);
+int nfs4_fchown_async(struct nfs_context *nfs, struct nfsfh *nfsfh, uint32_t uid,
+                      uint32_t gid, nfs_cb cb, void *private_data);
 int nfs4_fcntl_async(struct nfs_context *nfs, struct nfsfh *nfsfh,
                      enum nfs4_fcntl_op cmd, void *arg,
                      nfs_cb cb, void *private_data);

--- a/include/nfsc/libnfs-raw.h
+++ b/include/nfsc/libnfs-raw.h
@@ -101,8 +101,8 @@ EXTERN int rpc_queue_length(struct rpc_context *rpc);
  * By default libnfs will use getuid()/getgid() where available
  * and 65534/65534 where not, with no auxiliary GIDs.
  */
-EXTERN void rpc_set_uid(struct rpc_context *rpc, int uid);
-EXTERN void rpc_set_gid(struct rpc_context *rpc, int gid);
+EXTERN void rpc_set_uid(struct rpc_context *rpc, uint32_t uid);
+EXTERN void rpc_set_gid(struct rpc_context *rpc, uint32_t gid);
 EXTERN void rpc_set_auxiliary_gids(struct rpc_context *rpc, uint32_t len, uint32_t* gids);
 
 /*

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -299,8 +299,8 @@ EXTERN void nfs_set_writemax(struct nfs_context *nfs, uint64_t writemax);
  */
 
 EXTERN void nfs_set_tcp_syncnt(struct nfs_context *nfs, int v);
-EXTERN void nfs_set_uid(struct nfs_context *nfs, int uid);
-EXTERN void nfs_set_gid(struct nfs_context *nfs, int gid);
+EXTERN void nfs_set_uid(struct nfs_context *nfs, uint32_t uid);
+EXTERN void nfs_set_gid(struct nfs_context *nfs, uint32_t gid);
 EXTERN void nfs_set_auxiliary_gids(struct nfs_context *nfs, uint32_t len, uint32_t* gids);
 EXTERN void nfs_set_pagecache(struct nfs_context *nfs, uint32_t v);
 EXTERN void nfs_set_pagecache_ttl(struct nfs_context *nfs, uint32_t v);
@@ -1595,16 +1595,16 @@ EXTERN int nfs_fchmod(struct nfs_context *nfs, struct nfsfh *nfsfh, int mode);
  * -errno : An error occured.
  *          data is the error string.
  */
-EXTERN int nfs_chown_async(struct nfs_context *nfs, const char *path, int uid,
-                           int gid, nfs_cb cb, void *private_data);
+EXTERN int nfs_chown_async(struct nfs_context *nfs, const char *path, uint32_t uid,
+                           uint32_t gid, nfs_cb cb, void *private_data);
 /*
  * Sync chown(<name>)
  * Function returns
  *      0 : The operation was successful.
  * -errno : The command failed.
  */
-EXTERN int nfs_chown(struct nfs_context *nfs, const char *path, int uid,
-                     int gid);
+EXTERN int nfs_chown(struct nfs_context *nfs, const char *path, uint32_t uid,
+                     uint32_t gid);
 /*
  * Async chown(<name>)
  *
@@ -1623,8 +1623,8 @@ EXTERN int nfs_chown(struct nfs_context *nfs, const char *path, int uid,
  * -errno : An error occured.
  *          data is the error string.
  */
-EXTERN int nfs_lchown_async(struct nfs_context *nfs, const char *path, int uid,
-                            int gid, nfs_cb cb, void *private_data);
+EXTERN int nfs_lchown_async(struct nfs_context *nfs, const char *path, uint32_t uid,
+                            uint32_t gid, nfs_cb cb, void *private_data);
 /*
  * Sync chown(<name>)
  *
@@ -1635,8 +1635,8 @@ EXTERN int nfs_lchown_async(struct nfs_context *nfs, const char *path, int uid,
  *      0 : The operation was successful.
  * -errno : The command failed.
  */
-EXTERN int nfs_lchown(struct nfs_context *nfs, const char *path, int uid,
-                      int gid);
+EXTERN int nfs_lchown(struct nfs_context *nfs, const char *path, uint32_t uid,
+                      uint32_t gid);
 
 
 
@@ -1658,15 +1658,15 @@ EXTERN int nfs_lchown(struct nfs_context *nfs, const char *path, int uid,
  *          data is the error string.
  */
 EXTERN int nfs_fchown_async(struct nfs_context *nfs, struct nfsfh *nfsfh,
-                            int uid, int gid, nfs_cb cb, void *private_data);
+                            uint32_t uid, uint32_t gid, nfs_cb cb, void *private_data);
 /*
  * Sync fchown(<handle>)
  * Function returns
  *      0 : The operation was successful.
  * -errno : The command failed.
  */
-EXTERN int nfs_fchown(struct nfs_context *nfs, struct nfsfh *nfsfh, int uid,
-                      int gid);
+EXTERN int nfs_fchown(struct nfs_context *nfs, struct nfsfh *nfsfh, uint32_t uid,
+                      uint32_t gid);
 
 
 

--- a/lib/init.c
+++ b/lib/init.c
@@ -268,7 +268,7 @@ void rpc_set_auth(struct rpc_context *rpc, struct AUTH *auth)
 	rpc->auth = auth;
 }
 
-static void rpc_set_uid_gid(struct rpc_context *rpc, int uid, int gid) {
+static void rpc_set_uid_gid(struct rpc_context *rpc, uint32_t uid, uint32_t gid) {
 	if (uid != rpc->uid || gid != rpc->gid) {
 		struct AUTH *auth = libnfs_authunix_create("libnfs", uid, gid, 0, NULL);
 		if (auth != NULL) {
@@ -279,11 +279,11 @@ static void rpc_set_uid_gid(struct rpc_context *rpc, int uid, int gid) {
 	}
 }
 
-void rpc_set_uid(struct rpc_context *rpc, int uid) {
+void rpc_set_uid(struct rpc_context *rpc, uint32_t uid) {
 	rpc_set_uid_gid(rpc, uid, rpc->gid);
 }
 
-void rpc_set_gid(struct rpc_context *rpc, int gid) {
+void rpc_set_gid(struct rpc_context *rpc, uint32_t gid) {
 	rpc_set_uid_gid(rpc, rpc->uid, gid);
 }
 

--- a/lib/libnfs-sync.c
+++ b/lib/libnfs-sync.c
@@ -1739,7 +1739,7 @@ chown_cb(int status, struct nfs_context *nfs, void *data, void *private_data)
 }
 
 int
-nfs_chown(struct nfs_context *nfs, const char *path, int uid, int gid)
+nfs_chown(struct nfs_context *nfs, const char *path, uint32_t uid, uint32_t gid)
 {
 	struct sync_cb_data cb_data;
 
@@ -1764,7 +1764,7 @@ nfs_chown(struct nfs_context *nfs, const char *path, int uid, int gid)
  * lchown()
  */
 int
-nfs_lchown(struct nfs_context *nfs, const char *path, int uid, int gid)
+nfs_lchown(struct nfs_context *nfs, const char *path, uint32_t uid, uint32_t gid)
 {
 	struct sync_cb_data cb_data;
 
@@ -1804,7 +1804,7 @@ fchown_cb(int status, struct nfs_context *nfs, void *data, void *private_data)
 }
 
 int
-nfs_fchown(struct nfs_context *nfs, struct nfsfh *nfsfh, int uid, int gid)
+nfs_fchown(struct nfs_context *nfs, struct nfsfh *nfsfh, uint32_t uid, uint32_t gid)
 {
 	struct sync_cb_data cb_data;
 

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -1690,7 +1690,7 @@ nfs_fchmod_async(struct nfs_context *nfs, struct nfsfh *nfsfh, int mode,
 }
 
 int
-nfs_chown_async(struct nfs_context *nfs, const char *path, int uid, int gid,
+nfs_chown_async(struct nfs_context *nfs, const char *path, uint32_t uid, uint32_t gid,
                 nfs_cb cb, void *private_data)
 {
 	switch (nfs->nfsi->version) {
@@ -1708,7 +1708,7 @@ nfs_chown_async(struct nfs_context *nfs, const char *path, int uid, int gid,
 }
 
 int
-nfs_lchown_async(struct nfs_context *nfs, const char *path, int uid, int gid,
+nfs_lchown_async(struct nfs_context *nfs, const char *path, uint32_t uid, uint32_t gid,
                  nfs_cb cb, void *private_data)
 {
 	switch (nfs->nfsi->version) {
@@ -1726,8 +1726,8 @@ nfs_lchown_async(struct nfs_context *nfs, const char *path, int uid, int gid,
 }
 
 int
-nfs_fchown_async(struct nfs_context *nfs, struct nfsfh *nfsfh, int uid,
-                 int gid, nfs_cb cb, void *private_data)
+nfs_fchown_async(struct nfs_context *nfs, struct nfsfh *nfsfh, uint32_t uid,
+                 uint32_t gid, nfs_cb cb, void *private_data)
 {
 	switch (nfs->nfsi->version) {
         case NFS_V3:
@@ -1915,12 +1915,12 @@ nfs_set_tcp_syncnt(struct nfs_context *nfs, int v) {
 }
 
 void
-nfs_set_uid(struct nfs_context *nfs, int uid) {
+nfs_set_uid(struct nfs_context *nfs, uint32_t uid) {
 	rpc_set_uid(nfs->rpc, uid);
 }
 
 void
-nfs_set_gid(struct nfs_context *nfs, int gid) {
+nfs_set_gid(struct nfs_context *nfs, uint32_t gid) {
 	rpc_set_gid(nfs->rpc, gid);
 }
 

--- a/lib/nfs_v3.c
+++ b/lib/nfs_v3.c
@@ -2124,7 +2124,7 @@ nfs3_chown_continue_internal(struct nfs_context *nfs,
 
 int
 nfs3_chown_async_internal(struct nfs_context *nfs, const char *path,
-                          int no_follow, int uid, int gid,
+                          int no_follow, uint32_t uid, uint32_t gid,
                           nfs_cb cb, void *private_data)
 {
 	struct nfs_chown_data *chown_data;
@@ -2149,8 +2149,8 @@ nfs3_chown_async_internal(struct nfs_context *nfs, const char *path,
 }
 
 int
-nfs3_fchown_async(struct nfs_context *nfs, struct nfsfh *nfsfh, int uid,
-                  int gid, nfs_cb cb, void *private_data)
+nfs3_fchown_async(struct nfs_context *nfs, struct nfsfh *nfsfh, uint32_t uid,
+                  uint32_t gid, nfs_cb cb, void *private_data)
 {
 	struct nfs_cb_data *data;
 	struct nfs_chown_data *chown_data;

--- a/lib/nfs_v4.c
+++ b/lib/nfs_v4.c
@@ -4875,7 +4875,7 @@ nfs4_fchmod_async(struct nfs_context *nfs, struct nfsfh *fh, int mode,
 #define CHOWN_BLOB_SIZE 64
 static int
 nfs4_create_chown_buffer(struct nfs_context *nfs, struct nfs4_cb_data *data,
-                         int uid, int gid)
+                         uint32_t uid, uint32_t gid)
 {
         char *str;
         int i, l;
@@ -4947,7 +4947,7 @@ nfs4_populate_chown(struct nfs4_cb_data *data, nfs_argop4 *op)
 
 int
 nfs4_chown_async_internal(struct nfs_context *nfs, const char *path,
-                          int no_follow, int uid, int gid,
+                          int no_follow, uint32_t uid, uint32_t gid,
                           nfs_cb cb, void *private_data)
 {
         struct nfs4_cb_data *data;
@@ -4979,7 +4979,7 @@ nfs4_chown_async_internal(struct nfs_context *nfs, const char *path,
 }
 
 int
-nfs4_fchown_async(struct nfs_context *nfs, struct nfsfh *fh, int uid, int gid,
+nfs4_fchown_async(struct nfs_context *nfs, struct nfsfh *fh, uint32_t uid, uint32_t gid,
                   nfs_cb cb, void *private_data)
 {
         COMPOUND4args args;

--- a/tests/prog_chown.c
+++ b/tests/prog_chown.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 	struct nfs_context *nfs = NULL;
 	struct nfs_url *url = NULL;
 	int ret = 0;
-        int uid, gid;
+        uint32_t uid, gid;
 
 	if (argc != 6) {
 		usage();

--- a/tests/prog_fchown.c
+++ b/tests/prog_fchown.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 	struct nfs_context *nfs = NULL;
 	struct nfs_url *url = NULL;
 	int ret = 0;
-        int uid, gid;
+        uint32_t uid, gid;
         struct nfsfh *fh;
 
 	if (argc != 6) {

--- a/tests/prog_lchown.c
+++ b/tests/prog_lchown.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 	struct nfs_context *nfs = NULL;
 	struct nfs_url *url = NULL;
 	int ret = 0;
-        int uid, gid;
+        uint32_t uid, gid;
 
 	if (argc != 6) {
 		usage();

--- a/utils/nfs-stat.c
+++ b/utils/nfs-stat.c
@@ -160,12 +160,12 @@ char uidbuf[16];
 char gidbuf[16];
 
 #ifdef WIN32
-char *uid_to_name(int uid)
+char *uid_to_name(uint32_t uid)
 {
 	sprintf(uidbuf, "%d", uid);
 	return uidbuf;
 }
-char *gid_to_name(int gid)
+char *gid_to_name(uint32_t gid)
 {
 	sprintf(gidbuf, "%d", gid);
 	return gidbuf;
@@ -174,7 +174,7 @@ char *gid_to_name(int gid)
 #include <sys/types.h>
 #include <grp.h>
 #include <pwd.h>
-char *uid_to_name(int uid)
+char *uid_to_name(uint32_t uid)
 {
 	struct passwd *pw;
 
@@ -186,7 +186,7 @@ char *uid_to_name(int uid)
 		return uidbuf;
 	}
 }	
-char *gid_to_name(int gid)
+char *gid_to_name(uint32_t gid)
 {
 	struct group *gr;
 


### PR DESCRIPTION
They're defined as unsigned int in RFC 5531 and RFC 1813. Some parts of the code (e.g. libnfs_authunix_create()) already used uint32_t, causing implicit casts.

I didn't touch rquota since I couldn't find an RFC for it and rquota.h seems to use int.