### PR TITLE
PS3: initialize addrinfo struct

### DIFF
--- a/ps3_ppu/ps3_compat.c
+++ b/ps3_ppu/ps3_compat.c
@@ -57,6 +57,7 @@ struct addrinfo **res)
   } 
 
   *res = malloc(sizeof(struct addrinfo));
+  memset(*res, 0, sizeof(struct addrinfo));
 
   (*res)->ai_family = AF_INET;
   (*res)->ai_addrlen = sizeof(struct sockaddr_in);


### PR DESCRIPTION
Apply the same fix for libsmb2. It hasn't caused an issue yet, but just isolate any issue down the road.