### PR TITLE
Fix out-of-bounds reading of v4 READLINK results

### DIFF
--- a/lib/nfs_v4.c
+++ b/lib/nfs_v4.c
@@ -2902,7 +2902,8 @@ nfs4_readlink_cb(struct rpc_context *rpc, int status, void *command_data,
 
         rlresok = &res->resarray.resarray_val[i].nfs_resop4_u.opreadlink.READLINK4res_u.resok4;
 
-        target = strdup(rlresok->link.utf8string_val);
+        target = strndup(rlresok->link.utf8string_val,
+                         rlresok->link.utf8string_len);
         if (target == NULL) {
                 data->cb(-ENOMEM, nfs, "Failed to allocate memory",
                          data->private_data);


### PR DESCRIPTION
`nfs4_readlink_cb()`, part of `nfs_readlink_async()` and indirectly `nfs_readlink()` & `nfs_readlink2()`, presumes the results of v4 READLINK ops to be always NUL-terminated.  That isn't guaranteed, and is rarely the case at least when a result needs no NUL-padding on the wire toward a typically (or always?) four byte multiple: the next RAM byte can be NUL only coincidentally.

Under these conditions, memory is read beyond the end of the op result, at the very least corrupting the result returned to the caller, or even crashing, given no NUL byte in all the remainder of the corresponding memory area.

(Closes #338 by @ma-rom.)