### PR TITLE
Write multiple pdus at once.

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -173,7 +173,7 @@ struct rpc_context {
         struct rpc_endpoint *endpoints;
 };
 
-#define RPC_MAX_VECTORS 16
+#define RPC_MAX_VECTORS  8 /* Same as UIO_FASTIOV used by the Linux kernel */
 
 struct rpc_iovec {
         char *buf;


### PR DESCRIPTION
Attempt to batch the iovectors from several pdus in order to reduce the number of calls to writev.
In the best case this change will reduce the number of calls to writev to an eighth of what they were before.

The maximum number of vectors was reduced to match the limit set on the Linux kernel for the fast code path that handles iovectors.