### PR TITLE
Update waitpdu_len when a pdu times out.

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -607,6 +607,7 @@ rpc_timeout_scan(struct rpc_context *rpc)
 			if (!q->head) {
 				q->tail = NULL;
 			}
+			rpc->waitpdu_len--;
                         // qqq move to a temporary queue and process after
                         // we drop the mutex
 			rpc_set_error(rpc, "command timed out");


### PR DESCRIPTION
Otherwise the value of waitpdu_len gets out of sync with the actual number of pdus on the waitpdu hash table and the reported queue length is always higher than it really is.