### PR TITLE
Allow setting a limit on the number of commands in-flight.

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -139,6 +139,8 @@ struct rpc_context {
         uint32_t num_hashes;
 	struct rpc_queue *waitpdu;
 	uint32_t waitpdu_len;
+	uint32_t max_waitpdu_len;
+
 #ifdef HAVE_MULTITHREADING
         int multithreading_enabled;
         libnfs_mutex_t rpc_mutex;

--- a/include/nfsc/libnfs-raw.h
+++ b/include/nfsc/libnfs-raw.h
@@ -93,8 +93,27 @@ EXTERN int rpc_service(struct rpc_context *rpc, int revents);
  * Returns the number of commands in-flight. Can be used by the application
  * to check if there are any more responses we are awaiting from the server
  * or if the connection is completely idle.
+ * The number returned includes the commands on the output queue and the
+ * commands waiting from a response from the server.
  */
 EXTERN int rpc_queue_length(struct rpc_context *rpc);
+
+/*
+ * Returns the number of commands awaiting from the server.
+ * Can be used by the application to check if there are any
+ * more responses we are awaiting from the server
+ * or if the connection is completely idle.
+ */
+EXTERN int rpc_get_num_awaiting(struct rpc_context *rpc);
+
+/*
+ * Used to limit the total number of commands awaiting from the server.
+ * By default there is no limit, all commands will be sent as soon as possible.
+ * If a limit is set and it is reached then new commands will be kept on
+ * the output queue until the total number of commands in-flight goes below
+ * the limit again.
+ */
+EXTERN void rpc_set_awaiting_limit(struct rpc_context *rpc, int limit);
 
 /*
  * Set which UID/GIDs to use in the authenticator.

--- a/lib/init.c
+++ b/lib/init.c
@@ -147,6 +147,8 @@ struct rpc_context *rpc_init_context(void)
 	rpc->gid = getgid();
 #endif
 	rpc_reset_queue(&rpc->outqueue);
+	/* Default is no limit */
+	rpc->max_waitpdu_len = 0;
 
 	/* Default is no timeout */
 	rpc->timeout = -1;


### PR DESCRIPTION
Some NFS servers will limit the number of in-flight requests from NFS clients to a maximum of 128.
This limit is configured as "sunrpc.tcp_max_slot_table_entries". When a client reaches that limit the server responds by decreasing the window size for the TCP connection, hence decreasing throughput until the window size recovers.

The new functionality will allow applications to set a limit on the number of in-flight requests (or "awaiting" as the API defines them).

Also, a new function was added to request the number of commands waiting because this number may be very different to the total size of the output queue and it could be useful to know the difference between the two.