### PR TITLE
Handle small reads for record marker field.

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -460,10 +460,10 @@ rpc_read_from_socket(struct rpc_context *rpc)
                         if (adjust_inbuf(rpc, pdu_size) != 0) {
                             return -1;
                         }
-                        buf = rpc->inbuf + rpc->inpos;
+                        buf = rpc->inbuf;
                 }
 
-		count = recv(rpc->fd, buf, pdu_size - rpc->inpos,
+		count = recv(rpc->fd, buf + rpc->inpos, pdu_size - rpc->inpos,
                              MSG_DONTWAIT);
 		if (count < 0) {
 			if (errno == EINTR || errno == EAGAIN) {


### PR DESCRIPTION
If the call to recv for the record marker reads less than 4 bytes then the state will still be READ_RM and the next call to recv will overwrite the lowest bytes of the variable "record_marker", which when converted to little-endian will generate an incorrect and very high value for the payload.

The code is changed to always use the "inpos" value to move the buffer forward to the correct location for the next bytes, previously it was only used for the payload buffer. Note that the size of the data to read from the variable "pdu_size" was already usign "inpos".