### PR TITLE
Reset state on reconnect.

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -1029,6 +1029,10 @@ rpc_reconnect_requeue(struct rpc_context *rpc)
 		rpc->outqueue.head->out.num_done = 0;
 	}
 
+	rpc->inpos = 0;
+	rpc->record_marker = 0;
+	rpc->state = READ_RM;
+
 	/* Socket is closed so we will not get any replies to any commands
 	 * in flight. Move them all over from the waitpdu queue back to the
          * out queue.


### PR DESCRIPTION
Otherwise we may be attempting to read data belonging to the state of a previous socket which is now closed.

I could not find any code resetting the state during an automatic reconnect.

We had a situation where the socket was closed whilst on READ_PAYLOAD state due to a record marker that specified a payload bigger than supported and libnfs kept failing and reconnecting without processing any data because it kept trying to adjust the input buffer to the unsupported size.