### PR TITLE
Check return value from adjust_inbuf.

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -457,7 +457,9 @@ rpc_read_from_socket(struct rpc_context *rpc)
                 case READ_PAYLOAD:
                 case READ_FRAGMENT:
 			pdu_size = rpc->record_marker;
-                        adjust_inbuf(rpc, pdu_size);
+                        if (adjust_inbuf(rpc, pdu_size) != 0) {
+                            return -1;
+                        }
                         buf = rpc->inbuf + rpc->inpos;
                 }
 


### PR DESCRIPTION
Otherwise we may have failed to allocate the buffer required to read the rest of the response and we would not know, resulting in reading the incoming data into a buffer too small for it.