### PR TITLE
Fix bug in skipping of partially sent iov data

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -277,6 +277,7 @@ rpc_write_to_socket(struct rpc_context *rpc)
                                 }
                                 buf += num_done;
                                 len -= num_done;
+                                num_done = 0;
 
                                 /* Concatenate continous blocks */
                                 if (last_buf != buf) {


### PR DESCRIPTION
When skipping partially sent iov, num_done must be cleared after all previously sent data is skipped, else it will cause more data to be skipped from the next vector.