### PR TITLE
Update libnfs-sync.c

### DIFF
--- a/lib/libnfs-sync.c
+++ b/lib/libnfs-sync.c
@@ -95,6 +95,10 @@
 #include <sys/sockio.h>
 #endif
 
+#if defined(__sun)
+#include <sys/sockio.h>
+#endif
+
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif


### PR DESCRIPTION
fixed building on sparc solaris 11
```
tar xzvf libnfs.tar.gz; 
cd libnfs; mkdir build; cd build; 
cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX .. 
gmake; 
gmake install
```