### PR TITLE
ci: Run tests on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,20 @@ jobs:
       - uses: actions/checkout@main
       - run: sudo apt install -y cmake
       - run: mkdir build
-      - run: cmake -B build
+      - run: cmake -DENABLE_EXAMPLES=ON -DENABLE_TESTS=ON -B build
       - run: make --directory build
       - run: sudo make --directory build install
+      - run: |
+          sudo apt-get install libtool-bin nfs-kernel-server valgrind
+          sudo service nfs-kernel-server stop
+          echo 10 | sudo tee /proc/fs/nfsd/nfsv4leasetime
+          echo 10 | sudo tee /proc/fs/nfsd/nfsv4gracetime
+          sudo service nfs-kernel-server start
+
+          echo "Testing with NFSv3"
+          make VERSION=3 --directory build test
+          echo "Testing with NFSv4"
+          make VERSION=4 --directory build test
 
   Linux-Musl-QEMU:
     runs-on: ubuntu-latest

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,6 +24,12 @@ if(EVENT_LIBARY)
   list(APPEND EXTRA_LIBRARIES ${EVENT_LIBARY})
 endif()
 
+include_directories(../mount
+  ../nfs
+  ../nfs4
+  ../portmap
+  ../rquota)
+
 foreach(TARGET ${EXAMPLES})
   add_executable(${TARGET} ${TARGET}.c)
   target_link_libraries(${TARGET} nfs ${EXTRA_LIBRARIES})


### PR DESCRIPTION
This PR enables building examples, tests and running tests.

Building examples and many tests fail though, thus it would probably make sense to fix those issues first.

Having examples that build and having tests that pass would be a nice for distribution maintainers and I guess for other developers, too.
