### PR TITLE
Always close the socket.

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -959,17 +959,17 @@ rpc_disconnect(struct rpc_context *rpc, const char *error)
 {
 	assert(rpc->magic == RPC_CONTEXT_MAGIC);
 
+	if (rpc->fd != -1) {
+		close(rpc->fd);
+		rpc->fd  = -1;
+	}
+
 	/* Do not re-disconnect if we are already disconnected */
 	if (!rpc->is_connected) {
 		return 0;
 	}
 	/* Disable autoreconnect */
 	rpc_set_autoreconnect(rpc, 0);
-
-	if (rpc->fd != -1) {
-		close(rpc->fd);
-	}
-	rpc->fd  = -1;
 
 	rpc->is_connected = 0;
 


### PR DESCRIPTION
If the connection process fails it is possible for "is_connected" to be zero whilst still having a valid socket handle on "fd". The previous code was keeping the socket open on those situations and any future calls to "rpc_connect_async" will all fail with "Trying to connect while already connected", the only workaround was to destroy the context and start again. By always closing the socket if we have one we avoid that issue.