### PR TITLE
Added NFS 4.1 operations, fixed incomplete open_claim4 and added poll_timeout param

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -166,6 +166,7 @@ struct rpc_context {
         uint64_t last_timeout_scan;
 	int timeout;
 	char ifname[IFNAMSIZ];
+	int poll_timeout;
 
         /* Is a server context ? */
         int is_server_context;
@@ -271,6 +272,8 @@ void rpc_set_pagecache(struct rpc_context *rpc, uint32_t v);
 void rpc_set_pagecache_ttl(struct rpc_context *rpc, uint32_t v);
 void rpc_set_readahead(struct rpc_context *rpc, uint32_t v);
 void rpc_set_debug(struct rpc_context *rpc, int level);
+void rpc_set_poll_timeout(struct rpc_context *rpc, int poll_timeout);
+int rpc_get_poll_timeout(struct rpc_context *rpc);
 void rpc_set_timeout(struct rpc_context *rpc, int timeout);
 int rpc_get_timeout(struct rpc_context *rpc);
 int rpc_add_fragment(struct rpc_context *rpc, char *data, uint32_t size);

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -1989,6 +1989,27 @@ struct nfs_server_list *nfs_find_local_servers(void);
 void free_nfs_srvr_list(struct nfs_server_list *srv);
 
 /*
+ * nfs_set_poll_timeout()
+ * This function sets the polling timeout used for nfs rpc calls.
+ *
+ * Function returns nothing.
+ *
+ * int milliseconds : timeout that is passed to poll(2)
+ *                    to be applied in milliseconds (-1 no timeout)
+ */
+EXTERN void nfs_set_poll_timeout(struct nfs_context *nfs, int milliseconds);
+
+/*
+ * nfs_get_poll_timeout()
+ * This function gets the polling timeout used for nfs rpc calls.
+ *
+ * Function returns:
+ * int milliseconds : timeout that is passed to poll(2)
+ *                    to be applied in milliseconds (-1 no timeout)
+ */
+EXTERN int nfs_get_poll_timeout(struct nfs_context *nfs);
+
+/*
  * sync nfs_set_timeout()
  * This function sets the timeout used for nfs rpc calls.
  *

--- a/lib/init.c
+++ b/lib/init.c
@@ -147,6 +147,8 @@ struct rpc_context *rpc_init_context(void)
 
 	/* Default is no timeout */
 	rpc->timeout = -1;
+	/* Default is to timeout after 100ms of poll(2) */
+	rpc->poll_timeout = 100;
 
 	return rpc;
 }
@@ -470,6 +472,20 @@ void rpc_destroy_context(struct rpc_context *rpc)
         nfs_mt_mutex_destroy(&rpc->rpc_mutex);
 #endif /* HAVE_MULTITHREADING */
 	free(rpc);
+}
+
+void rpc_set_poll_timeout(struct rpc_context *rpc, int poll_timeout)
+{
+	assert(rpc->magic == RPC_CONTEXT_MAGIC);
+
+	rpc->poll_timeout = poll_timeout;
+}
+
+int rpc_get_poll_timeout(struct rpc_context *rpc)
+{
+	assert(rpc->magic == RPC_CONTEXT_MAGIC);
+
+	return rpc->poll_timeout;
 }
 
 void rpc_set_timeout(struct rpc_context *rpc, int timeout)

--- a/lib/libnfs-sync.c
+++ b/lib/libnfs-sync.c
@@ -225,7 +225,7 @@ wait_for_reply(struct rpc_context *rpc, struct sync_cb_data *cb_data)
 		pfd.events  = rpc_which_events(rpc);
 		pfd.revents = 0;
 
-		ret = poll(&pfd, 1, 100);
+		ret = poll(&pfd, 1, rpc->poll_timeout);
 		if (ret < 0) {
 			rpc_set_error(rpc, "Poll failed");
 			revents = -1;
@@ -271,7 +271,7 @@ wait_for_nfs_reply(struct nfs_context *nfs, struct sync_cb_data *cb_data)
 		pfd.events = nfs_which_events(nfs);
 		pfd.revents = 0;
 
-		ret = poll(&pfd, 1, 100);
+		ret = poll(&pfd, 1, nfs->rpc->poll_timeout);
 		if (ret < 0) {
 			nfs_set_error(nfs, "Poll failed");
 			revents = -1;

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -2156,12 +2156,30 @@ nfs_umask(struct nfs_context *nfs, uint16_t mask) {
 }
 
 /*
+* Sets polling timeout for nfs apis
+*/
+void
+nfs_set_poll_timeout(struct nfs_context *nfs, int poll_timeout)
+{
+	rpc_set_timeout(nfs->rpc,poll_timeout);
+}
+
+/*
+* Gets polling timeout for nfs apis
+*/
+int
+nfs_get_poll_timeout(struct nfs_context *nfs)
+{
+	return rpc_get_poll_timeout(nfs->rpc);
+}
+
+/*
 * Sets timeout for nfs apis
 */
 void
 nfs_set_timeout(struct nfs_context *nfs,int timeout)
 {
-	 rpc_set_timeout(nfs->rpc,timeout);
+	rpc_set_timeout(nfs->rpc,timeout);
 }
 
 /*

--- a/lib/multithreading.c
+++ b/lib/multithreading.c
@@ -84,9 +84,8 @@ static void *nfs_mt_service_thread(void *arg)
 		pfd.fd = nfs_get_fd(nfs);
 		pfd.events = nfs_which_events(nfs);
 		pfd.revents = 0;
-
-		// Wake up at least every 100ms to process timeouts.
-		ret = poll(&pfd, 1, 100);
+        
+		ret = poll(&pfd, 1, nfs->rpc->poll_timeout);
 		if (ret < 0) {
 			nfs_set_error(nfs, "Poll failed");
 			revents = -1;

--- a/nfs4/libnfs-raw-nfs4.c
+++ b/nfs4/libnfs-raw-nfs4.c
@@ -1202,6 +1202,44 @@ zdr_nfs_lock_type4 (ZDR *zdrs, nfs_lock_type4 *objp)
 }
 
 uint32_t
+zdr_client_owner4 (ZDR *zdrs, client_owner4 *objp)
+{
+	
+
+	 if (!zdr_verifier4 (zdrs, objp->co_verifier))
+		 return FALSE;
+	 if (!zdr_bytes (zdrs, (char **)&objp->co_ownerid.co_ownerid_val, (u_int *) &objp->co_ownerid.co_ownerid_len, NFS4_OPAQUE_LIMIT))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
+zdr_server_owner4 (ZDR *zdrs, server_owner4 *objp)
+{
+	
+
+	 if (!zdr_uint64_t (zdrs, &objp->so_minor_id))
+		 return FALSE;
+	 if (!zdr_bytes (zdrs, (char **)&objp->so_major_id.so_major_id_val, (u_int *) &objp->so_major_id.so_major_id_len, NFS4_OPAQUE_LIMIT))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
+zdr_nfs_impl_id4 (ZDR *zdrs, nfs_impl_id4 *objp)
+{
+	
+
+	 if (!zdr_utf8str_cis (zdrs, &objp->nii_domain))
+		 return FALSE;
+	 if (!zdr_utf8str_cs (zdrs, &objp->nii_name))
+		 return FALSE;
+	 if (!zdr_nfstime4 (zdrs, &objp->nii_date))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
 zdr_ACCESS4args (ZDR *zdrs, ACCESS4args *objp)
 {
 	
@@ -2735,6 +2773,16 @@ zdr_RELEASE_LOCKOWNER4res (ZDR *zdrs, RELEASE_LOCKOWNER4res *objp)
 }
 
 uint32_t
+zdr_gsshandle4_t (ZDR *zdrs, gsshandle4_t *objp)
+{
+	
+
+	 if (!zdr_bytes (zdrs, (char **)&objp->gsshandle4_t_val, (u_int *) &objp->gsshandle4_t_len, ~0))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
 zdr_callback_sec_parms4 (ZDR *zdrs, callback_sec_parms4 *objp)
 {
 	
@@ -2750,6 +2798,241 @@ zdr_callback_sec_parms4 (ZDR *zdrs, callback_sec_parms4 *objp)
 		break;
 	default:
 		return FALSE;
+	}
+	return TRUE;
+}
+
+uint32_t
+zdr_channel_dir_from_client4 (ZDR *zdrs, channel_dir_from_client4 *objp)
+{
+	
+
+	 if (!zdr_enum (zdrs, (enum_t *) objp))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
+zdr_BIND_CONN_TO_SESSION4args (ZDR *zdrs, BIND_CONN_TO_SESSION4args *objp)
+{
+	
+
+	 if (!zdr_sessionid4 (zdrs, objp->bctsa_sessid))
+		 return FALSE;
+	 if (!zdr_channel_dir_from_client4 (zdrs, &objp->bctsa_dir))
+		 return FALSE;
+	 if (!zdr_bool (zdrs, &objp->bctsa_use_conn_in_rdma_mode))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
+zdr_channel_dir_from_server4 (ZDR *zdrs, channel_dir_from_server4 *objp)
+{
+	
+
+	 if (!zdr_enum (zdrs, (enum_t *) objp))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
+zdr_BIND_CONN_TO_SESSION4resok (ZDR *zdrs, BIND_CONN_TO_SESSION4resok *objp)
+{
+	
+
+	 if (!zdr_sessionid4 (zdrs, objp->bctsr_sessid))
+		 return FALSE;
+	 if (!zdr_channel_dir_from_server4 (zdrs, &objp->bctsr_dir))
+		 return FALSE;
+	 if (!zdr_bool (zdrs, &objp->bctsr_use_conn_in_rdma_mode))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
+zdr_BIND_CONN_TO_SESSION4res (ZDR *zdrs, BIND_CONN_TO_SESSION4res *objp)
+{
+	
+
+	 if (!zdr_nfsstat4 (zdrs, &objp->bctsr_status))
+		 return FALSE;
+	switch (objp->bctsr_status) {
+	case NFS4_OK:
+		 if (!zdr_BIND_CONN_TO_SESSION4resok (zdrs, &objp->BIND_CONN_TO_SESSION4res_u.bctsr_resok4))
+			 return FALSE;
+		break;
+	default:
+		break;
+	}
+	return TRUE;
+}
+
+uint32_t
+zdr_state_protect_ops4 (ZDR *zdrs, state_protect_ops4 *objp)
+{
+	
+
+	 if (!zdr_bitmap4 (zdrs, &objp->spo_must_enforce))
+		 return FALSE;
+	 if (!zdr_bitmap4 (zdrs, &objp->spo_must_allow))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
+zdr_ssv_sp_parms4 (ZDR *zdrs, ssv_sp_parms4 *objp)
+{
+	
+
+	 if (!zdr_state_protect_ops4 (zdrs, &objp->ssp_ops))
+		 return FALSE;
+	 if (!zdr_array (zdrs, (char **)&objp->ssp_hash_algs.ssp_hash_algs_val, (u_int *) &objp->ssp_hash_algs.ssp_hash_algs_len, ~0,
+		sizeof (sec_oid4), (zdrproc_t) zdr_sec_oid4))
+		 return FALSE;
+	 if (!zdr_array (zdrs, (char **)&objp->ssp_encr_algs.ssp_encr_algs_val, (u_int *) &objp->ssp_encr_algs.ssp_encr_algs_len, ~0,
+		sizeof (sec_oid4), (zdrproc_t) zdr_sec_oid4))
+		 return FALSE;
+	 if (!zdr_uint32_t (zdrs, &objp->ssp_window))
+		 return FALSE;
+	 if (!zdr_uint32_t (zdrs, &objp->ssp_num_gss_handles))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
+zdr_state_protect_how4 (ZDR *zdrs, state_protect_how4 *objp)
+{
+	
+
+	 if (!zdr_enum (zdrs, (enum_t *) objp))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
+zdr_state_protect4_a (ZDR *zdrs, state_protect4_a *objp)
+{
+	
+
+	 if (!zdr_state_protect_how4 (zdrs, &objp->spa_how))
+		 return FALSE;
+	switch (objp->spa_how) {
+	case SP4_NONE:
+		break;
+	case SP4_MACH_CRED:
+		 if (!zdr_state_protect_ops4 (zdrs, &objp->state_protect4_a_u.spa_mach_ops))
+			 return FALSE;
+		break;
+	case SP4_SSV:
+		 if (!zdr_ssv_sp_parms4 (zdrs, &objp->state_protect4_a_u.spa_ssv_parms))
+			 return FALSE;
+		break;
+	default:
+		return FALSE;
+	}
+	return TRUE;
+}
+
+uint32_t
+zdr_EXCHANGE_ID4args (ZDR *zdrs, EXCHANGE_ID4args *objp)
+{
+	
+
+	 if (!zdr_client_owner4 (zdrs, &objp->eia_clientowner))
+		 return FALSE;
+	 if (!zdr_uint32_t (zdrs, &objp->eia_flags))
+		 return FALSE;
+	 if (!zdr_state_protect4_a (zdrs, &objp->eia_state_protect))
+		 return FALSE;
+	 if (!zdr_array (zdrs, (char **)&objp->eia_client_impl_id.eia_client_impl_id_val, (u_int *) &objp->eia_client_impl_id.eia_client_impl_id_len, 1,
+		sizeof (nfs_impl_id4), (zdrproc_t) zdr_nfs_impl_id4))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
+zdr_ssv_prot_info4 (ZDR *zdrs, ssv_prot_info4 *objp)
+{
+	
+
+	 if (!zdr_state_protect_ops4 (zdrs, &objp->spi_ops))
+		 return FALSE;
+	 if (!zdr_uint32_t (zdrs, &objp->spi_hash_alg))
+		 return FALSE;
+	 if (!zdr_uint32_t (zdrs, &objp->spi_encr_alg))
+		 return FALSE;
+	 if (!zdr_uint32_t (zdrs, &objp->spi_ssv_len))
+		 return FALSE;
+	 if (!zdr_uint32_t (zdrs, &objp->spi_window))
+		 return FALSE;
+	 if (!zdr_array (zdrs, (char **)&objp->spi_handles.spi_handles_val, (u_int *) &objp->spi_handles.spi_handles_len, ~0,
+		sizeof (gsshandle4_t), (zdrproc_t) zdr_gsshandle4_t))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
+zdr_state_protect4_r (ZDR *zdrs, state_protect4_r *objp)
+{
+	
+
+	 if (!zdr_state_protect_how4 (zdrs, &objp->spr_how))
+		 return FALSE;
+	switch (objp->spr_how) {
+	case SP4_NONE:
+		break;
+	case SP4_MACH_CRED:
+		 if (!zdr_state_protect_ops4 (zdrs, &objp->state_protect4_r_u.spr_mach_ops))
+			 return FALSE;
+		break;
+	case SP4_SSV:
+		 if (!zdr_ssv_prot_info4 (zdrs, &objp->state_protect4_r_u.spr_ssv_info))
+			 return FALSE;
+		break;
+	default:
+		return FALSE;
+	}
+	return TRUE;
+}
+
+uint32_t
+zdr_EXCHANGE_ID4resok (ZDR *zdrs, EXCHANGE_ID4resok *objp)
+{
+	
+
+	 if (!zdr_clientid4 (zdrs, &objp->eir_clientid))
+		 return FALSE;
+	 if (!zdr_sequenceid4 (zdrs, &objp->eir_sequenceid))
+		 return FALSE;
+	 if (!zdr_uint32_t (zdrs, &objp->eir_flags))
+		 return FALSE;
+	 if (!zdr_state_protect4_r (zdrs, &objp->eir_state_protect))
+		 return FALSE;
+	 if (!zdr_server_owner4 (zdrs, &objp->eir_server_owner))
+		 return FALSE;
+	 if (!zdr_bytes (zdrs, (char **)&objp->eir_server_scope.eir_server_scope_val, (u_int *) &objp->eir_server_scope.eir_server_scope_len, NFS4_OPAQUE_LIMIT))
+		 return FALSE;
+	 if (!zdr_array (zdrs, (char **)&objp->eir_server_impl_id.eir_server_impl_id_val, (u_int *) &objp->eir_server_impl_id.eir_server_impl_id_len, 1,
+		sizeof (nfs_impl_id4), (zdrproc_t) zdr_nfs_impl_id4))
+		 return FALSE;
+	return TRUE;
+}
+
+uint32_t
+zdr_EXCHANGE_ID4res (ZDR *zdrs, EXCHANGE_ID4res *objp)
+{
+	
+
+	 if (!zdr_nfsstat4 (zdrs, &objp->eir_status))
+		 return FALSE;
+	switch (objp->eir_status) {
+	case NFS4_OK:
+		 if (!zdr_EXCHANGE_ID4resok (zdrs, &objp->EXCHANGE_ID4res_u.eir_resok4))
+			 return FALSE;
+		break;
+	default:
+		break;
 	}
 	return TRUE;
 }
@@ -3784,6 +4067,14 @@ zdr_nfs_argop4 (ZDR *zdrs, nfs_argop4 *objp)
 		 if (!zdr_RELEASE_LOCKOWNER4args (zdrs, &objp->nfs_argop4_u.oprelease_lockowner))
 			 return FALSE;
 		break;
+	case OP_BIND_CONN_TO_SESSION:
+		 if (!zdr_BIND_CONN_TO_SESSION4args (zdrs, &objp->nfs_argop4_u.opbindconntosession))
+			 return FALSE;
+		break;
+	case OP_EXCHANGE_ID:
+		 if (!zdr_EXCHANGE_ID4args (zdrs, &objp->nfs_argop4_u.opexchangeid))
+			 return FALSE;
+		break;
 	case OP_CREATE_SESSION:
 		 if (!zdr_CREATE_SESSION4args (zdrs, &objp->nfs_argop4_u.opcreatesession))
 			 return FALSE;
@@ -4010,6 +4301,14 @@ zdr_nfs_resop4 (ZDR *zdrs, nfs_resop4 *objp)
 		break;
 	case OP_RELEASE_LOCKOWNER:
 		 if (!zdr_RELEASE_LOCKOWNER4res (zdrs, &objp->nfs_resop4_u.oprelease_lockowner))
+			 return FALSE;
+		break;
+	case OP_BIND_CONN_TO_SESSION:
+		 if (!zdr_BIND_CONN_TO_SESSION4res (zdrs, &objp->nfs_resop4_u.opbindconntosession))
+			 return FALSE;
+		break;
+	case OP_EXCHANGE_ID:
+		 if (!zdr_EXCHANGE_ID4res (zdrs, &objp->nfs_resop4_u.opexchangeid))
 			 return FALSE;
 		break;
 	case OP_CREATE_SESSION:

--- a/nfs4/libnfs-raw-nfs4.c
+++ b/nfs4/libnfs-raw-nfs4.c
@@ -1925,6 +1925,14 @@ zdr_open_claim4 (ZDR *zdrs, open_claim4 *objp)
 		 if (!zdr_component4 (zdrs, &objp->open_claim4_u.file_delegate_prev))
 			 return FALSE;
 		break;
+	case CLAIM_FH:
+		break;
+	case CLAIM_DELEG_PREV_FH:
+		break;
+	case CLAIM_DELEG_CUR_FH:
+		 if (!zdr_stateid4 (zdrs, &objp->open_claim4_u.oc_delegate_stateid))
+			 return FALSE;
+		break;
 	default:
 		return FALSE;
 	}

--- a/nfs4/libnfs-raw-nfs4.h
+++ b/nfs4/libnfs-raw-nfs4.h
@@ -973,6 +973,7 @@ struct open_claim4 {
 		open_delegation_type4 delegate_type;
 		open_claim_delegate_cur4 delegate_cur_info;
 		component4 file_delegate_prev;
+		stateid4 oc_delegate_stateid;
 	} open_claim4_u;
 };
 typedef struct open_claim4 open_claim4;

--- a/nfs4/libnfs-raw-nfs4.h
+++ b/nfs4/libnfs-raw-nfs4.h
@@ -614,6 +614,31 @@ enum nfs_lock_type4 {
 	WRITEW_LT = 4,
 };
 typedef enum nfs_lock_type4 nfs_lock_type4;
+
+struct client_owner4 {
+	verifier4 co_verifier;
+	struct {
+		u_int co_ownerid_len;
+		char *co_ownerid_val;
+	} co_ownerid;
+};
+typedef struct client_owner4 client_owner4;
+
+struct server_owner4 {
+	uint64_t so_minor_id;
+	struct {
+		u_int so_major_id_len;
+		char *so_major_id_val;
+	} so_major_id;
+};
+typedef struct server_owner4 server_owner4;
+
+struct nfs_impl_id4 {
+	utf8str_cis nii_domain;
+	utf8str_cs nii_name;
+	nfstime4 nii_date;
+};
+typedef struct nfs_impl_id4 nfs_impl_id4;
 #define ACCESS4_READ 0x00000001
 #define ACCESS4_LOOKUP 0x00000002
 #define ACCESS4_MODIFY 0x00000004
@@ -1372,6 +1397,11 @@ struct RELEASE_LOCKOWNER4res {
 };
 typedef struct RELEASE_LOCKOWNER4res RELEASE_LOCKOWNER4res;
 
+typedef struct {
+	u_int gsshandle4_t_len;
+	char *gsshandle4_t_val;
+} gsshandle4_t;
+
 struct callback_sec_parms4 {
 	uint32_t cb_secflavor;
 	union {
@@ -1379,6 +1409,147 @@ struct callback_sec_parms4 {
 	} callback_sec_parms4_u;
 };
 typedef struct callback_sec_parms4 callback_sec_parms4;
+
+enum channel_dir_from_client4 {
+	CDFC4_FORE = 0x1,
+	CDFC4_BACK = 0x2,
+	CDFC4_FORE_OR_BOTH = 0x3,
+	CDFC4_BACK_OR_BOTH = 0x7,
+};
+typedef enum channel_dir_from_client4 channel_dir_from_client4;
+
+struct BIND_CONN_TO_SESSION4args {
+	sessionid4 bctsa_sessid;
+	channel_dir_from_client4 bctsa_dir;
+	uint32_t bctsa_use_conn_in_rdma_mode;
+};
+typedef struct BIND_CONN_TO_SESSION4args BIND_CONN_TO_SESSION4args;
+
+enum channel_dir_from_server4 {
+	CDFS4_FORE = 0x1,
+	CDFS4_BACK = 0x2,
+	CDFS4_BOTH = 0x3,
+};
+typedef enum channel_dir_from_server4 channel_dir_from_server4;
+
+struct BIND_CONN_TO_SESSION4resok {
+	sessionid4 bctsr_sessid;
+	channel_dir_from_server4 bctsr_dir;
+	uint32_t bctsr_use_conn_in_rdma_mode;
+};
+typedef struct BIND_CONN_TO_SESSION4resok BIND_CONN_TO_SESSION4resok;
+
+struct BIND_CONN_TO_SESSION4res {
+	nfsstat4 bctsr_status;
+	union {
+		BIND_CONN_TO_SESSION4resok bctsr_resok4;
+	} BIND_CONN_TO_SESSION4res_u;
+};
+typedef struct BIND_CONN_TO_SESSION4res BIND_CONN_TO_SESSION4res;
+#define EXCHGID4_FLAG_SUPP_MOVED_REFER 0x00000001
+#define EXCHGID4_FLAG_SUPP_MOVED_MIGR 0x00000002
+#define EXCHGID4_FLAG_BIND_PRINC_STATEID 0x00000100
+#define EXCHGID4_FLAG_USE_NON_PNFS 0x00010000
+#define EXCHGID4_FLAG_USE_PNFS_MDS 0x00020000
+#define EXCHGID4_FLAG_USE_PNFS_DS 0x00040000
+#define EXCHGID4_FLAG_MASK_PNFS 0x00070000
+#define EXCHGID4_FLAG_UPD_CONFIRMED_REC_A 0x40000000
+#define EXCHGID4_FLAG_CONFIRMED_R 0x80000000
+
+struct state_protect_ops4 {
+	bitmap4 spo_must_enforce;
+	bitmap4 spo_must_allow;
+};
+typedef struct state_protect_ops4 state_protect_ops4;
+
+struct ssv_sp_parms4 {
+	state_protect_ops4 ssp_ops;
+	struct {
+		u_int ssp_hash_algs_len;
+		sec_oid4 *ssp_hash_algs_val;
+	} ssp_hash_algs;
+	struct {
+		u_int ssp_encr_algs_len;
+		sec_oid4 *ssp_encr_algs_val;
+	} ssp_encr_algs;
+	uint32_t ssp_window;
+	uint32_t ssp_num_gss_handles;
+};
+typedef struct ssv_sp_parms4 ssv_sp_parms4;
+
+enum state_protect_how4 {
+	SP4_NONE = 0,
+	SP4_MACH_CRED = 1,
+	SP4_SSV = 2,
+};
+typedef enum state_protect_how4 state_protect_how4;
+
+struct state_protect4_a {
+	state_protect_how4 spa_how;
+	union {
+		state_protect_ops4 spa_mach_ops;
+		ssv_sp_parms4 spa_ssv_parms;
+	} state_protect4_a_u;
+};
+typedef struct state_protect4_a state_protect4_a;
+
+struct EXCHANGE_ID4args {
+	client_owner4 eia_clientowner;
+	uint32_t eia_flags;
+	state_protect4_a eia_state_protect;
+	struct {
+		u_int eia_client_impl_id_len;
+		nfs_impl_id4 *eia_client_impl_id_val;
+	} eia_client_impl_id;
+};
+typedef struct EXCHANGE_ID4args EXCHANGE_ID4args;
+
+struct ssv_prot_info4 {
+	state_protect_ops4 spi_ops;
+	uint32_t spi_hash_alg;
+	uint32_t spi_encr_alg;
+	uint32_t spi_ssv_len;
+	uint32_t spi_window;
+	struct {
+		u_int spi_handles_len;
+		gsshandle4_t *spi_handles_val;
+	} spi_handles;
+};
+typedef struct ssv_prot_info4 ssv_prot_info4;
+
+struct state_protect4_r {
+	state_protect_how4 spr_how;
+	union {
+		state_protect_ops4 spr_mach_ops;
+		ssv_prot_info4 spr_ssv_info;
+	} state_protect4_r_u;
+};
+typedef struct state_protect4_r state_protect4_r;
+
+struct EXCHANGE_ID4resok {
+	clientid4 eir_clientid;
+	sequenceid4 eir_sequenceid;
+	uint32_t eir_flags;
+	state_protect4_r eir_state_protect;
+	server_owner4 eir_server_owner;
+	struct {
+		u_int eir_server_scope_len;
+		char *eir_server_scope_val;
+	} eir_server_scope;
+	struct {
+		u_int eir_server_impl_id_len;
+		nfs_impl_id4 *eir_server_impl_id_val;
+	} eir_server_impl_id;
+};
+typedef struct EXCHANGE_ID4resok EXCHANGE_ID4resok;
+
+struct EXCHANGE_ID4res {
+	nfsstat4 eir_status;
+	union {
+		EXCHANGE_ID4resok eir_resok4;
+	} EXCHANGE_ID4res_u;
+};
+typedef struct EXCHANGE_ID4res EXCHANGE_ID4res;
 
 struct channel_attrs4 {
 	count4 ca_headerpadsize;
@@ -1871,6 +2042,8 @@ enum nfs_opnum4 {
 	OP_VERIFY = 37,
 	OP_WRITE = 38,
 	OP_RELEASE_LOCKOWNER = 39,
+	OP_BIND_CONN_TO_SESSION = 41,
+	OP_EXCHANGE_ID = 42,
 	OP_CREATE_SESSION = 43,
 	OP_DESTROY_SESSION = 44,
 	OP_FREE_STATEID = 45,
@@ -1924,6 +2097,8 @@ struct nfs_argop4 {
 		VERIFY4args opverify;
 		WRITE4args opwrite;
 		RELEASE_LOCKOWNER4args oprelease_lockowner;
+		BIND_CONN_TO_SESSION4args opbindconntosession;
+		EXCHANGE_ID4args opexchangeid;
 		CREATE_SESSION4args opcreatesession;
 		DESTROY_SESSION4args opdestroysession;
 		FREE_STATEID4args opfreestateid;
@@ -1984,6 +2159,8 @@ struct nfs_resop4 {
 		VERIFY4res opverify;
 		WRITE4res opwrite;
 		RELEASE_LOCKOWNER4res oprelease_lockowner;
+		BIND_CONN_TO_SESSION4res opbindconntosession;
+		EXCHANGE_ID4res opexchangeid;
 		CREATE_SESSION4res opcreatesession;
 		DESTROY_SESSION4res opdestroysession;
 		FREE_STATEID4res opfreestateid;
@@ -2266,6 +2443,9 @@ extern  uint32_t zdr_nfs_client_id4 (ZDR *, nfs_client_id4*);
 extern  uint32_t zdr_open_owner4 (ZDR *, open_owner4*);
 extern  uint32_t zdr_lock_owner4 (ZDR *, lock_owner4*);
 extern  uint32_t zdr_nfs_lock_type4 (ZDR *, nfs_lock_type4*);
+extern  uint32_t zdr_client_owner4 (ZDR *, client_owner4*);
+extern  uint32_t zdr_server_owner4 (ZDR *, server_owner4*);
+extern  uint32_t zdr_nfs_impl_id4 (ZDR *, nfs_impl_id4*);
 extern  uint32_t zdr_ACCESS4args (ZDR *, ACCESS4args*);
 extern  uint32_t zdr_ACCESS4resok (ZDR *, ACCESS4resok*);
 extern  uint32_t zdr_ACCESS4res (ZDR *, ACCESS4res*);
@@ -2376,7 +2556,22 @@ extern  uint32_t zdr_WRITE4resok (ZDR *, WRITE4resok*);
 extern  uint32_t zdr_WRITE4res (ZDR *, WRITE4res*);
 extern  uint32_t zdr_RELEASE_LOCKOWNER4args (ZDR *, RELEASE_LOCKOWNER4args*);
 extern  uint32_t zdr_RELEASE_LOCKOWNER4res (ZDR *, RELEASE_LOCKOWNER4res*);
+extern  uint32_t zdr_gsshandle4_t (ZDR *, gsshandle4_t*);
 extern  uint32_t zdr_callback_sec_parms4 (ZDR *, callback_sec_parms4*);
+extern  uint32_t zdr_channel_dir_from_client4 (ZDR *, channel_dir_from_client4*);
+extern  uint32_t zdr_BIND_CONN_TO_SESSION4args (ZDR *, BIND_CONN_TO_SESSION4args*);
+extern  uint32_t zdr_channel_dir_from_server4 (ZDR *, channel_dir_from_server4*);
+extern  uint32_t zdr_BIND_CONN_TO_SESSION4resok (ZDR *, BIND_CONN_TO_SESSION4resok*);
+extern  uint32_t zdr_BIND_CONN_TO_SESSION4res (ZDR *, BIND_CONN_TO_SESSION4res*);
+extern  uint32_t zdr_state_protect_ops4 (ZDR *, state_protect_ops4*);
+extern  uint32_t zdr_ssv_sp_parms4 (ZDR *, ssv_sp_parms4*);
+extern  uint32_t zdr_state_protect_how4 (ZDR *, state_protect_how4*);
+extern  uint32_t zdr_state_protect4_a (ZDR *, state_protect4_a*);
+extern  uint32_t zdr_EXCHANGE_ID4args (ZDR *, EXCHANGE_ID4args*);
+extern  uint32_t zdr_ssv_prot_info4 (ZDR *, ssv_prot_info4*);
+extern  uint32_t zdr_state_protect4_r (ZDR *, state_protect4_r*);
+extern  uint32_t zdr_EXCHANGE_ID4resok (ZDR *, EXCHANGE_ID4resok*);
+extern  uint32_t zdr_EXCHANGE_ID4res (ZDR *, EXCHANGE_ID4res*);
 extern  uint32_t zdr_channel_attrs4 (ZDR *, channel_attrs4*);
 extern  uint32_t zdr_CREATE_SESSION4args (ZDR *, CREATE_SESSION4args*);
 extern  uint32_t zdr_CREATE_SESSION4resok (ZDR *, CREATE_SESSION4resok*);
@@ -2563,6 +2758,9 @@ extern uint32_t zdr_nfs_client_id4 ();
 extern uint32_t zdr_open_owner4 ();
 extern uint32_t zdr_lock_owner4 ();
 extern uint32_t zdr_nfs_lock_type4 ();
+extern uint32_t zdr_client_owner4 ();
+extern uint32_t zdr_server_owner4 ();
+extern uint32_t zdr_nfs_impl_id4 ();
 extern uint32_t zdr_ACCESS4args ();
 extern uint32_t zdr_ACCESS4resok ();
 extern uint32_t zdr_ACCESS4res ();
@@ -2673,7 +2871,22 @@ extern uint32_t zdr_WRITE4resok ();
 extern uint32_t zdr_WRITE4res ();
 extern uint32_t zdr_RELEASE_LOCKOWNER4args ();
 extern uint32_t zdr_RELEASE_LOCKOWNER4res ();
+extern uint32_t zdr_gsshandle4_t ();
 extern uint32_t zdr_callback_sec_parms4 ();
+extern uint32_t zdr_channel_dir_from_client4 ();
+extern uint32_t zdr_BIND_CONN_TO_SESSION4args ();
+extern uint32_t zdr_channel_dir_from_server4 ();
+extern uint32_t zdr_BIND_CONN_TO_SESSION4resok ();
+extern uint32_t zdr_BIND_CONN_TO_SESSION4res ();
+extern uint32_t zdr_state_protect_ops4 ();
+extern uint32_t zdr_ssv_sp_parms4 ();
+extern uint32_t zdr_state_protect_how4 ();
+extern uint32_t zdr_state_protect4_a ();
+extern uint32_t zdr_EXCHANGE_ID4args ();
+extern uint32_t zdr_ssv_prot_info4 ();
+extern uint32_t zdr_state_protect4_r ();
+extern uint32_t zdr_EXCHANGE_ID4resok ();
+extern uint32_t zdr_EXCHANGE_ID4res ();
 extern uint32_t zdr_channel_attrs4 ();
 extern uint32_t zdr_CREATE_SESSION4args ();
 extern uint32_t zdr_CREATE_SESSION4resok ();

--- a/nfs4/nfs4.x
+++ b/nfs4/nfs4.x
@@ -990,8 +990,36 @@ union open_claim4 switch (open_claim_type4 claim) {
   * instance of the client.  File is specified by name.
   */
  case CLAIM_DELEGATE_PREV:
-         /* CURRENT_FH: directory */
+        /* CURRENT_FH: directory */
         component4      file_delegate_prev;
+
+ /*
+  * Like CLAIM_NULL.  No special rights
+  * to file.  Ordinary OPEN of the
+  * specified file by current filehandle.
+  */
+ case CLAIM_FH: /* new to v4.1 */
+        /* CURRENT_FH: regular file to open */
+        void;
+
+ /*
+  * Like CLAIM_DELEGATE_PREV.  Right to file based on a
+  * delegation granted to a previous boot
+  * instance of the client.  File is identified by
+  * by filehandle.
+  */
+ case CLAIM_DELEG_PREV_FH: /* new to v4.1 */
+        /* CURRENT_FH: file being opened */
+        void;
+
+ /*
+  * Like CLAIM_DELEGATE_CUR.  Right to file based on
+  * a delegation granted by the server.
+  * File is identified by filehandle.
+  */
+ case CLAIM_DELEG_CUR_FH: /* new to v4.1 */
+        /* CURRENT_FH: file being opened */
+        stateid4       oc_delegate_stateid;
 };
 
 /*


### PR DESCRIPTION
For [a project I am working on](https://github.com/IBM/dpu-virtio-fs/), we needed a few things that were not in libnfs yet:

- The EXCHANGE_ID and BIND_CONN_TO_SESSION operations from NFS 4.1 (these were pulled straight from RFC 5661)
- The open_claim4 from NFS 4.1 that allows you to open the file of the current filehandle, was only partially implemented, added the rest (straight from RFC 5661 again)
- We needed to control the polling timeout that is used in the service thread, so we added `set_poll_timeout` and `get_poll_timeout`.

Let me know if I added things in the wrong place. :)