### PR TITLE
Fix compiler warnings and a subtle precedence error

### DIFF
--- a/nfs/libnfs-raw-nfs.c
+++ b/nfs/libnfs-raw-nfs.c
@@ -38,9 +38,6 @@ either expressed or implied, of the FreeBSD Project.
 uint32_t
 zdr_cookieverf3 (ZDR *zdrs, cookieverf3 objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, NFS3_COOKIEVERFSIZE))
 		 return FALSE;
 	return TRUE;
@@ -49,9 +46,6 @@ zdr_cookieverf3 (ZDR *zdrs, cookieverf3 objp)
 uint32_t
 zdr_cookie3 (ZDR *zdrs, cookie3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -60,9 +54,6 @@ zdr_cookie3 (ZDR *zdrs, cookie3 *objp)
 uint32_t
 zdr_nfs_fh3 (ZDR *zdrs, nfs_fh3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->data.data_val, (u_int *) &objp->data.data_len, NFS3_FHSIZE))
 		 return FALSE;
 	return TRUE;
@@ -71,9 +62,6 @@ zdr_nfs_fh3 (ZDR *zdrs, nfs_fh3 *objp)
 uint32_t
 zdr_filename3 (ZDR *zdrs, filename3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, objp, ~0))
 		 return FALSE;
 	return TRUE;
@@ -82,9 +70,6 @@ zdr_filename3 (ZDR *zdrs, filename3 *objp)
 uint32_t
 zdr_diropargs3 (ZDR *zdrs, diropargs3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->dir))
 		 return FALSE;
 	 if (!zdr_filename3 (zdrs, &objp->name))
@@ -95,9 +80,6 @@ zdr_diropargs3 (ZDR *zdrs, diropargs3 *objp)
 uint32_t
 zdr_ftype3 (ZDR *zdrs, ftype3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -106,9 +88,6 @@ zdr_ftype3 (ZDR *zdrs, ftype3 *objp)
 uint32_t
 zdr_mode3 (ZDR *zdrs, mode3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -117,9 +96,6 @@ zdr_mode3 (ZDR *zdrs, mode3 *objp)
 uint32_t
 zdr_uid3 (ZDR *zdrs, uid3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -128,9 +104,6 @@ zdr_uid3 (ZDR *zdrs, uid3 *objp)
 uint32_t
 zdr_gid3 (ZDR *zdrs, gid3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -139,9 +112,6 @@ zdr_gid3 (ZDR *zdrs, gid3 *objp)
 uint32_t
 zdr_size3 (ZDR *zdrs, size3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -150,9 +120,6 @@ zdr_size3 (ZDR *zdrs, size3 *objp)
 uint32_t
 zdr_fileid3 (ZDR *zdrs, fileid3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -161,9 +128,6 @@ zdr_fileid3 (ZDR *zdrs, fileid3 *objp)
 uint32_t
 zdr_specdata3 (ZDR *zdrs, specdata3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->specdata1))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->specdata2))
@@ -174,9 +138,6 @@ zdr_specdata3 (ZDR *zdrs, specdata3 *objp)
 uint32_t
 zdr_nfstime3 (ZDR *zdrs, nfstime3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->seconds))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->nseconds))
@@ -187,9 +148,6 @@ zdr_nfstime3 (ZDR *zdrs, nfstime3 *objp)
 uint32_t
 zdr_fattr3 (ZDR *zdrs, fattr3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_ftype3 (zdrs, &objp->type))
 		 return FALSE;
 	 if (!zdr_mode3 (zdrs, &objp->mode))
@@ -222,9 +180,6 @@ zdr_fattr3 (ZDR *zdrs, fattr3 *objp)
 uint32_t
 zdr_post_op_attr (ZDR *zdrs, post_op_attr *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->attributes_follow))
 		 return FALSE;
 	switch (objp->attributes_follow) {
@@ -243,9 +198,6 @@ zdr_post_op_attr (ZDR *zdrs, post_op_attr *objp)
 uint32_t
 zdr_nfsstat3 (ZDR *zdrs, nfsstat3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -254,9 +206,6 @@ zdr_nfsstat3 (ZDR *zdrs, nfsstat3 *objp)
 uint32_t
 zdr_stable_how (ZDR *zdrs, stable_how *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -265,9 +214,6 @@ zdr_stable_how (ZDR *zdrs, stable_how *objp)
 uint32_t
 zdr_offset3 (ZDR *zdrs, offset3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -276,9 +222,6 @@ zdr_offset3 (ZDR *zdrs, offset3 *objp)
 uint32_t
 zdr_count3 (ZDR *zdrs, count3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -287,9 +230,6 @@ zdr_count3 (ZDR *zdrs, count3 *objp)
 uint32_t
 zdr_wcc_attr (ZDR *zdrs, wcc_attr *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_size3 (zdrs, &objp->size))
 		 return FALSE;
 	 if (!zdr_nfstime3 (zdrs, &objp->mtime))
@@ -302,9 +242,6 @@ zdr_wcc_attr (ZDR *zdrs, wcc_attr *objp)
 uint32_t
 zdr_pre_op_attr (ZDR *zdrs, pre_op_attr *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->attributes_follow))
 		 return FALSE;
 	switch (objp->attributes_follow) {
@@ -323,9 +260,6 @@ zdr_pre_op_attr (ZDR *zdrs, pre_op_attr *objp)
 uint32_t
 zdr_wcc_data (ZDR *zdrs, wcc_data *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pre_op_attr (zdrs, &objp->before))
 		 return FALSE;
 	 if (!zdr_post_op_attr (zdrs, &objp->after))
@@ -336,9 +270,6 @@ zdr_wcc_data (ZDR *zdrs, wcc_data *objp)
 uint32_t
 zdr_WRITE3args (ZDR *zdrs, WRITE3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->file))
 		 return FALSE;
 	 if (!zdr_offset3 (zdrs, &objp->offset))
@@ -355,9 +286,6 @@ zdr_WRITE3args (ZDR *zdrs, WRITE3args *objp)
 uint32_t
 zdr_writeverf3 (ZDR *zdrs, writeverf3 objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, NFS3_WRITEVERFSIZE))
 		 return FALSE;
 	return TRUE;
@@ -366,9 +294,6 @@ zdr_writeverf3 (ZDR *zdrs, writeverf3 objp)
 uint32_t
 zdr_WRITE3resok (ZDR *zdrs, WRITE3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->file_wcc))
 		 return FALSE;
 	 if (!zdr_count3 (zdrs, &objp->count))
@@ -383,9 +308,6 @@ zdr_WRITE3resok (ZDR *zdrs, WRITE3resok *objp)
 uint32_t
 zdr_WRITE3resfail (ZDR *zdrs, WRITE3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->file_wcc))
 		 return FALSE;
 	return TRUE;
@@ -394,9 +316,6 @@ zdr_WRITE3resfail (ZDR *zdrs, WRITE3resfail *objp)
 uint32_t
 zdr_WRITE3res (ZDR *zdrs, WRITE3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -415,9 +334,6 @@ zdr_WRITE3res (ZDR *zdrs, WRITE3res *objp)
 uint32_t
 zdr_LOOKUP3args (ZDR *zdrs, LOOKUP3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->what))
 		 return FALSE;
 	return TRUE;
@@ -426,9 +342,6 @@ zdr_LOOKUP3args (ZDR *zdrs, LOOKUP3args *objp)
 uint32_t
 zdr_LOOKUP3resok (ZDR *zdrs, LOOKUP3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->object))
 		 return FALSE;
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -441,9 +354,6 @@ zdr_LOOKUP3resok (ZDR *zdrs, LOOKUP3resok *objp)
 uint32_t
 zdr_LOOKUP3resfail (ZDR *zdrs, LOOKUP3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->dir_attributes))
 		 return FALSE;
 	return TRUE;
@@ -452,9 +362,6 @@ zdr_LOOKUP3resfail (ZDR *zdrs, LOOKUP3resfail *objp)
 uint32_t
 zdr_LOOKUP3res (ZDR *zdrs, LOOKUP3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -473,9 +380,6 @@ zdr_LOOKUP3res (ZDR *zdrs, LOOKUP3res *objp)
 uint32_t
 zdr_COMMIT3args (ZDR *zdrs, COMMIT3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->file))
 		 return FALSE;
 	 if (!zdr_offset3 (zdrs, &objp->offset))
@@ -488,9 +392,6 @@ zdr_COMMIT3args (ZDR *zdrs, COMMIT3args *objp)
 uint32_t
 zdr_COMMIT3resok (ZDR *zdrs, COMMIT3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->file_wcc))
 		 return FALSE;
 	 if (!zdr_writeverf3 (zdrs, objp->verf))
@@ -501,9 +402,6 @@ zdr_COMMIT3resok (ZDR *zdrs, COMMIT3resok *objp)
 uint32_t
 zdr_COMMIT3resfail (ZDR *zdrs, COMMIT3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->file_wcc))
 		 return FALSE;
 	return TRUE;
@@ -512,9 +410,6 @@ zdr_COMMIT3resfail (ZDR *zdrs, COMMIT3resfail *objp)
 uint32_t
 zdr_COMMIT3res (ZDR *zdrs, COMMIT3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -533,9 +428,6 @@ zdr_COMMIT3res (ZDR *zdrs, COMMIT3res *objp)
 uint32_t
 zdr_ACCESS3args (ZDR *zdrs, ACCESS3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->object))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->access))
@@ -546,9 +438,6 @@ zdr_ACCESS3args (ZDR *zdrs, ACCESS3args *objp)
 uint32_t
 zdr_ACCESS3resok (ZDR *zdrs, ACCESS3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->access))
@@ -559,9 +448,6 @@ zdr_ACCESS3resok (ZDR *zdrs, ACCESS3resok *objp)
 uint32_t
 zdr_ACCESS3resfail (ZDR *zdrs, ACCESS3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -570,9 +456,6 @@ zdr_ACCESS3resfail (ZDR *zdrs, ACCESS3resfail *objp)
 uint32_t
 zdr_ACCESS3res (ZDR *zdrs, ACCESS3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -591,9 +474,6 @@ zdr_ACCESS3res (ZDR *zdrs, ACCESS3res *objp)
 uint32_t
 zdr_GETATTR3args (ZDR *zdrs, GETATTR3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->object))
 		 return FALSE;
 	return TRUE;
@@ -602,9 +482,6 @@ zdr_GETATTR3args (ZDR *zdrs, GETATTR3args *objp)
 uint32_t
 zdr_GETATTR3resok (ZDR *zdrs, GETATTR3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fattr3 (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -613,9 +490,6 @@ zdr_GETATTR3resok (ZDR *zdrs, GETATTR3resok *objp)
 uint32_t
 zdr_GETATTR3res (ZDR *zdrs, GETATTR3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -632,9 +506,6 @@ zdr_GETATTR3res (ZDR *zdrs, GETATTR3res *objp)
 uint32_t
 zdr_time_how (ZDR *zdrs, time_how *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -643,9 +514,6 @@ zdr_time_how (ZDR *zdrs, time_how *objp)
 uint32_t
 zdr_set_mode3 (ZDR *zdrs, set_mode3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -662,9 +530,6 @@ zdr_set_mode3 (ZDR *zdrs, set_mode3 *objp)
 uint32_t
 zdr_set_uid3 (ZDR *zdrs, set_uid3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -681,9 +546,6 @@ zdr_set_uid3 (ZDR *zdrs, set_uid3 *objp)
 uint32_t
 zdr_set_gid3 (ZDR *zdrs, set_gid3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -700,9 +562,6 @@ zdr_set_gid3 (ZDR *zdrs, set_gid3 *objp)
 uint32_t
 zdr_set_size3 (ZDR *zdrs, set_size3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -719,9 +578,6 @@ zdr_set_size3 (ZDR *zdrs, set_size3 *objp)
 uint32_t
 zdr_set_atime (ZDR *zdrs, set_atime *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_time_how (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -738,9 +594,6 @@ zdr_set_atime (ZDR *zdrs, set_atime *objp)
 uint32_t
 zdr_set_mtime (ZDR *zdrs, set_mtime *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_time_how (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -757,9 +610,6 @@ zdr_set_mtime (ZDR *zdrs, set_mtime *objp)
 uint32_t
 zdr_sattr3 (ZDR *zdrs, sattr3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_set_mode3 (zdrs, &objp->mode))
 		 return FALSE;
 	 if (!zdr_set_uid3 (zdrs, &objp->uid))
@@ -778,9 +628,6 @@ zdr_sattr3 (ZDR *zdrs, sattr3 *objp)
 uint32_t
 zdr_createmode3 (ZDR *zdrs, createmode3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -789,9 +636,6 @@ zdr_createmode3 (ZDR *zdrs, createmode3 *objp)
 uint32_t
 zdr_createverf3 (ZDR *zdrs, createverf3 objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, NFS3_CREATEVERFSIZE))
 		 return FALSE;
 	return TRUE;
@@ -800,9 +644,6 @@ zdr_createverf3 (ZDR *zdrs, createverf3 objp)
 uint32_t
 zdr_createhow3 (ZDR *zdrs, createhow3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_createmode3 (zdrs, &objp->mode))
 		 return FALSE;
 	switch (objp->mode) {
@@ -827,9 +668,6 @@ zdr_createhow3 (ZDR *zdrs, createhow3 *objp)
 uint32_t
 zdr_CREATE3args (ZDR *zdrs, CREATE3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->where))
 		 return FALSE;
 	 if (!zdr_createhow3 (zdrs, &objp->how))
@@ -840,9 +678,6 @@ zdr_CREATE3args (ZDR *zdrs, CREATE3args *objp)
 uint32_t
 zdr_post_op_fh3 (ZDR *zdrs, post_op_fh3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->handle_follows))
 		 return FALSE;
 	switch (objp->handle_follows) {
@@ -861,9 +696,6 @@ zdr_post_op_fh3 (ZDR *zdrs, post_op_fh3 *objp)
 uint32_t
 zdr_CREATE3resok (ZDR *zdrs, CREATE3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_fh3 (zdrs, &objp->obj))
 		 return FALSE;
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -876,9 +708,6 @@ zdr_CREATE3resok (ZDR *zdrs, CREATE3resok *objp)
 uint32_t
 zdr_CREATE3resfail (ZDR *zdrs, CREATE3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -887,9 +716,6 @@ zdr_CREATE3resfail (ZDR *zdrs, CREATE3resfail *objp)
 uint32_t
 zdr_CREATE3res (ZDR *zdrs, CREATE3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -908,9 +734,6 @@ zdr_CREATE3res (ZDR *zdrs, CREATE3res *objp)
 uint32_t
 zdr_REMOVE3args (ZDR *zdrs, REMOVE3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->object))
 		 return FALSE;
 	return TRUE;
@@ -919,9 +742,6 @@ zdr_REMOVE3args (ZDR *zdrs, REMOVE3args *objp)
 uint32_t
 zdr_REMOVE3resok (ZDR *zdrs, REMOVE3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -930,9 +750,6 @@ zdr_REMOVE3resok (ZDR *zdrs, REMOVE3resok *objp)
 uint32_t
 zdr_REMOVE3resfail (ZDR *zdrs, REMOVE3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -941,9 +758,6 @@ zdr_REMOVE3resfail (ZDR *zdrs, REMOVE3resfail *objp)
 uint32_t
 zdr_REMOVE3res (ZDR *zdrs, REMOVE3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -962,9 +776,6 @@ zdr_REMOVE3res (ZDR *zdrs, REMOVE3res *objp)
 uint32_t
 zdr_READ3args (ZDR *zdrs, READ3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->file))
 		 return FALSE;
 	 if (!zdr_offset3 (zdrs, &objp->offset))
@@ -977,9 +788,6 @@ zdr_READ3args (ZDR *zdrs, READ3args *objp)
 uint32_t
 zdr_READ3resok (ZDR *zdrs, READ3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->file_attributes))
 		 return FALSE;
 	 if (!zdr_count3 (zdrs, &objp->count))
@@ -994,9 +802,6 @@ zdr_READ3resok (ZDR *zdrs, READ3resok *objp)
 uint32_t
 zdr_READ3resfail (ZDR *zdrs, READ3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->file_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1005,9 +810,6 @@ zdr_READ3resfail (ZDR *zdrs, READ3resfail *objp)
 uint32_t
 zdr_READ3res (ZDR *zdrs, READ3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1026,9 +828,6 @@ zdr_READ3res (ZDR *zdrs, READ3res *objp)
 uint32_t
 zdr_FSINFO3args (ZDR *zdrs, FSINFO3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->fsroot))
 		 return FALSE;
 	return TRUE;
@@ -1038,8 +837,6 @@ uint32_t
 zdr_FSINFO3resok (ZDR *zdrs, FSINFO3resok *objp)
 {
 	register int32_t *buf;
-	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -1143,9 +940,6 @@ zdr_FSINFO3resok (ZDR *zdrs, FSINFO3resok *objp)
 uint32_t
 zdr_FSINFO3resfail (ZDR *zdrs, FSINFO3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1154,9 +948,6 @@ zdr_FSINFO3resfail (ZDR *zdrs, FSINFO3resfail *objp)
 uint32_t
 zdr_FSINFO3res (ZDR *zdrs, FSINFO3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1175,9 +966,6 @@ zdr_FSINFO3res (ZDR *zdrs, FSINFO3res *objp)
 uint32_t
 zdr_FSSTAT3args (ZDR *zdrs, FSSTAT3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->fsroot))
 		 return FALSE;
 	return TRUE;
@@ -1186,9 +974,6 @@ zdr_FSSTAT3args (ZDR *zdrs, FSSTAT3args *objp)
 uint32_t
 zdr_FSSTAT3resok (ZDR *zdrs, FSSTAT3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	 if (!zdr_size3 (zdrs, &objp->tbytes))
@@ -1211,9 +996,6 @@ zdr_FSSTAT3resok (ZDR *zdrs, FSSTAT3resok *objp)
 uint32_t
 zdr_FSSTAT3resfail (ZDR *zdrs, FSSTAT3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1222,9 +1004,6 @@ zdr_FSSTAT3resfail (ZDR *zdrs, FSSTAT3resfail *objp)
 uint32_t
 zdr_FSSTAT3res (ZDR *zdrs, FSSTAT3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1243,9 +1022,6 @@ zdr_FSSTAT3res (ZDR *zdrs, FSSTAT3res *objp)
 uint32_t
 zdr_PATHCONF3args (ZDR *zdrs, PATHCONF3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->object))
 		 return FALSE;
 	return TRUE;
@@ -1255,8 +1031,6 @@ uint32_t
 zdr_PATHCONF3resok (ZDR *zdrs, PATHCONF3resok *objp)
 {
 	register int32_t *buf;
-	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -1332,9 +1106,6 @@ zdr_PATHCONF3resok (ZDR *zdrs, PATHCONF3resok *objp)
 uint32_t
 zdr_PATHCONF3resfail (ZDR *zdrs, PATHCONF3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1343,9 +1114,6 @@ zdr_PATHCONF3resfail (ZDR *zdrs, PATHCONF3resfail *objp)
 uint32_t
 zdr_PATHCONF3res (ZDR *zdrs, PATHCONF3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1364,9 +1132,6 @@ zdr_PATHCONF3res (ZDR *zdrs, PATHCONF3res *objp)
 uint32_t
 zdr_nfspath3 (ZDR *zdrs, nfspath3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, objp, ~0))
 		 return FALSE;
 	return TRUE;
@@ -1375,9 +1140,6 @@ zdr_nfspath3 (ZDR *zdrs, nfspath3 *objp)
 uint32_t
 zdr_symlinkdata3 (ZDR *zdrs, symlinkdata3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_sattr3 (zdrs, &objp->symlink_attributes))
 		 return FALSE;
 	 if (!zdr_nfspath3 (zdrs, &objp->symlink_data))
@@ -1388,9 +1150,6 @@ zdr_symlinkdata3 (ZDR *zdrs, symlinkdata3 *objp)
 uint32_t
 zdr_SYMLINK3args (ZDR *zdrs, SYMLINK3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->where))
 		 return FALSE;
 	 if (!zdr_symlinkdata3 (zdrs, &objp->symlink))
@@ -1401,9 +1160,6 @@ zdr_SYMLINK3args (ZDR *zdrs, SYMLINK3args *objp)
 uint32_t
 zdr_SYMLINK3resok (ZDR *zdrs, SYMLINK3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_fh3 (zdrs, &objp->obj))
 		 return FALSE;
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -1416,9 +1172,6 @@ zdr_SYMLINK3resok (ZDR *zdrs, SYMLINK3resok *objp)
 uint32_t
 zdr_SYMLINK3resfail (ZDR *zdrs, SYMLINK3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -1427,9 +1180,6 @@ zdr_SYMLINK3resfail (ZDR *zdrs, SYMLINK3resfail *objp)
 uint32_t
 zdr_SYMLINK3res (ZDR *zdrs, SYMLINK3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1448,9 +1198,6 @@ zdr_SYMLINK3res (ZDR *zdrs, SYMLINK3res *objp)
 uint32_t
 zdr_READLINK3args (ZDR *zdrs, READLINK3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->symlink))
 		 return FALSE;
 	return TRUE;
@@ -1459,9 +1206,6 @@ zdr_READLINK3args (ZDR *zdrs, READLINK3args *objp)
 uint32_t
 zdr_READLINK3resok (ZDR *zdrs, READLINK3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->symlink_attributes))
 		 return FALSE;
 	 if (!zdr_nfspath3 (zdrs, &objp->data))
@@ -1472,9 +1216,6 @@ zdr_READLINK3resok (ZDR *zdrs, READLINK3resok *objp)
 uint32_t
 zdr_READLINK3resfail (ZDR *zdrs, READLINK3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->symlink_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1483,9 +1224,6 @@ zdr_READLINK3resfail (ZDR *zdrs, READLINK3resfail *objp)
 uint32_t
 zdr_READLINK3res (ZDR *zdrs, READLINK3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1504,9 +1242,6 @@ zdr_READLINK3res (ZDR *zdrs, READLINK3res *objp)
 uint32_t
 zdr_devicedata3 (ZDR *zdrs, devicedata3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_sattr3 (zdrs, &objp->dev_attributes))
 		 return FALSE;
 	 if (!zdr_specdata3 (zdrs, &objp->spec))
@@ -1517,9 +1252,6 @@ zdr_devicedata3 (ZDR *zdrs, devicedata3 *objp)
 uint32_t
 zdr_mknoddata3 (ZDR *zdrs, mknoddata3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_ftype3 (zdrs, &objp->type))
 		 return FALSE;
 	switch (objp->type) {
@@ -1548,9 +1280,6 @@ zdr_mknoddata3 (ZDR *zdrs, mknoddata3 *objp)
 uint32_t
 zdr_MKNOD3args (ZDR *zdrs, MKNOD3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->where))
 		 return FALSE;
 	 if (!zdr_mknoddata3 (zdrs, &objp->what))
@@ -1561,9 +1290,6 @@ zdr_MKNOD3args (ZDR *zdrs, MKNOD3args *objp)
 uint32_t
 zdr_MKNOD3resok (ZDR *zdrs, MKNOD3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_fh3 (zdrs, &objp->obj))
 		 return FALSE;
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -1576,9 +1302,6 @@ zdr_MKNOD3resok (ZDR *zdrs, MKNOD3resok *objp)
 uint32_t
 zdr_MKNOD3resfail (ZDR *zdrs, MKNOD3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -1587,9 +1310,6 @@ zdr_MKNOD3resfail (ZDR *zdrs, MKNOD3resfail *objp)
 uint32_t
 zdr_MKNOD3res (ZDR *zdrs, MKNOD3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1608,9 +1328,6 @@ zdr_MKNOD3res (ZDR *zdrs, MKNOD3res *objp)
 uint32_t
 zdr_MKDIR3args (ZDR *zdrs, MKDIR3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->where))
 		 return FALSE;
 	 if (!zdr_sattr3 (zdrs, &objp->attributes))
@@ -1621,9 +1338,6 @@ zdr_MKDIR3args (ZDR *zdrs, MKDIR3args *objp)
 uint32_t
 zdr_MKDIR3resok (ZDR *zdrs, MKDIR3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_fh3 (zdrs, &objp->obj))
 		 return FALSE;
 	 if (!zdr_post_op_attr (zdrs, &objp->obj_attributes))
@@ -1636,9 +1350,6 @@ zdr_MKDIR3resok (ZDR *zdrs, MKDIR3resok *objp)
 uint32_t
 zdr_MKDIR3resfail (ZDR *zdrs, MKDIR3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -1647,9 +1358,6 @@ zdr_MKDIR3resfail (ZDR *zdrs, MKDIR3resfail *objp)
 uint32_t
 zdr_MKDIR3res (ZDR *zdrs, MKDIR3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1668,9 +1376,6 @@ zdr_MKDIR3res (ZDR *zdrs, MKDIR3res *objp)
 uint32_t
 zdr_RMDIR3args (ZDR *zdrs, RMDIR3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->object))
 		 return FALSE;
 	return TRUE;
@@ -1679,9 +1384,6 @@ zdr_RMDIR3args (ZDR *zdrs, RMDIR3args *objp)
 uint32_t
 zdr_RMDIR3resok (ZDR *zdrs, RMDIR3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -1690,9 +1392,6 @@ zdr_RMDIR3resok (ZDR *zdrs, RMDIR3resok *objp)
 uint32_t
 zdr_RMDIR3resfail (ZDR *zdrs, RMDIR3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->dir_wcc))
 		 return FALSE;
 	return TRUE;
@@ -1701,9 +1400,6 @@ zdr_RMDIR3resfail (ZDR *zdrs, RMDIR3resfail *objp)
 uint32_t
 zdr_RMDIR3res (ZDR *zdrs, RMDIR3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1722,9 +1418,6 @@ zdr_RMDIR3res (ZDR *zdrs, RMDIR3res *objp)
 uint32_t
 zdr_RENAME3args (ZDR *zdrs, RENAME3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs3 (zdrs, &objp->from))
 		 return FALSE;
 	 if (!zdr_diropargs3 (zdrs, &objp->to))
@@ -1735,9 +1428,6 @@ zdr_RENAME3args (ZDR *zdrs, RENAME3args *objp)
 uint32_t
 zdr_RENAME3resok (ZDR *zdrs, RENAME3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->fromdir_wcc))
 		 return FALSE;
 	 if (!zdr_wcc_data (zdrs, &objp->todir_wcc))
@@ -1748,9 +1438,6 @@ zdr_RENAME3resok (ZDR *zdrs, RENAME3resok *objp)
 uint32_t
 zdr_RENAME3resfail (ZDR *zdrs, RENAME3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->fromdir_wcc))
 		 return FALSE;
 	 if (!zdr_wcc_data (zdrs, &objp->todir_wcc))
@@ -1761,9 +1448,6 @@ zdr_RENAME3resfail (ZDR *zdrs, RENAME3resfail *objp)
 uint32_t
 zdr_RENAME3res (ZDR *zdrs, RENAME3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1782,9 +1466,6 @@ zdr_RENAME3res (ZDR *zdrs, RENAME3res *objp)
 uint32_t
 zdr_READDIRPLUS3args (ZDR *zdrs, READDIRPLUS3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->dir))
 		 return FALSE;
 	 if (!zdr_cookie3 (zdrs, &objp->cookie))
@@ -1801,9 +1482,6 @@ zdr_READDIRPLUS3args (ZDR *zdrs, READDIRPLUS3args *objp)
 uint32_t
 zdr_entryplus3 (ZDR *zdrs, entryplus3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fileid3 (zdrs, &objp->fileid))
 		 return FALSE;
 	 if (!zdr_filename3 (zdrs, &objp->name))
@@ -1822,9 +1500,6 @@ zdr_entryplus3 (ZDR *zdrs, entryplus3 *objp)
 uint32_t
 zdr_dirlistplus3 (ZDR *zdrs, dirlistplus3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pointer (zdrs, (char **)&objp->entries, sizeof (entryplus3), (zdrproc_t) zdr_entryplus3))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->eof))
@@ -1835,9 +1510,6 @@ zdr_dirlistplus3 (ZDR *zdrs, dirlistplus3 *objp)
 uint32_t
 zdr_READDIRPLUS3resok (ZDR *zdrs, READDIRPLUS3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->dir_attributes))
 		 return FALSE;
 	 if (!zdr_cookieverf3 (zdrs, objp->cookieverf))
@@ -1850,9 +1522,6 @@ zdr_READDIRPLUS3resok (ZDR *zdrs, READDIRPLUS3resok *objp)
 uint32_t
 zdr_READDIRPLUS3resfail (ZDR *zdrs, READDIRPLUS3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->dir_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1861,9 +1530,6 @@ zdr_READDIRPLUS3resfail (ZDR *zdrs, READDIRPLUS3resfail *objp)
 uint32_t
 zdr_READDIRPLUS3res (ZDR *zdrs, READDIRPLUS3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1882,9 +1548,6 @@ zdr_READDIRPLUS3res (ZDR *zdrs, READDIRPLUS3res *objp)
 uint32_t
 zdr_READDIR3args (ZDR *zdrs, READDIR3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->dir))
 		 return FALSE;
 	 if (!zdr_cookie3 (zdrs, &objp->cookie))
@@ -1899,9 +1562,6 @@ zdr_READDIR3args (ZDR *zdrs, READDIR3args *objp)
 uint32_t
 zdr_entry3 (ZDR *zdrs, entry3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fileid3 (zdrs, &objp->fileid))
 		 return FALSE;
 	 if (!zdr_filename3 (zdrs, &objp->name))
@@ -1916,9 +1576,6 @@ zdr_entry3 (ZDR *zdrs, entry3 *objp)
 uint32_t
 zdr_dirlist3 (ZDR *zdrs, dirlist3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pointer (zdrs, (char **)&objp->entries, sizeof (entry3), (zdrproc_t) zdr_entry3))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->eof))
@@ -1929,9 +1586,6 @@ zdr_dirlist3 (ZDR *zdrs, dirlist3 *objp)
 uint32_t
 zdr_READDIR3resok (ZDR *zdrs, READDIR3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->dir_attributes))
 		 return FALSE;
 	 if (!zdr_cookieverf3 (zdrs, objp->cookieverf))
@@ -1944,9 +1598,6 @@ zdr_READDIR3resok (ZDR *zdrs, READDIR3resok *objp)
 uint32_t
 zdr_READDIR3resfail (ZDR *zdrs, READDIR3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->dir_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1955,9 +1606,6 @@ zdr_READDIR3resfail (ZDR *zdrs, READDIR3resfail *objp)
 uint32_t
 zdr_READDIR3res (ZDR *zdrs, READDIR3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1976,9 +1624,6 @@ zdr_READDIR3res (ZDR *zdrs, READDIR3res *objp)
 uint32_t
 zdr_LINK3args (ZDR *zdrs, LINK3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->file))
 		 return FALSE;
 	 if (!zdr_diropargs3 (zdrs, &objp->link))
@@ -1989,9 +1634,6 @@ zdr_LINK3args (ZDR *zdrs, LINK3args *objp)
 uint32_t
 zdr_LINK3resok (ZDR *zdrs, LINK3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->file_attributes))
 		 return FALSE;
 	 if (!zdr_wcc_data (zdrs, &objp->linkdir_wcc))
@@ -2002,9 +1644,6 @@ zdr_LINK3resok (ZDR *zdrs, LINK3resok *objp)
 uint32_t
 zdr_LINK3resfail (ZDR *zdrs, LINK3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->file_attributes))
 		 return FALSE;
 	 if (!zdr_wcc_data (zdrs, &objp->linkdir_wcc))
@@ -2015,9 +1654,6 @@ zdr_LINK3resfail (ZDR *zdrs, LINK3resfail *objp)
 uint32_t
 zdr_LINK3res (ZDR *zdrs, LINK3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2036,9 +1672,6 @@ zdr_LINK3res (ZDR *zdrs, LINK3res *objp)
 uint32_t
 zdr_sattrguard3 (ZDR *zdrs, sattrguard3 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->check))
 		 return FALSE;
 	switch (objp->check) {
@@ -2057,9 +1690,6 @@ zdr_sattrguard3 (ZDR *zdrs, sattrguard3 *objp)
 uint32_t
 zdr_SETATTR3args (ZDR *zdrs, SETATTR3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->object))
 		 return FALSE;
 	 if (!zdr_sattr3 (zdrs, &objp->new_attributes))
@@ -2072,9 +1702,6 @@ zdr_SETATTR3args (ZDR *zdrs, SETATTR3args *objp)
 uint32_t
 zdr_SETATTR3resok (ZDR *zdrs, SETATTR3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->obj_wcc))
 		 return FALSE;
 	return TRUE;
@@ -2083,9 +1710,6 @@ zdr_SETATTR3resok (ZDR *zdrs, SETATTR3resok *objp)
 uint32_t
 zdr_SETATTR3resfail (ZDR *zdrs, SETATTR3resfail *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_wcc_data (zdrs, &objp->obj_wcc))
 		 return FALSE;
 	return TRUE;
@@ -2094,9 +1718,6 @@ zdr_SETATTR3resfail (ZDR *zdrs, SETATTR3resfail *objp)
 uint32_t
 zdr_SETATTR3res (ZDR *zdrs, SETATTR3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2115,9 +1736,6 @@ zdr_SETATTR3res (ZDR *zdrs, SETATTR3res *objp)
 uint32_t
 zdr_fhandle2 (ZDR *zdrs, fhandle2 objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, FHSIZE2))
 		 return FALSE;
 	return TRUE;
@@ -2126,9 +1744,6 @@ zdr_fhandle2 (ZDR *zdrs, fhandle2 objp)
 uint32_t
 zdr_ftype2 (ZDR *zdrs, ftype2 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -2138,8 +1753,6 @@ uint32_t
 zdr_fattr2 (ZDR *zdrs, fattr2 *objp)
 {
 	register int32_t *buf;
-	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		 if (!zdr_ftype2 (zdrs, &objp->type))
@@ -2268,8 +1881,6 @@ uint32_t
 zdr_sattr2 (ZDR *zdrs, sattr2 *objp)
 {
 	register int32_t *buf;
-	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		buf = ZDR_INLINE (zdrs, 4 * BYTES_PER_ZDR_UNIT);
@@ -2337,9 +1948,6 @@ zdr_sattr2 (ZDR *zdrs, sattr2 *objp)
 uint32_t
 zdr_filename2 (ZDR *zdrs, filename2 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, objp, MAXNAMLEN2))
 		 return FALSE;
 	return TRUE;
@@ -2348,9 +1956,6 @@ zdr_filename2 (ZDR *zdrs, filename2 *objp)
 uint32_t
 zdr_path2 (ZDR *zdrs, path2 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_string (zdrs, objp, MAXPATHLEN2))
 		 return FALSE;
 	return TRUE;
@@ -2359,9 +1964,6 @@ zdr_path2 (ZDR *zdrs, path2 *objp)
 uint32_t
 zdr_nfsdata2 (ZDR *zdrs, nfsdata2 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->nfsdata2_val, (u_int *) &objp->nfsdata2_len, NFSMAXDATA2))
 		 return FALSE;
 	return TRUE;
@@ -2370,9 +1972,6 @@ zdr_nfsdata2 (ZDR *zdrs, nfsdata2 *objp)
 uint32_t
 zdr_nfscookie2 (ZDR *zdrs, nfscookie2 objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, NFSCOOKIESIZE2))
 		 return FALSE;
 	return TRUE;
@@ -2381,9 +1980,6 @@ zdr_nfscookie2 (ZDR *zdrs, nfscookie2 objp)
 uint32_t
 zdr_entry2 (ZDR *zdrs, entry2 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->fileid))
 		 return FALSE;
 	 if (!zdr_filename2 (zdrs, &objp->name))
@@ -2398,9 +1994,6 @@ zdr_entry2 (ZDR *zdrs, entry2 *objp)
 uint32_t
 zdr_diropargs2 (ZDR *zdrs, diropargs2 *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->dir))
 		 return FALSE;
 	 if (!zdr_filename2 (zdrs, &objp->name))
@@ -2411,9 +2004,6 @@ zdr_diropargs2 (ZDR *zdrs, diropargs2 *objp)
 uint32_t
 zdr_GETATTR2args (ZDR *zdrs, GETATTR2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->fhandle))
 		 return FALSE;
 	return TRUE;
@@ -2422,9 +2012,6 @@ zdr_GETATTR2args (ZDR *zdrs, GETATTR2args *objp)
 uint32_t
 zdr_GETATTR2resok (ZDR *zdrs, GETATTR2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
 		 return FALSE;
 	return TRUE;
@@ -2433,9 +2020,6 @@ zdr_GETATTR2resok (ZDR *zdrs, GETATTR2resok *objp)
 uint32_t
 zdr_GETATTR2res (ZDR *zdrs, GETATTR2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2452,9 +2036,6 @@ zdr_GETATTR2res (ZDR *zdrs, GETATTR2res *objp)
 uint32_t
 zdr_SETATTR2args (ZDR *zdrs, SETATTR2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->fhandle))
 		 return FALSE;
 	 if (!zdr_sattr2 (zdrs, &objp->attributes))
@@ -2465,9 +2046,6 @@ zdr_SETATTR2args (ZDR *zdrs, SETATTR2args *objp)
 uint32_t
 zdr_SETATTR2resok (ZDR *zdrs, SETATTR2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
 		 return FALSE;
 	return TRUE;
@@ -2476,9 +2054,6 @@ zdr_SETATTR2resok (ZDR *zdrs, SETATTR2resok *objp)
 uint32_t
 zdr_SETATTR2res (ZDR *zdrs, SETATTR2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2495,9 +2070,6 @@ zdr_SETATTR2res (ZDR *zdrs, SETATTR2res *objp)
 uint32_t
 zdr_LOOKUP2args (ZDR *zdrs, LOOKUP2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->what))
 		 return FALSE;
 	return TRUE;
@@ -2506,9 +2078,6 @@ zdr_LOOKUP2args (ZDR *zdrs, LOOKUP2args *objp)
 uint32_t
 zdr_LOOKUP2resok (ZDR *zdrs, LOOKUP2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->file))
 		 return FALSE;
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
@@ -2519,9 +2088,6 @@ zdr_LOOKUP2resok (ZDR *zdrs, LOOKUP2resok *objp)
 uint32_t
 zdr_LOOKUP2res (ZDR *zdrs, LOOKUP2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2538,9 +2104,6 @@ zdr_LOOKUP2res (ZDR *zdrs, LOOKUP2res *objp)
 uint32_t
 zdr_READLINK2args (ZDR *zdrs, READLINK2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->file))
 		 return FALSE;
 	return TRUE;
@@ -2549,9 +2112,6 @@ zdr_READLINK2args (ZDR *zdrs, READLINK2args *objp)
 uint32_t
 zdr_READLINK2resok (ZDR *zdrs, READLINK2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_path2 (zdrs, &objp->data))
 		 return FALSE;
 	return TRUE;
@@ -2560,9 +2120,6 @@ zdr_READLINK2resok (ZDR *zdrs, READLINK2resok *objp)
 uint32_t
 zdr_READLINK2res (ZDR *zdrs, READLINK2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2579,9 +2136,6 @@ zdr_READLINK2res (ZDR *zdrs, READLINK2res *objp)
 uint32_t
 zdr_READ2args (ZDR *zdrs, READ2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->file))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->offset))
@@ -2596,9 +2150,6 @@ zdr_READ2args (ZDR *zdrs, READ2args *objp)
 uint32_t
 zdr_READ2resok (ZDR *zdrs, READ2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
 		 return FALSE;
 	 if (!zdr_nfsdata2 (zdrs, &objp->data))
@@ -2609,9 +2160,6 @@ zdr_READ2resok (ZDR *zdrs, READ2resok *objp)
 uint32_t
 zdr_READ2res (ZDR *zdrs, READ2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2629,8 +2177,6 @@ uint32_t
 zdr_WRITE2args (ZDR *zdrs, WRITE2args *objp)
 {
 	register int32_t *buf;
-	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		 if (!zdr_fhandle2 (zdrs, objp->file))
@@ -2690,9 +2236,6 @@ zdr_WRITE2args (ZDR *zdrs, WRITE2args *objp)
 uint32_t
 zdr_WRITE2resok (ZDR *zdrs, WRITE2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
 		 return FALSE;
 	return TRUE;
@@ -2701,9 +2244,6 @@ zdr_WRITE2resok (ZDR *zdrs, WRITE2resok *objp)
 uint32_t
 zdr_WRITE2res (ZDR *zdrs, WRITE2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2720,9 +2260,6 @@ zdr_WRITE2res (ZDR *zdrs, WRITE2res *objp)
 uint32_t
 zdr_CREATE2args (ZDR *zdrs, CREATE2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->where))
 		 return FALSE;
 	 if (!zdr_sattr2 (zdrs, &objp->attributes))
@@ -2733,9 +2270,6 @@ zdr_CREATE2args (ZDR *zdrs, CREATE2args *objp)
 uint32_t
 zdr_CREATE2resok (ZDR *zdrs, CREATE2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->file))
 		 return FALSE;
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
@@ -2746,9 +2280,6 @@ zdr_CREATE2resok (ZDR *zdrs, CREATE2resok *objp)
 uint32_t
 zdr_CREATE2res (ZDR *zdrs, CREATE2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2765,9 +2296,6 @@ zdr_CREATE2res (ZDR *zdrs, CREATE2res *objp)
 uint32_t
 zdr_REMOVE2args (ZDR *zdrs, REMOVE2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->what))
 		 return FALSE;
 	return TRUE;
@@ -2776,9 +2304,6 @@ zdr_REMOVE2args (ZDR *zdrs, REMOVE2args *objp)
 uint32_t
 zdr_REMOVE2res (ZDR *zdrs, REMOVE2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2787,9 +2312,6 @@ zdr_REMOVE2res (ZDR *zdrs, REMOVE2res *objp)
 uint32_t
 zdr_RENAME2args (ZDR *zdrs, RENAME2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->from))
 		 return FALSE;
 	 if (!zdr_diropargs2 (zdrs, &objp->to))
@@ -2800,9 +2322,6 @@ zdr_RENAME2args (ZDR *zdrs, RENAME2args *objp)
 uint32_t
 zdr_RENAME2res (ZDR *zdrs, RENAME2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2811,9 +2330,6 @@ zdr_RENAME2res (ZDR *zdrs, RENAME2res *objp)
 uint32_t
 zdr_LINK2args (ZDR *zdrs, LINK2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->from))
 		 return FALSE;
 	 if (!zdr_diropargs2 (zdrs, &objp->to))
@@ -2824,9 +2340,6 @@ zdr_LINK2args (ZDR *zdrs, LINK2args *objp)
 uint32_t
 zdr_LINK2res (ZDR *zdrs, LINK2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2835,9 +2348,6 @@ zdr_LINK2res (ZDR *zdrs, LINK2res *objp)
 uint32_t
 zdr_SYMLINK2args (ZDR *zdrs, SYMLINK2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->from))
 		 return FALSE;
 	 if (!zdr_path2 (zdrs, &objp->to))
@@ -2850,9 +2360,6 @@ zdr_SYMLINK2args (ZDR *zdrs, SYMLINK2args *objp)
 uint32_t
 zdr_SYMLINK2res (ZDR *zdrs, SYMLINK2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2861,9 +2368,6 @@ zdr_SYMLINK2res (ZDR *zdrs, SYMLINK2res *objp)
 uint32_t
 zdr_MKDIR2args (ZDR *zdrs, MKDIR2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->where))
 		 return FALSE;
 	 if (!zdr_sattr2 (zdrs, &objp->attributes))
@@ -2874,9 +2378,6 @@ zdr_MKDIR2args (ZDR *zdrs, MKDIR2args *objp)
 uint32_t
 zdr_MKDIR2resok (ZDR *zdrs, MKDIR2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->file))
 		 return FALSE;
 	 if (!zdr_fattr2 (zdrs, &objp->attributes))
@@ -2887,9 +2388,6 @@ zdr_MKDIR2resok (ZDR *zdrs, MKDIR2resok *objp)
 uint32_t
 zdr_MKDIR2res (ZDR *zdrs, MKDIR2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2906,9 +2404,6 @@ zdr_MKDIR2res (ZDR *zdrs, MKDIR2res *objp)
 uint32_t
 zdr_RMDIR2args (ZDR *zdrs, RMDIR2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_diropargs2 (zdrs, &objp->what))
 		 return FALSE;
 	return TRUE;
@@ -2917,9 +2412,6 @@ zdr_RMDIR2args (ZDR *zdrs, RMDIR2args *objp)
 uint32_t
 zdr_RMDIR2res (ZDR *zdrs, RMDIR2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2928,9 +2420,6 @@ zdr_RMDIR2res (ZDR *zdrs, RMDIR2res *objp)
 uint32_t
 zdr_READDIR2args (ZDR *zdrs, READDIR2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->dir))
 		 return FALSE;
 	 if (!zdr_nfscookie2 (zdrs, objp->cookie))
@@ -2943,9 +2432,6 @@ zdr_READDIR2args (ZDR *zdrs, READDIR2args *objp)
 uint32_t
 zdr_READDIR2resok (ZDR *zdrs, READDIR2resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_pointer (zdrs, (char **)&objp->entries, sizeof (entry2), (zdrproc_t) zdr_entry2))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->eof))
@@ -2956,9 +2442,6 @@ zdr_READDIR2resok (ZDR *zdrs, READDIR2resok *objp)
 uint32_t
 zdr_READDIR2res (ZDR *zdrs, READDIR2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2975,9 +2458,6 @@ zdr_READDIR2res (ZDR *zdrs, READDIR2res *objp)
 uint32_t
 zdr_STATFS2args (ZDR *zdrs, STATFS2args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_fhandle2 (zdrs, objp->dir))
 		 return FALSE;
 	return TRUE;
@@ -2987,8 +2467,6 @@ uint32_t
 zdr_STATFS2resok (ZDR *zdrs, STATFS2resok *objp)
 {
 	register int32_t *buf;
-	buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		buf = ZDR_INLINE (zdrs, 5 * BYTES_PER_ZDR_UNIT);
@@ -3050,9 +2528,6 @@ zdr_STATFS2resok (ZDR *zdrs, STATFS2resok *objp)
 uint32_t
 zdr_STATFS2res (ZDR *zdrs, STATFS2res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -3069,9 +2544,6 @@ zdr_STATFS2res (ZDR *zdrs, STATFS2res *objp)
 uint32_t
 zdr_nfsacl_type (ZDR *zdrs, nfsacl_type *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -3080,9 +2552,6 @@ zdr_nfsacl_type (ZDR *zdrs, nfsacl_type *objp)
 uint32_t
 zdr_nfsacl_ace (ZDR *zdrs, nfsacl_ace *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsacl_type (zdrs, &objp->type))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->id))
@@ -3095,9 +2564,6 @@ zdr_nfsacl_ace (ZDR *zdrs, nfsacl_ace *objp)
 uint32_t
 zdr_GETACL3args (ZDR *zdrs, GETACL3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->dir))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->mask))
@@ -3108,9 +2574,6 @@ zdr_GETACL3args (ZDR *zdrs, GETACL3args *objp)
 uint32_t
 zdr_GETACL3resok (ZDR *zdrs, GETACL3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->attr))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->mask))
@@ -3131,9 +2594,6 @@ zdr_GETACL3resok (ZDR *zdrs, GETACL3resok *objp)
 uint32_t
 zdr_GETACL3res (ZDR *zdrs, GETACL3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -3150,9 +2610,6 @@ zdr_GETACL3res (ZDR *zdrs, GETACL3res *objp)
 uint32_t
 zdr_SETACL3args (ZDR *zdrs, SETACL3args *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfs_fh3 (zdrs, &objp->dir))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->mask))
@@ -3173,9 +2630,6 @@ zdr_SETACL3args (ZDR *zdrs, SETACL3args *objp)
 uint32_t
 zdr_SETACL3resok (ZDR *zdrs, SETACL3resok *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_post_op_attr (zdrs, &objp->attr))
 		 return FALSE;
 	return TRUE;
@@ -3184,9 +2638,6 @@ zdr_SETACL3resok (ZDR *zdrs, SETACL3resok *objp)
 uint32_t
 zdr_SETACL3res (ZDR *zdrs, SETACL3res *objp)
 {
-	register int32_t *buf;
-	buf = NULL;
-
 	 if (!zdr_nfsstat3 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {

--- a/nfs/nfs.c
+++ b/nfs/nfs.c
@@ -361,7 +361,7 @@ struct rpc_pdu *rpc_nfs3_write_task(struct rpc_context *rpc, rpc_cb cb,
         /* We may need to pad this to 4 byte boundary */
         if (args->data.data_len & 0x03) {
                 if (rpc_add_iovector(rpc, &pdu->out, (char *)&zero_padding,
-                                     4 - args->data.data_len & 0x03,
+                                     4 - (args->data.data_len & 0x03),
                                      NULL) < 0) {
                         rpc_free_pdu(rpc, pdu);
                         return NULL;

--- a/nfs4/libnfs-raw-nfs4.c
+++ b/nfs4/libnfs-raw-nfs4.c
@@ -25,9 +25,6 @@
 uint32_t
 zdr_nfs_ftype4 (ZDR *zdrs, nfs_ftype4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -36,9 +33,6 @@ zdr_nfs_ftype4 (ZDR *zdrs, nfs_ftype4 *objp)
 uint32_t
 zdr_nfsstat4 (ZDR *zdrs, nfsstat4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -47,9 +41,6 @@ zdr_nfsstat4 (ZDR *zdrs, nfsstat4 *objp)
 uint32_t
 zdr_bitmap4 (ZDR *zdrs, bitmap4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_array (zdrs, (char **)&objp->bitmap4_val, (u_int *) &objp->bitmap4_len, ~0,
 		sizeof (uint32_t), (zdrproc_t) zdr_uint32_t))
 		 return FALSE;
@@ -59,9 +50,6 @@ zdr_bitmap4 (ZDR *zdrs, bitmap4 *objp)
 uint32_t
 zdr_offset4 (ZDR *zdrs, offset4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -70,9 +58,6 @@ zdr_offset4 (ZDR *zdrs, offset4 *objp)
 uint32_t
 zdr_count4 (ZDR *zdrs, count4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -81,9 +66,6 @@ zdr_count4 (ZDR *zdrs, count4 *objp)
 uint32_t
 zdr_length4 (ZDR *zdrs, length4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -92,9 +74,6 @@ zdr_length4 (ZDR *zdrs, length4 *objp)
 uint32_t
 zdr_clientid4 (ZDR *zdrs, clientid4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -103,9 +82,6 @@ zdr_clientid4 (ZDR *zdrs, clientid4 *objp)
 uint32_t
 zdr_sequenceid4 (ZDR *zdrs, sequenceid4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -114,9 +90,6 @@ zdr_sequenceid4 (ZDR *zdrs, sequenceid4 *objp)
 uint32_t
 zdr_seqid4 (ZDR *zdrs, seqid4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -125,9 +98,6 @@ zdr_seqid4 (ZDR *zdrs, seqid4 *objp)
 uint32_t
 zdr_slotid4 (ZDR *zdrs, slotid4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -136,9 +106,6 @@ zdr_slotid4 (ZDR *zdrs, slotid4 *objp)
 uint32_t
 zdr_utf8string (ZDR *zdrs, utf8string *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->utf8string_val, (u_int *) &objp->utf8string_len, ~0))
 		 return FALSE;
 	return TRUE;
@@ -147,9 +114,6 @@ zdr_utf8string (ZDR *zdrs, utf8string *objp)
 uint32_t
 zdr_utf8str_cis (ZDR *zdrs, utf8str_cis *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_utf8string (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -158,9 +122,6 @@ zdr_utf8str_cis (ZDR *zdrs, utf8str_cis *objp)
 uint32_t
 zdr_utf8str_cs (ZDR *zdrs, utf8str_cs *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_utf8string (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -169,9 +130,6 @@ zdr_utf8str_cs (ZDR *zdrs, utf8str_cs *objp)
 uint32_t
 zdr_utf8str_mixed (ZDR *zdrs, utf8str_mixed *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_utf8string (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -180,9 +138,6 @@ zdr_utf8str_mixed (ZDR *zdrs, utf8str_mixed *objp)
 uint32_t
 zdr_component4 (ZDR *zdrs, component4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_utf8str_cs (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -191,9 +146,6 @@ zdr_component4 (ZDR *zdrs, component4 *objp)
 uint32_t
 zdr_pathname4 (ZDR *zdrs, pathname4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_array (zdrs, (char **)&objp->pathname4_val, (u_int *) &objp->pathname4_len, ~0,
 		sizeof (component4), (zdrproc_t) zdr_component4))
 		 return FALSE;
@@ -203,9 +155,6 @@ zdr_pathname4 (ZDR *zdrs, pathname4 *objp)
 uint32_t
 zdr_nfs_lockid4 (ZDR *zdrs, nfs_lockid4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -214,9 +163,6 @@ zdr_nfs_lockid4 (ZDR *zdrs, nfs_lockid4 *objp)
 uint32_t
 zdr_nfs_cookie4 (ZDR *zdrs, nfs_cookie4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -225,9 +171,6 @@ zdr_nfs_cookie4 (ZDR *zdrs, nfs_cookie4 *objp)
 uint32_t
 zdr_linktext4 (ZDR *zdrs, linktext4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_utf8str_cs (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -236,9 +179,6 @@ zdr_linktext4 (ZDR *zdrs, linktext4 *objp)
 uint32_t
 zdr_sec_oid4 (ZDR *zdrs, sec_oid4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->sec_oid4_val, (u_int *) &objp->sec_oid4_len, ~0))
 		 return FALSE;
 	return TRUE;
@@ -247,9 +187,6 @@ zdr_sec_oid4 (ZDR *zdrs, sec_oid4 *objp)
 uint32_t
 zdr_qop4 (ZDR *zdrs, qop4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -258,9 +195,6 @@ zdr_qop4 (ZDR *zdrs, qop4 *objp)
 uint32_t
 zdr_mode4 (ZDR *zdrs, mode4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -269,9 +203,6 @@ zdr_mode4 (ZDR *zdrs, mode4 *objp)
 uint32_t
 zdr_changeid4 (ZDR *zdrs, changeid4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -280,9 +211,6 @@ zdr_changeid4 (ZDR *zdrs, changeid4 *objp)
 uint32_t
 zdr_verifier4 (ZDR *zdrs, verifier4 objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, NFS4_VERIFIER_SIZE))
 		 return FALSE;
 	return TRUE;
@@ -291,9 +219,6 @@ zdr_verifier4 (ZDR *zdrs, verifier4 objp)
 uint32_t
 zdr_sessionid4 (ZDR *zdrs, sessionid4 objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, NFS4_SESSIONID_SIZE))
 		 return FALSE;
 	return TRUE;
@@ -302,9 +227,6 @@ zdr_sessionid4 (ZDR *zdrs, sessionid4 objp)
 uint32_t
 zdr_authsys_parms (ZDR *zdrs, authsys_parms *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->stamp))
 		 return FALSE;
 	 if (!zdr_string (zdrs, &objp->machinename, 255))
@@ -322,9 +244,6 @@ zdr_authsys_parms (ZDR *zdrs, authsys_parms *objp)
 uint32_t
 zdr_deviceid4 (ZDR *zdrs, deviceid4 objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_opaque (zdrs, objp, NFS4_DEVICEID4_SIZE))
 		 return FALSE;
 	return TRUE;
@@ -333,9 +252,6 @@ zdr_deviceid4 (ZDR *zdrs, deviceid4 objp)
 uint32_t
 zdr_layouttype4 (ZDR *zdrs, layouttype4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -344,9 +260,6 @@ zdr_layouttype4 (ZDR *zdrs, layouttype4 *objp)
 uint32_t
 zdr_layoutupdate4 (ZDR *zdrs, layoutupdate4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_layouttype4 (zdrs, &objp->lou_type))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->lou_body.lou_body_val, (u_int *) &objp->lou_body.lou_body_len, ~0))
@@ -357,9 +270,6 @@ zdr_layoutupdate4 (ZDR *zdrs, layoutupdate4 *objp)
 uint32_t
 zdr_device_addr4 (ZDR *zdrs, device_addr4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_layouttype4 (zdrs, &objp->da_layout_type))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->da_addr_body.da_addr_body_val, (u_int *) &objp->da_addr_body.da_addr_body_len, ~0))
@@ -370,9 +280,6 @@ zdr_device_addr4 (ZDR *zdrs, device_addr4 *objp)
 uint32_t
 zdr_nfstime4 (ZDR *zdrs, nfstime4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_int64_t (zdrs, &objp->seconds))
 		 return FALSE;
 	 if (!zdr_uint32_t (zdrs, &objp->nseconds))
@@ -383,9 +290,6 @@ zdr_nfstime4 (ZDR *zdrs, nfstime4 *objp)
 uint32_t
 zdr_time_how4 (ZDR *zdrs, time_how4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -394,9 +298,6 @@ zdr_time_how4 (ZDR *zdrs, time_how4 *objp)
 uint32_t
 zdr_layoutiomode4 (ZDR *zdrs, layoutiomode4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -405,9 +306,6 @@ zdr_layoutiomode4 (ZDR *zdrs, layoutiomode4 *objp)
 uint32_t
 zdr_layout_content4 (ZDR *zdrs, layout_content4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_layouttype4 (zdrs, &objp->loc_type))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->loc_body.loc_body_val, (u_int *) &objp->loc_body.loc_body_len, ~0))
@@ -418,9 +316,6 @@ zdr_layout_content4 (ZDR *zdrs, layout_content4 *objp)
 uint32_t
 zdr_layout4 (ZDR *zdrs, layout4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_offset4 (zdrs, &objp->lo_offset))
 		 return FALSE;
 	 if (!zdr_length4 (zdrs, &objp->lo_length))
@@ -435,9 +330,6 @@ zdr_layout4 (ZDR *zdrs, layout4 *objp)
 uint32_t
 zdr_settime4 (ZDR *zdrs, settime4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_time_how4 (zdrs, &objp->set_it))
 		 return FALSE;
 	switch (objp->set_it) {
@@ -454,9 +346,6 @@ zdr_settime4 (ZDR *zdrs, settime4 *objp)
 uint32_t
 zdr_nfs_fh4 (ZDR *zdrs, nfs_fh4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->nfs_fh4_val, (u_int *) &objp->nfs_fh4_len, NFS4_FHSIZE))
 		 return FALSE;
 	return TRUE;
@@ -465,9 +354,6 @@ zdr_nfs_fh4 (ZDR *zdrs, nfs_fh4 *objp)
 uint32_t
 zdr_fsid4 (ZDR *zdrs, fsid4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, &objp->major))
 		 return FALSE;
 	 if (!zdr_uint64_t (zdrs, &objp->minor))
@@ -478,9 +364,6 @@ zdr_fsid4 (ZDR *zdrs, fsid4 *objp)
 uint32_t
 zdr_fs_location4 (ZDR *zdrs, fs_location4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_array (zdrs, (char **)&objp->server.server_val, (u_int *) &objp->server.server_len, ~0,
 		sizeof (utf8str_cis), (zdrproc_t) zdr_utf8str_cis))
 		 return FALSE;
@@ -492,9 +375,6 @@ zdr_fs_location4 (ZDR *zdrs, fs_location4 *objp)
 uint32_t
 zdr_fs_locations4 (ZDR *zdrs, fs_locations4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_pathname4 (zdrs, &objp->fs_root))
 		 return FALSE;
 	 if (!zdr_array (zdrs, (char **)&objp->locations.locations_val, (u_int *) &objp->locations.locations_len, ~0,
@@ -506,9 +386,6 @@ zdr_fs_locations4 (ZDR *zdrs, fs_locations4 *objp)
 uint32_t
 zdr_acetype4 (ZDR *zdrs, acetype4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -517,9 +394,6 @@ zdr_acetype4 (ZDR *zdrs, acetype4 *objp)
 uint32_t
 zdr_aceflag4 (ZDR *zdrs, aceflag4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -528,9 +402,6 @@ zdr_aceflag4 (ZDR *zdrs, aceflag4 *objp)
 uint32_t
 zdr_acemask4 (ZDR *zdrs, acemask4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -539,9 +410,6 @@ zdr_acemask4 (ZDR *zdrs, acemask4 *objp)
 uint32_t
 zdr_nfsace4 (ZDR *zdrs, nfsace4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_acetype4 (zdrs, &objp->type))
 		 return FALSE;
 	 if (!zdr_aceflag4 (zdrs, &objp->flag))
@@ -556,9 +424,6 @@ zdr_nfsace4 (ZDR *zdrs, nfsace4 *objp)
 uint32_t
 zdr_specdata4 (ZDR *zdrs, specdata4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, &objp->specdata1))
 		 return FALSE;
 	 if (!zdr_uint32_t (zdrs, &objp->specdata2))
@@ -569,9 +434,6 @@ zdr_specdata4 (ZDR *zdrs, specdata4 *objp)
 uint32_t
 zdr_fattr4_supported_attrs (ZDR *zdrs, fattr4_supported_attrs *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bitmap4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -580,9 +442,6 @@ zdr_fattr4_supported_attrs (ZDR *zdrs, fattr4_supported_attrs *objp)
 uint32_t
 zdr_fattr4_type (ZDR *zdrs, fattr4_type *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_ftype4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -591,9 +450,6 @@ zdr_fattr4_type (ZDR *zdrs, fattr4_type *objp)
 uint32_t
 zdr_fattr4_fh_expire_type (ZDR *zdrs, fattr4_fh_expire_type *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -602,9 +458,6 @@ zdr_fattr4_fh_expire_type (ZDR *zdrs, fattr4_fh_expire_type *objp)
 uint32_t
 zdr_fattr4_change (ZDR *zdrs, fattr4_change *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_changeid4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -613,9 +466,6 @@ zdr_fattr4_change (ZDR *zdrs, fattr4_change *objp)
 uint32_t
 zdr_fattr4_size (ZDR *zdrs, fattr4_size *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -624,9 +474,6 @@ zdr_fattr4_size (ZDR *zdrs, fattr4_size *objp)
 uint32_t
 zdr_fattr4_link_support (ZDR *zdrs, fattr4_link_support *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -635,9 +482,6 @@ zdr_fattr4_link_support (ZDR *zdrs, fattr4_link_support *objp)
 uint32_t
 zdr_fattr4_symlink_support (ZDR *zdrs, fattr4_symlink_support *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -646,9 +490,6 @@ zdr_fattr4_symlink_support (ZDR *zdrs, fattr4_symlink_support *objp)
 uint32_t
 zdr_fattr4_named_attr (ZDR *zdrs, fattr4_named_attr *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -657,9 +498,6 @@ zdr_fattr4_named_attr (ZDR *zdrs, fattr4_named_attr *objp)
 uint32_t
 zdr_fattr4_fsid (ZDR *zdrs, fattr4_fsid *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_fsid4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -668,9 +506,6 @@ zdr_fattr4_fsid (ZDR *zdrs, fattr4_fsid *objp)
 uint32_t
 zdr_fattr4_unique_handles (ZDR *zdrs, fattr4_unique_handles *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -679,9 +514,6 @@ zdr_fattr4_unique_handles (ZDR *zdrs, fattr4_unique_handles *objp)
 uint32_t
 zdr_fattr4_lease_time (ZDR *zdrs, fattr4_lease_time *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -690,9 +522,6 @@ zdr_fattr4_lease_time (ZDR *zdrs, fattr4_lease_time *objp)
 uint32_t
 zdr_fattr4_rdattr_error (ZDR *zdrs, fattr4_rdattr_error *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -701,9 +530,6 @@ zdr_fattr4_rdattr_error (ZDR *zdrs, fattr4_rdattr_error *objp)
 uint32_t
 zdr_fattr4_acl (ZDR *zdrs, fattr4_acl *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_array (zdrs, (char **)&objp->fattr4_acl_val, (u_int *) &objp->fattr4_acl_len, ~0,
 		sizeof (nfsace4), (zdrproc_t) zdr_nfsace4))
 		 return FALSE;
@@ -713,9 +539,6 @@ zdr_fattr4_acl (ZDR *zdrs, fattr4_acl *objp)
 uint32_t
 zdr_fattr4_aclsupport (ZDR *zdrs, fattr4_aclsupport *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -724,9 +547,6 @@ zdr_fattr4_aclsupport (ZDR *zdrs, fattr4_aclsupport *objp)
 uint32_t
 zdr_fattr4_archive (ZDR *zdrs, fattr4_archive *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -735,9 +555,6 @@ zdr_fattr4_archive (ZDR *zdrs, fattr4_archive *objp)
 uint32_t
 zdr_fattr4_cansettime (ZDR *zdrs, fattr4_cansettime *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -746,9 +563,6 @@ zdr_fattr4_cansettime (ZDR *zdrs, fattr4_cansettime *objp)
 uint32_t
 zdr_fattr4_case_insensitive (ZDR *zdrs, fattr4_case_insensitive *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -757,9 +571,6 @@ zdr_fattr4_case_insensitive (ZDR *zdrs, fattr4_case_insensitive *objp)
 uint32_t
 zdr_fattr4_case_preserving (ZDR *zdrs, fattr4_case_preserving *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -768,9 +579,6 @@ zdr_fattr4_case_preserving (ZDR *zdrs, fattr4_case_preserving *objp)
 uint32_t
 zdr_fattr4_chown_restricted (ZDR *zdrs, fattr4_chown_restricted *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -779,9 +587,6 @@ zdr_fattr4_chown_restricted (ZDR *zdrs, fattr4_chown_restricted *objp)
 uint32_t
 zdr_fattr4_fileid (ZDR *zdrs, fattr4_fileid *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -790,9 +595,6 @@ zdr_fattr4_fileid (ZDR *zdrs, fattr4_fileid *objp)
 uint32_t
 zdr_fattr4_files_avail (ZDR *zdrs, fattr4_files_avail *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -801,9 +603,6 @@ zdr_fattr4_files_avail (ZDR *zdrs, fattr4_files_avail *objp)
 uint32_t
 zdr_fattr4_filehandle (ZDR *zdrs, fattr4_filehandle *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_fh4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -812,9 +611,6 @@ zdr_fattr4_filehandle (ZDR *zdrs, fattr4_filehandle *objp)
 uint32_t
 zdr_fattr4_files_free (ZDR *zdrs, fattr4_files_free *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -823,9 +619,6 @@ zdr_fattr4_files_free (ZDR *zdrs, fattr4_files_free *objp)
 uint32_t
 zdr_fattr4_files_total (ZDR *zdrs, fattr4_files_total *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -834,9 +627,6 @@ zdr_fattr4_files_total (ZDR *zdrs, fattr4_files_total *objp)
 uint32_t
 zdr_fattr4_fs_locations (ZDR *zdrs, fattr4_fs_locations *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_fs_locations4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -845,9 +635,6 @@ zdr_fattr4_fs_locations (ZDR *zdrs, fattr4_fs_locations *objp)
 uint32_t
 zdr_fattr4_hidden (ZDR *zdrs, fattr4_hidden *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -856,9 +643,6 @@ zdr_fattr4_hidden (ZDR *zdrs, fattr4_hidden *objp)
 uint32_t
 zdr_fattr4_homogeneous (ZDR *zdrs, fattr4_homogeneous *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -867,9 +651,6 @@ zdr_fattr4_homogeneous (ZDR *zdrs, fattr4_homogeneous *objp)
 uint32_t
 zdr_fattr4_maxfilesize (ZDR *zdrs, fattr4_maxfilesize *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -878,9 +659,6 @@ zdr_fattr4_maxfilesize (ZDR *zdrs, fattr4_maxfilesize *objp)
 uint32_t
 zdr_fattr4_maxlink (ZDR *zdrs, fattr4_maxlink *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -889,9 +667,6 @@ zdr_fattr4_maxlink (ZDR *zdrs, fattr4_maxlink *objp)
 uint32_t
 zdr_fattr4_maxname (ZDR *zdrs, fattr4_maxname *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -900,9 +675,6 @@ zdr_fattr4_maxname (ZDR *zdrs, fattr4_maxname *objp)
 uint32_t
 zdr_fattr4_maxread (ZDR *zdrs, fattr4_maxread *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -911,9 +683,6 @@ zdr_fattr4_maxread (ZDR *zdrs, fattr4_maxread *objp)
 uint32_t
 zdr_fattr4_maxwrite (ZDR *zdrs, fattr4_maxwrite *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -922,9 +691,6 @@ zdr_fattr4_maxwrite (ZDR *zdrs, fattr4_maxwrite *objp)
 uint32_t
 zdr_fattr4_mimetype (ZDR *zdrs, fattr4_mimetype *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_utf8str_cs (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -933,9 +699,6 @@ zdr_fattr4_mimetype (ZDR *zdrs, fattr4_mimetype *objp)
 uint32_t
 zdr_fattr4_mode (ZDR *zdrs, fattr4_mode *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_mode4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -944,9 +707,6 @@ zdr_fattr4_mode (ZDR *zdrs, fattr4_mode *objp)
 uint32_t
 zdr_fattr4_mounted_on_fileid (ZDR *zdrs, fattr4_mounted_on_fileid *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -955,9 +715,6 @@ zdr_fattr4_mounted_on_fileid (ZDR *zdrs, fattr4_mounted_on_fileid *objp)
 uint32_t
 zdr_fattr4_no_trunc (ZDR *zdrs, fattr4_no_trunc *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -966,9 +723,6 @@ zdr_fattr4_no_trunc (ZDR *zdrs, fattr4_no_trunc *objp)
 uint32_t
 zdr_fattr4_numlinks (ZDR *zdrs, fattr4_numlinks *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -977,9 +731,6 @@ zdr_fattr4_numlinks (ZDR *zdrs, fattr4_numlinks *objp)
 uint32_t
 zdr_fattr4_owner (ZDR *zdrs, fattr4_owner *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_utf8str_mixed (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -988,9 +739,6 @@ zdr_fattr4_owner (ZDR *zdrs, fattr4_owner *objp)
 uint32_t
 zdr_fattr4_owner_group (ZDR *zdrs, fattr4_owner_group *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_utf8str_mixed (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -999,9 +747,6 @@ zdr_fattr4_owner_group (ZDR *zdrs, fattr4_owner_group *objp)
 uint32_t
 zdr_fattr4_quota_avail_hard (ZDR *zdrs, fattr4_quota_avail_hard *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1010,9 +755,6 @@ zdr_fattr4_quota_avail_hard (ZDR *zdrs, fattr4_quota_avail_hard *objp)
 uint32_t
 zdr_fattr4_quota_avail_soft (ZDR *zdrs, fattr4_quota_avail_soft *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1021,9 +763,6 @@ zdr_fattr4_quota_avail_soft (ZDR *zdrs, fattr4_quota_avail_soft *objp)
 uint32_t
 zdr_fattr4_quota_used (ZDR *zdrs, fattr4_quota_used *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1032,9 +771,6 @@ zdr_fattr4_quota_used (ZDR *zdrs, fattr4_quota_used *objp)
 uint32_t
 zdr_fattr4_rawdev (ZDR *zdrs, fattr4_rawdev *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_specdata4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1043,9 +779,6 @@ zdr_fattr4_rawdev (ZDR *zdrs, fattr4_rawdev *objp)
 uint32_t
 zdr_fattr4_space_avail (ZDR *zdrs, fattr4_space_avail *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1054,9 +787,6 @@ zdr_fattr4_space_avail (ZDR *zdrs, fattr4_space_avail *objp)
 uint32_t
 zdr_fattr4_space_free (ZDR *zdrs, fattr4_space_free *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1065,9 +795,6 @@ zdr_fattr4_space_free (ZDR *zdrs, fattr4_space_free *objp)
 uint32_t
 zdr_fattr4_space_total (ZDR *zdrs, fattr4_space_total *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1076,9 +803,6 @@ zdr_fattr4_space_total (ZDR *zdrs, fattr4_space_total *objp)
 uint32_t
 zdr_fattr4_space_used (ZDR *zdrs, fattr4_space_used *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1087,9 +811,6 @@ zdr_fattr4_space_used (ZDR *zdrs, fattr4_space_used *objp)
 uint32_t
 zdr_fattr4_system (ZDR *zdrs, fattr4_system *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1098,9 +819,6 @@ zdr_fattr4_system (ZDR *zdrs, fattr4_system *objp)
 uint32_t
 zdr_fattr4_time_access (ZDR *zdrs, fattr4_time_access *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfstime4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1109,9 +827,6 @@ zdr_fattr4_time_access (ZDR *zdrs, fattr4_time_access *objp)
 uint32_t
 zdr_fattr4_time_access_set (ZDR *zdrs, fattr4_time_access_set *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_settime4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1120,9 +835,6 @@ zdr_fattr4_time_access_set (ZDR *zdrs, fattr4_time_access_set *objp)
 uint32_t
 zdr_fattr4_time_backup (ZDR *zdrs, fattr4_time_backup *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfstime4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1131,9 +843,6 @@ zdr_fattr4_time_backup (ZDR *zdrs, fattr4_time_backup *objp)
 uint32_t
 zdr_fattr4_time_create (ZDR *zdrs, fattr4_time_create *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfstime4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1142,9 +851,6 @@ zdr_fattr4_time_create (ZDR *zdrs, fattr4_time_create *objp)
 uint32_t
 zdr_fattr4_time_delta (ZDR *zdrs, fattr4_time_delta *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfstime4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1153,9 +859,6 @@ zdr_fattr4_time_delta (ZDR *zdrs, fattr4_time_delta *objp)
 uint32_t
 zdr_fattr4_time_metadata (ZDR *zdrs, fattr4_time_metadata *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfstime4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1164,9 +867,6 @@ zdr_fattr4_time_metadata (ZDR *zdrs, fattr4_time_metadata *objp)
 uint32_t
 zdr_fattr4_time_modify (ZDR *zdrs, fattr4_time_modify *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfstime4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1175,9 +875,6 @@ zdr_fattr4_time_modify (ZDR *zdrs, fattr4_time_modify *objp)
 uint32_t
 zdr_fattr4_time_modify_set (ZDR *zdrs, fattr4_time_modify_set *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_settime4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -1186,9 +883,6 @@ zdr_fattr4_time_modify_set (ZDR *zdrs, fattr4_time_modify_set *objp)
 uint32_t
 zdr_attrlist4 (ZDR *zdrs, attrlist4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->attrlist4_val, (u_int *) &objp->attrlist4_len, ~0))
 		 return FALSE;
 	return TRUE;
@@ -1197,9 +891,6 @@ zdr_attrlist4 (ZDR *zdrs, attrlist4 *objp)
 uint32_t
 zdr_fattr4 (ZDR *zdrs, fattr4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bitmap4 (zdrs, &objp->attrmask))
 		 return FALSE;
 	 if (!zdr_attrlist4 (zdrs, &objp->attr_vals))
@@ -1210,9 +901,6 @@ zdr_fattr4 (ZDR *zdrs, fattr4 *objp)
 uint32_t
 zdr_change_info4 (ZDR *zdrs, change_info4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->atomic))
 		 return FALSE;
 	 if (!zdr_changeid4 (zdrs, &objp->before))
@@ -1225,9 +913,6 @@ zdr_change_info4 (ZDR *zdrs, change_info4 *objp)
 uint32_t
 zdr_clientaddr4 (ZDR *zdrs, clientaddr4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_string (zdrs, &objp->r_netid, ~0))
 		 return FALSE;
 	 if (!zdr_string (zdrs, &objp->r_addr, ~0))
@@ -1238,9 +923,6 @@ zdr_clientaddr4 (ZDR *zdrs, clientaddr4 *objp)
 uint32_t
 zdr_cb_client4 (ZDR *zdrs, cb_client4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, &objp->cb_program))
 		 return FALSE;
 	 if (!zdr_clientaddr4 (zdrs, &objp->cb_location))
@@ -1251,9 +933,6 @@ zdr_cb_client4 (ZDR *zdrs, cb_client4 *objp)
 uint32_t
 zdr_stateid4 (ZDR *zdrs, stateid4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	
 	 if (!zdr_uint32_t (zdrs, &objp->seqid))
 		 return FALSE;
@@ -1265,9 +944,6 @@ zdr_stateid4 (ZDR *zdrs, stateid4 *objp)
 uint32_t
 zdr_nfs_client_id4 (ZDR *zdrs, nfs_client_id4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_verifier4 (zdrs, objp->verifier))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->id.id_val, (u_int *) &objp->id.id_len, NFS4_OPAQUE_LIMIT))
@@ -1278,9 +954,6 @@ zdr_nfs_client_id4 (ZDR *zdrs, nfs_client_id4 *objp)
 uint32_t
 zdr_open_owner4 (ZDR *zdrs, open_owner4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_clientid4 (zdrs, &objp->clientid))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->owner.owner_val, (u_int *) &objp->owner.owner_len, NFS4_OPAQUE_LIMIT))
@@ -1291,9 +964,6 @@ zdr_open_owner4 (ZDR *zdrs, open_owner4 *objp)
 uint32_t
 zdr_lock_owner4 (ZDR *zdrs, lock_owner4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_clientid4 (zdrs, &objp->clientid))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->owner.owner_val, (u_int *) &objp->owner.owner_len, NFS4_OPAQUE_LIMIT))
@@ -1304,9 +974,6 @@ zdr_lock_owner4 (ZDR *zdrs, lock_owner4 *objp)
 uint32_t
 zdr_nfs_lock_type4 (ZDR *zdrs, nfs_lock_type4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -1315,9 +982,6 @@ zdr_nfs_lock_type4 (ZDR *zdrs, nfs_lock_type4 *objp)
 uint32_t
 zdr_client_owner4 (ZDR *zdrs, client_owner4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_verifier4 (zdrs, objp->co_verifier))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->co_ownerid.co_ownerid_val, (u_int *) &objp->co_ownerid.co_ownerid_len, NFS4_OPAQUE_LIMIT))
@@ -1328,9 +992,6 @@ zdr_client_owner4 (ZDR *zdrs, client_owner4 *objp)
 uint32_t
 zdr_server_owner4 (ZDR *zdrs, server_owner4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint64_t (zdrs, &objp->so_minor_id))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->so_major_id.so_major_id_val, (u_int *) &objp->so_major_id.so_major_id_len, NFS4_OPAQUE_LIMIT))
@@ -1341,9 +1002,6 @@ zdr_server_owner4 (ZDR *zdrs, server_owner4 *objp)
 uint32_t
 zdr_nfs_impl_id4 (ZDR *zdrs, nfs_impl_id4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_utf8str_cis (zdrs, &objp->nii_domain))
 		 return FALSE;
 	 if (!zdr_utf8str_cs (zdrs, &objp->nii_name))
@@ -1356,9 +1014,6 @@ zdr_nfs_impl_id4 (ZDR *zdrs, nfs_impl_id4 *objp)
 uint32_t
 zdr_ACCESS4args (ZDR *zdrs, ACCESS4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, &objp->access))
 		 return FALSE;
 	return TRUE;
@@ -1367,9 +1022,6 @@ zdr_ACCESS4args (ZDR *zdrs, ACCESS4args *objp)
 uint32_t
 zdr_ACCESS4resok (ZDR *zdrs, ACCESS4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, &objp->supported))
 		 return FALSE;
 	 if (!zdr_uint32_t (zdrs, &objp->access))
@@ -1380,9 +1032,6 @@ zdr_ACCESS4resok (ZDR *zdrs, ACCESS4resok *objp)
 uint32_t
 zdr_ACCESS4res (ZDR *zdrs, ACCESS4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1399,9 +1048,6 @@ zdr_ACCESS4res (ZDR *zdrs, ACCESS4res *objp)
 uint32_t
 zdr_CLOSE4args (ZDR *zdrs, CLOSE4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_seqid4 (zdrs, &objp->seqid))
 		 return FALSE;
 	 if (!zdr_stateid4 (zdrs, &objp->open_stateid))
@@ -1412,9 +1058,6 @@ zdr_CLOSE4args (ZDR *zdrs, CLOSE4args *objp)
 uint32_t
 zdr_CLOSE4res (ZDR *zdrs, CLOSE4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1431,9 +1074,6 @@ zdr_CLOSE4res (ZDR *zdrs, CLOSE4res *objp)
 uint32_t
 zdr_COMMIT4args (ZDR *zdrs, COMMIT4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_offset4 (zdrs, &objp->offset))
 		 return FALSE;
 	 if (!zdr_count4 (zdrs, &objp->count))
@@ -1444,9 +1084,6 @@ zdr_COMMIT4args (ZDR *zdrs, COMMIT4args *objp)
 uint32_t
 zdr_COMMIT4resok (ZDR *zdrs, COMMIT4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_verifier4 (zdrs, objp->writeverf))
 		 return FALSE;
 	return TRUE;
@@ -1455,9 +1092,6 @@ zdr_COMMIT4resok (ZDR *zdrs, COMMIT4resok *objp)
 uint32_t
 zdr_COMMIT4res (ZDR *zdrs, COMMIT4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1474,9 +1108,6 @@ zdr_COMMIT4res (ZDR *zdrs, COMMIT4res *objp)
 uint32_t
 zdr_createtype4 (ZDR *zdrs, createtype4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_ftype4 (zdrs, &objp->type))
 		 return FALSE;
 	switch (objp->type) {
@@ -1502,9 +1133,6 @@ zdr_createtype4 (ZDR *zdrs, createtype4 *objp)
 uint32_t
 zdr_CREATE4args (ZDR *zdrs, CREATE4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_createtype4 (zdrs, &objp->objtype))
 		 return FALSE;
 	 if (!zdr_component4 (zdrs, &objp->objname))
@@ -1517,9 +1145,6 @@ zdr_CREATE4args (ZDR *zdrs, CREATE4args *objp)
 uint32_t
 zdr_CREATE4resok (ZDR *zdrs, CREATE4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_change_info4 (zdrs, &objp->cinfo))
 		 return FALSE;
 	 if (!zdr_bitmap4 (zdrs, &objp->attrset))
@@ -1530,9 +1155,6 @@ zdr_CREATE4resok (ZDR *zdrs, CREATE4resok *objp)
 uint32_t
 zdr_CREATE4res (ZDR *zdrs, CREATE4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1549,9 +1171,6 @@ zdr_CREATE4res (ZDR *zdrs, CREATE4res *objp)
 uint32_t
 zdr_DELEGPURGE4args (ZDR *zdrs, DELEGPURGE4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_clientid4 (zdrs, &objp->clientid))
 		 return FALSE;
 	return TRUE;
@@ -1560,9 +1179,6 @@ zdr_DELEGPURGE4args (ZDR *zdrs, DELEGPURGE4args *objp)
 uint32_t
 zdr_DELEGPURGE4res (ZDR *zdrs, DELEGPURGE4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -1571,9 +1187,6 @@ zdr_DELEGPURGE4res (ZDR *zdrs, DELEGPURGE4res *objp)
 uint32_t
 zdr_DELEGRETURN4args (ZDR *zdrs, DELEGRETURN4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->deleg_stateid))
 		 return FALSE;
 	return TRUE;
@@ -1582,9 +1195,6 @@ zdr_DELEGRETURN4args (ZDR *zdrs, DELEGRETURN4args *objp)
 uint32_t
 zdr_DELEGRETURN4res (ZDR *zdrs, DELEGRETURN4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -1593,9 +1203,6 @@ zdr_DELEGRETURN4res (ZDR *zdrs, DELEGRETURN4res *objp)
 uint32_t
 zdr_GETATTR4args (ZDR *zdrs, GETATTR4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bitmap4 (zdrs, &objp->attr_request))
 		 return FALSE;
 	return TRUE;
@@ -1604,9 +1211,6 @@ zdr_GETATTR4args (ZDR *zdrs, GETATTR4args *objp)
 uint32_t
 zdr_GETATTR4resok (ZDR *zdrs, GETATTR4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_fattr4 (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1615,9 +1219,6 @@ zdr_GETATTR4resok (ZDR *zdrs, GETATTR4resok *objp)
 uint32_t
 zdr_GETATTR4res (ZDR *zdrs, GETATTR4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1634,9 +1235,6 @@ zdr_GETATTR4res (ZDR *zdrs, GETATTR4res *objp)
 uint32_t
 zdr_GETFH4resok (ZDR *zdrs, GETFH4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_fh4 (zdrs, &objp->object))
 		 return FALSE;
 	return TRUE;
@@ -1645,9 +1243,6 @@ zdr_GETFH4resok (ZDR *zdrs, GETFH4resok *objp)
 uint32_t
 zdr_GETFH4res (ZDR *zdrs, GETFH4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1664,9 +1259,6 @@ zdr_GETFH4res (ZDR *zdrs, GETFH4res *objp)
 uint32_t
 zdr_LINK4args (ZDR *zdrs, LINK4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_component4 (zdrs, &objp->newname))
 		 return FALSE;
 	return TRUE;
@@ -1675,9 +1267,6 @@ zdr_LINK4args (ZDR *zdrs, LINK4args *objp)
 uint32_t
 zdr_LINK4resok (ZDR *zdrs, LINK4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_change_info4 (zdrs, &objp->cinfo))
 		 return FALSE;
 	return TRUE;
@@ -1686,9 +1275,6 @@ zdr_LINK4resok (ZDR *zdrs, LINK4resok *objp)
 uint32_t
 zdr_LINK4res (ZDR *zdrs, LINK4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1705,9 +1291,6 @@ zdr_LINK4res (ZDR *zdrs, LINK4res *objp)
 uint32_t
 zdr_open_to_lock_owner4 (ZDR *zdrs, open_to_lock_owner4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_seqid4 (zdrs, &objp->open_seqid))
 		 return FALSE;
 	 if (!zdr_stateid4 (zdrs, &objp->open_stateid))
@@ -1722,9 +1305,6 @@ zdr_open_to_lock_owner4 (ZDR *zdrs, open_to_lock_owner4 *objp)
 uint32_t
 zdr_exist_lock_owner4 (ZDR *zdrs, exist_lock_owner4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->lock_stateid))
 		 return FALSE;
 	 if (!zdr_seqid4 (zdrs, &objp->lock_seqid))
@@ -1735,9 +1315,6 @@ zdr_exist_lock_owner4 (ZDR *zdrs, exist_lock_owner4 *objp)
 uint32_t
 zdr_locker4 (ZDR *zdrs, locker4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->new_lock_owner))
 		 return FALSE;
 	switch (objp->new_lock_owner) {
@@ -1758,9 +1335,6 @@ zdr_locker4 (ZDR *zdrs, locker4 *objp)
 uint32_t
 zdr_LOCK4args (ZDR *zdrs, LOCK4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_lock_type4 (zdrs, &objp->locktype))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->reclaim))
@@ -1777,9 +1351,6 @@ zdr_LOCK4args (ZDR *zdrs, LOCK4args *objp)
 uint32_t
 zdr_LOCK4denied (ZDR *zdrs, LOCK4denied *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_offset4 (zdrs, &objp->offset))
 		 return FALSE;
 	 if (!zdr_length4 (zdrs, &objp->length))
@@ -1794,9 +1365,6 @@ zdr_LOCK4denied (ZDR *zdrs, LOCK4denied *objp)
 uint32_t
 zdr_LOCK4resok (ZDR *zdrs, LOCK4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->lock_stateid))
 		 return FALSE;
 	return TRUE;
@@ -1805,9 +1373,6 @@ zdr_LOCK4resok (ZDR *zdrs, LOCK4resok *objp)
 uint32_t
 zdr_LOCK4res (ZDR *zdrs, LOCK4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1828,9 +1393,6 @@ zdr_LOCK4res (ZDR *zdrs, LOCK4res *objp)
 uint32_t
 zdr_LOCKT4args (ZDR *zdrs, LOCKT4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_lock_type4 (zdrs, &objp->locktype))
 		 return FALSE;
 	 if (!zdr_offset4 (zdrs, &objp->offset))
@@ -1845,9 +1407,6 @@ zdr_LOCKT4args (ZDR *zdrs, LOCKT4args *objp)
 uint32_t
 zdr_LOCKT4res (ZDR *zdrs, LOCKT4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1866,9 +1425,6 @@ zdr_LOCKT4res (ZDR *zdrs, LOCKT4res *objp)
 uint32_t
 zdr_LOCKU4args (ZDR *zdrs, LOCKU4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_lock_type4 (zdrs, &objp->locktype))
 		 return FALSE;
 	 if (!zdr_seqid4 (zdrs, &objp->seqid))
@@ -1885,9 +1441,6 @@ zdr_LOCKU4args (ZDR *zdrs, LOCKU4args *objp)
 uint32_t
 zdr_LOCKU4res (ZDR *zdrs, LOCKU4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -1904,9 +1457,6 @@ zdr_LOCKU4res (ZDR *zdrs, LOCKU4res *objp)
 uint32_t
 zdr_LOOKUP4args (ZDR *zdrs, LOOKUP4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_component4 (zdrs, &objp->objname))
 		 return FALSE;
 	return TRUE;
@@ -1915,9 +1465,6 @@ zdr_LOOKUP4args (ZDR *zdrs, LOOKUP4args *objp)
 uint32_t
 zdr_LOOKUP4res (ZDR *zdrs, LOOKUP4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -1926,9 +1473,6 @@ zdr_LOOKUP4res (ZDR *zdrs, LOOKUP4res *objp)
 uint32_t
 zdr_LOOKUPP4res (ZDR *zdrs, LOOKUPP4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -1937,9 +1481,6 @@ zdr_LOOKUPP4res (ZDR *zdrs, LOOKUPP4res *objp)
 uint32_t
 zdr_NVERIFY4args (ZDR *zdrs, NVERIFY4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_fattr4 (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -1948,9 +1489,6 @@ zdr_NVERIFY4args (ZDR *zdrs, NVERIFY4args *objp)
 uint32_t
 zdr_NVERIFY4res (ZDR *zdrs, NVERIFY4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -1959,9 +1497,6 @@ zdr_NVERIFY4res (ZDR *zdrs, NVERIFY4res *objp)
 uint32_t
 zdr_createmode4 (ZDR *zdrs, createmode4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -1970,9 +1505,6 @@ zdr_createmode4 (ZDR *zdrs, createmode4 *objp)
 uint32_t
 zdr_createhow4 (ZDR *zdrs, createhow4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_createmode4 (zdrs, &objp->mode))
 		 return FALSE;
 	switch (objp->mode) {
@@ -1994,9 +1526,6 @@ zdr_createhow4 (ZDR *zdrs, createhow4 *objp)
 uint32_t
 zdr_opentype4 (ZDR *zdrs, opentype4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -2005,9 +1534,6 @@ zdr_opentype4 (ZDR *zdrs, opentype4 *objp)
 uint32_t
 zdr_openflag4 (ZDR *zdrs, openflag4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_opentype4 (zdrs, &objp->opentype))
 		 return FALSE;
 	switch (objp->opentype) {
@@ -2024,9 +1550,6 @@ zdr_openflag4 (ZDR *zdrs, openflag4 *objp)
 uint32_t
 zdr_limit_by4 (ZDR *zdrs, limit_by4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -2035,9 +1558,6 @@ zdr_limit_by4 (ZDR *zdrs, limit_by4 *objp)
 uint32_t
 zdr_nfs_modified_limit4 (ZDR *zdrs, nfs_modified_limit4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, &objp->num_blocks))
 		 return FALSE;
 	 if (!zdr_uint32_t (zdrs, &objp->bytes_per_block))
@@ -2048,9 +1568,6 @@ zdr_nfs_modified_limit4 (ZDR *zdrs, nfs_modified_limit4 *objp)
 uint32_t
 zdr_nfs_space_limit4 (ZDR *zdrs, nfs_space_limit4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_limit_by4 (zdrs, &objp->limitby))
 		 return FALSE;
 	switch (objp->limitby) {
@@ -2071,9 +1588,6 @@ zdr_nfs_space_limit4 (ZDR *zdrs, nfs_space_limit4 *objp)
 uint32_t
 zdr_open_delegation_type4 (ZDR *zdrs, open_delegation_type4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -2082,9 +1596,6 @@ zdr_open_delegation_type4 (ZDR *zdrs, open_delegation_type4 *objp)
 uint32_t
 zdr_open_claim_type4 (ZDR *zdrs, open_claim_type4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -2093,9 +1604,6 @@ zdr_open_claim_type4 (ZDR *zdrs, open_claim_type4 *objp)
 uint32_t
 zdr_open_claim_delegate_cur4 (ZDR *zdrs, open_claim_delegate_cur4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->delegate_stateid))
 		 return FALSE;
 	 if (!zdr_component4 (zdrs, &objp->file))
@@ -2106,9 +1614,6 @@ zdr_open_claim_delegate_cur4 (ZDR *zdrs, open_claim_delegate_cur4 *objp)
 uint32_t
 zdr_open_claim4 (ZDR *zdrs, open_claim4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_open_claim_type4 (zdrs, &objp->claim))
 		 return FALSE;
 	switch (objp->claim) {
@@ -2145,9 +1650,6 @@ zdr_open_claim4 (ZDR *zdrs, open_claim4 *objp)
 uint32_t
 zdr_OPEN4args (ZDR *zdrs, OPEN4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_seqid4 (zdrs, &objp->seqid))
 		 return FALSE;
 	 if (!zdr_uint32_t (zdrs, &objp->share_access))
@@ -2166,9 +1668,6 @@ zdr_OPEN4args (ZDR *zdrs, OPEN4args *objp)
 uint32_t
 zdr_open_read_delegation4 (ZDR *zdrs, open_read_delegation4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->stateid))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->recall))
@@ -2181,9 +1680,6 @@ zdr_open_read_delegation4 (ZDR *zdrs, open_read_delegation4 *objp)
 uint32_t
 zdr_open_write_delegation4 (ZDR *zdrs, open_write_delegation4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->stateid))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->recall))
@@ -2198,9 +1694,6 @@ zdr_open_write_delegation4 (ZDR *zdrs, open_write_delegation4 *objp)
 uint32_t
 zdr_open_delegation4 (ZDR *zdrs, open_delegation4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_open_delegation_type4 (zdrs, &objp->delegation_type))
 		 return FALSE;
 	switch (objp->delegation_type) {
@@ -2223,9 +1716,6 @@ zdr_open_delegation4 (ZDR *zdrs, open_delegation4 *objp)
 uint32_t
 zdr_OPEN4resok (ZDR *zdrs, OPEN4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->stateid))
 		 return FALSE;
 	 if (!zdr_change_info4 (zdrs, &objp->cinfo))
@@ -2242,9 +1732,6 @@ zdr_OPEN4resok (ZDR *zdrs, OPEN4resok *objp)
 uint32_t
 zdr_OPEN4res (ZDR *zdrs, OPEN4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2261,9 +1748,6 @@ zdr_OPEN4res (ZDR *zdrs, OPEN4res *objp)
 uint32_t
 zdr_OPENATTR4args (ZDR *zdrs, OPENATTR4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->createdir))
 		 return FALSE;
 	return TRUE;
@@ -2272,9 +1756,6 @@ zdr_OPENATTR4args (ZDR *zdrs, OPENATTR4args *objp)
 uint32_t
 zdr_OPENATTR4res (ZDR *zdrs, OPENATTR4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2283,9 +1764,6 @@ zdr_OPENATTR4res (ZDR *zdrs, OPENATTR4res *objp)
 uint32_t
 zdr_OPEN_CONFIRM4args (ZDR *zdrs, OPEN_CONFIRM4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->open_stateid))
 		 return FALSE;
 	 if (!zdr_seqid4 (zdrs, &objp->seqid))
@@ -2296,9 +1774,6 @@ zdr_OPEN_CONFIRM4args (ZDR *zdrs, OPEN_CONFIRM4args *objp)
 uint32_t
 zdr_OPEN_CONFIRM4resok (ZDR *zdrs, OPEN_CONFIRM4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->open_stateid))
 		 return FALSE;
 	return TRUE;
@@ -2307,9 +1782,6 @@ zdr_OPEN_CONFIRM4resok (ZDR *zdrs, OPEN_CONFIRM4resok *objp)
 uint32_t
 zdr_OPEN_CONFIRM4res (ZDR *zdrs, OPEN_CONFIRM4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2326,9 +1798,6 @@ zdr_OPEN_CONFIRM4res (ZDR *zdrs, OPEN_CONFIRM4res *objp)
 uint32_t
 zdr_OPEN_DOWNGRADE4args (ZDR *zdrs, OPEN_DOWNGRADE4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->open_stateid))
 		 return FALSE;
 	 if (!zdr_seqid4 (zdrs, &objp->seqid))
@@ -2343,9 +1812,6 @@ zdr_OPEN_DOWNGRADE4args (ZDR *zdrs, OPEN_DOWNGRADE4args *objp)
 uint32_t
 zdr_OPEN_DOWNGRADE4resok (ZDR *zdrs, OPEN_DOWNGRADE4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->open_stateid))
 		 return FALSE;
 	return TRUE;
@@ -2354,9 +1820,6 @@ zdr_OPEN_DOWNGRADE4resok (ZDR *zdrs, OPEN_DOWNGRADE4resok *objp)
 uint32_t
 zdr_OPEN_DOWNGRADE4res (ZDR *zdrs, OPEN_DOWNGRADE4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2373,9 +1836,6 @@ zdr_OPEN_DOWNGRADE4res (ZDR *zdrs, OPEN_DOWNGRADE4res *objp)
 uint32_t
 zdr_PUTFH4args (ZDR *zdrs, PUTFH4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_fh4 (zdrs, &objp->object))
 		 return FALSE;
 	return TRUE;
@@ -2384,9 +1844,6 @@ zdr_PUTFH4args (ZDR *zdrs, PUTFH4args *objp)
 uint32_t
 zdr_PUTFH4res (ZDR *zdrs, PUTFH4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2395,9 +1852,6 @@ zdr_PUTFH4res (ZDR *zdrs, PUTFH4res *objp)
 uint32_t
 zdr_PUTPUBFH4res (ZDR *zdrs, PUTPUBFH4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2406,9 +1860,6 @@ zdr_PUTPUBFH4res (ZDR *zdrs, PUTPUBFH4res *objp)
 uint32_t
 zdr_PUTROOTFH4res (ZDR *zdrs, PUTROOTFH4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2417,9 +1868,6 @@ zdr_PUTROOTFH4res (ZDR *zdrs, PUTROOTFH4res *objp)
 uint32_t
 zdr_READ4args (ZDR *zdrs, READ4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->stateid))
 		 return FALSE;
 	 if (!zdr_offset4 (zdrs, &objp->offset))
@@ -2432,9 +1880,6 @@ zdr_READ4args (ZDR *zdrs, READ4args *objp)
 uint32_t
 zzdr_READ4resok (ZDR *zdrs, READ4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->eof))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->data.data_val, (u_int *) &objp->data.data_len, ~0))
@@ -2445,9 +1890,6 @@ zzdr_READ4resok (ZDR *zdrs, READ4resok *objp)
 uint32_t
 zdr_READ4res (ZDR *zdrs, READ4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2464,9 +1906,6 @@ zdr_READ4res (ZDR *zdrs, READ4res *objp)
 uint32_t
 zdr_READDIR4args (ZDR *zdrs, READDIR4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_cookie4 (zdrs, &objp->cookie))
 		 return FALSE;
 	 if (!zdr_verifier4 (zdrs, objp->cookieverf))
@@ -2483,9 +1922,6 @@ zdr_READDIR4args (ZDR *zdrs, READDIR4args *objp)
 uint32_t
 zdr_entry4 (ZDR *zdrs, entry4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_cookie4 (zdrs, &objp->cookie))
 		 return FALSE;
 	 if (!zdr_component4 (zdrs, &objp->name))
@@ -2500,9 +1936,6 @@ zdr_entry4 (ZDR *zdrs, entry4 *objp)
 uint32_t
 zdr_dirlist4 (ZDR *zdrs, dirlist4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_pointer (zdrs, (char **)&objp->entries, sizeof (entry4), (zdrproc_t) zdr_entry4))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->eof))
@@ -2513,9 +1946,6 @@ zdr_dirlist4 (ZDR *zdrs, dirlist4 *objp)
 uint32_t
 zdr_READDIR4resok (ZDR *zdrs, READDIR4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_verifier4 (zdrs, objp->cookieverf))
 		 return FALSE;
 	 if (!zdr_dirlist4 (zdrs, &objp->reply))
@@ -2526,9 +1956,6 @@ zdr_READDIR4resok (ZDR *zdrs, READDIR4resok *objp)
 uint32_t
 zdr_READDIR4res (ZDR *zdrs, READDIR4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2545,9 +1972,6 @@ zdr_READDIR4res (ZDR *zdrs, READDIR4res *objp)
 uint32_t
 zdr_READLINK4resok (ZDR *zdrs, READLINK4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_linktext4 (zdrs, &objp->link))
 		 return FALSE;
 	return TRUE;
@@ -2556,9 +1980,6 @@ zdr_READLINK4resok (ZDR *zdrs, READLINK4resok *objp)
 uint32_t
 zdr_READLINK4res (ZDR *zdrs, READLINK4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2575,9 +1996,6 @@ zdr_READLINK4res (ZDR *zdrs, READLINK4res *objp)
 uint32_t
 zdr_REMOVE4args (ZDR *zdrs, REMOVE4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_component4 (zdrs, &objp->target))
 		 return FALSE;
 	return TRUE;
@@ -2586,9 +2004,6 @@ zdr_REMOVE4args (ZDR *zdrs, REMOVE4args *objp)
 uint32_t
 zdr_REMOVE4resok (ZDR *zdrs, REMOVE4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_change_info4 (zdrs, &objp->cinfo))
 		 return FALSE;
 	return TRUE;
@@ -2597,9 +2012,6 @@ zdr_REMOVE4resok (ZDR *zdrs, REMOVE4resok *objp)
 uint32_t
 zdr_REMOVE4res (ZDR *zdrs, REMOVE4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2616,9 +2028,6 @@ zdr_REMOVE4res (ZDR *zdrs, REMOVE4res *objp)
 uint32_t
 zdr_RENAME4args (ZDR *zdrs, RENAME4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_component4 (zdrs, &objp->oldname))
 		 return FALSE;
 	 if (!zdr_component4 (zdrs, &objp->newname))
@@ -2629,9 +2038,6 @@ zdr_RENAME4args (ZDR *zdrs, RENAME4args *objp)
 uint32_t
 zdr_RENAME4resok (ZDR *zdrs, RENAME4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_change_info4 (zdrs, &objp->source_cinfo))
 		 return FALSE;
 	 if (!zdr_change_info4 (zdrs, &objp->target_cinfo))
@@ -2642,9 +2048,6 @@ zdr_RENAME4resok (ZDR *zdrs, RENAME4resok *objp)
 uint32_t
 zdr_RENAME4res (ZDR *zdrs, RENAME4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2661,9 +2064,6 @@ zdr_RENAME4res (ZDR *zdrs, RENAME4res *objp)
 uint32_t
 zdr_RENEW4args (ZDR *zdrs, RENEW4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_clientid4 (zdrs, &objp->clientid))
 		 return FALSE;
 	return TRUE;
@@ -2672,9 +2072,6 @@ zdr_RENEW4args (ZDR *zdrs, RENEW4args *objp)
 uint32_t
 zdr_RENEW4res (ZDR *zdrs, RENEW4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2683,9 +2080,6 @@ zdr_RENEW4res (ZDR *zdrs, RENEW4res *objp)
 uint32_t
 zdr_RESTOREFH4res (ZDR *zdrs, RESTOREFH4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2694,9 +2088,6 @@ zdr_RESTOREFH4res (ZDR *zdrs, RESTOREFH4res *objp)
 uint32_t
 zdr_SAVEFH4res (ZDR *zdrs, SAVEFH4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2705,9 +2096,6 @@ zdr_SAVEFH4res (ZDR *zdrs, SAVEFH4res *objp)
 uint32_t
 zdr_SECINFO4args (ZDR *zdrs, SECINFO4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_component4 (zdrs, &objp->name))
 		 return FALSE;
 	return TRUE;
@@ -2716,9 +2104,6 @@ zdr_SECINFO4args (ZDR *zdrs, SECINFO4args *objp)
 uint32_t
 zdr_rpc_gss_svc_t (ZDR *zdrs, rpc_gss_svc_t *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -2727,9 +2112,6 @@ zdr_rpc_gss_svc_t (ZDR *zdrs, rpc_gss_svc_t *objp)
 uint32_t
 zdr_rpcsec_gss_info (ZDR *zdrs, rpcsec_gss_info *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_sec_oid4 (zdrs, &objp->oid))
 		 return FALSE;
 	 if (!zdr_qop4 (zdrs, &objp->qop))
@@ -2742,9 +2124,6 @@ zdr_rpcsec_gss_info (ZDR *zdrs, rpcsec_gss_info *objp)
 uint32_t
 zdr_secinfo4 (ZDR *zdrs, secinfo4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, &objp->flavor))
 		 return FALSE;
 	switch (objp->flavor) {
@@ -2761,9 +2140,6 @@ zdr_secinfo4 (ZDR *zdrs, secinfo4 *objp)
 uint32_t
 zdr_SECINFO4resok (ZDR *zdrs, SECINFO4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_array (zdrs, (char **)&objp->SECINFO4resok_val, (u_int *) &objp->SECINFO4resok_len, ~0,
 		sizeof (secinfo4), (zdrproc_t) zdr_secinfo4))
 		 return FALSE;
@@ -2773,9 +2149,6 @@ zdr_SECINFO4resok (ZDR *zdrs, SECINFO4resok *objp)
 uint32_t
 zdr_SECINFO4res (ZDR *zdrs, SECINFO4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2792,9 +2165,6 @@ zdr_SECINFO4res (ZDR *zdrs, SECINFO4res *objp)
 uint32_t
 zdr_SETATTR4args (ZDR *zdrs, SETATTR4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->stateid))
 		 return FALSE;
 	 if (!zdr_fattr4 (zdrs, &objp->obj_attributes))
@@ -2805,9 +2175,6 @@ zdr_SETATTR4args (ZDR *zdrs, SETATTR4args *objp)
 uint32_t
 zdr_SETATTR4res (ZDR *zdrs, SETATTR4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	 if (!zdr_bitmap4 (zdrs, &objp->attrsset))
@@ -2818,9 +2185,6 @@ zdr_SETATTR4res (ZDR *zdrs, SETATTR4res *objp)
 uint32_t
 zdr_SETCLIENTID4args (ZDR *zdrs, SETCLIENTID4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_client_id4 (zdrs, &objp->client))
 		 return FALSE;
 	 if (!zdr_cb_client4 (zdrs, &objp->callback))
@@ -2833,9 +2197,6 @@ zdr_SETCLIENTID4args (ZDR *zdrs, SETCLIENTID4args *objp)
 uint32_t
 zdr_SETCLIENTID4resok (ZDR *zdrs, SETCLIENTID4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_clientid4 (zdrs, &objp->clientid))
 		 return FALSE;
 	 if (!zdr_verifier4 (zdrs, objp->setclientid_confirm))
@@ -2846,9 +2207,6 @@ zdr_SETCLIENTID4resok (ZDR *zdrs, SETCLIENTID4resok *objp)
 uint32_t
 zdr_SETCLIENTID4res (ZDR *zdrs, SETCLIENTID4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2869,9 +2227,6 @@ zdr_SETCLIENTID4res (ZDR *zdrs, SETCLIENTID4res *objp)
 uint32_t
 zdr_SETCLIENTID_CONFIRM4args (ZDR *zdrs, SETCLIENTID_CONFIRM4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_clientid4 (zdrs, &objp->clientid))
 		 return FALSE;
 	 if (!zdr_verifier4 (zdrs, objp->setclientid_confirm))
@@ -2882,9 +2237,6 @@ zdr_SETCLIENTID_CONFIRM4args (ZDR *zdrs, SETCLIENTID_CONFIRM4args *objp)
 uint32_t
 zdr_SETCLIENTID_CONFIRM4res (ZDR *zdrs, SETCLIENTID_CONFIRM4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2893,9 +2245,6 @@ zdr_SETCLIENTID_CONFIRM4res (ZDR *zdrs, SETCLIENTID_CONFIRM4res *objp)
 uint32_t
 zdr_VERIFY4args (ZDR *zdrs, VERIFY4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_fattr4 (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -2904,9 +2253,6 @@ zdr_VERIFY4args (ZDR *zdrs, VERIFY4args *objp)
 uint32_t
 zdr_VERIFY4res (ZDR *zdrs, VERIFY4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2915,9 +2261,6 @@ zdr_VERIFY4res (ZDR *zdrs, VERIFY4res *objp)
 uint32_t
 zdr_stable_how4 (ZDR *zdrs, stable_how4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -2926,9 +2269,6 @@ zdr_stable_how4 (ZDR *zdrs, stable_how4 *objp)
 uint32_t
 zzdr_WRITE4args (ZDR *zdrs, WRITE4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->stateid))
 		 return FALSE;
 	 if (!zdr_offset4 (zdrs, &objp->offset))
@@ -2943,9 +2283,6 @@ zzdr_WRITE4args (ZDR *zdrs, WRITE4args *objp)
 uint32_t
 zdr_WRITE4resok (ZDR *zdrs, WRITE4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_count4 (zdrs, &objp->count))
 		 return FALSE;
 	 if (!zdr_stable_how4 (zdrs, &objp->committed))
@@ -2958,9 +2295,6 @@ zdr_WRITE4resok (ZDR *zdrs, WRITE4resok *objp)
 uint32_t
 zdr_WRITE4res (ZDR *zdrs, WRITE4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -2977,9 +2311,6 @@ zdr_WRITE4res (ZDR *zdrs, WRITE4res *objp)
 uint32_t
 zdr_RELEASE_LOCKOWNER4args (ZDR *zdrs, RELEASE_LOCKOWNER4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_lock_owner4 (zdrs, &objp->lock_owner))
 		 return FALSE;
 	return TRUE;
@@ -2988,9 +2319,6 @@ zdr_RELEASE_LOCKOWNER4args (ZDR *zdrs, RELEASE_LOCKOWNER4args *objp)
 uint32_t
 zdr_RELEASE_LOCKOWNER4res (ZDR *zdrs, RELEASE_LOCKOWNER4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -2999,9 +2327,6 @@ zdr_RELEASE_LOCKOWNER4res (ZDR *zdrs, RELEASE_LOCKOWNER4res *objp)
 uint32_t
 zdr_gsshandle4_t (ZDR *zdrs, gsshandle4_t *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->gsshandle4_t_val, (u_int *) &objp->gsshandle4_t_len, ~0))
 		 return FALSE;
 	return TRUE;
@@ -3010,9 +2335,6 @@ zdr_gsshandle4_t (ZDR *zdrs, gsshandle4_t *objp)
 uint32_t
 zdr_callback_sec_parms4 (ZDR *zdrs, callback_sec_parms4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, &objp->cb_secflavor))
 		 return FALSE;
 	switch (objp->cb_secflavor) {
@@ -3031,9 +2353,6 @@ zdr_callback_sec_parms4 (ZDR *zdrs, callback_sec_parms4 *objp)
 uint32_t
 zdr_channel_dir_from_client4 (ZDR *zdrs, channel_dir_from_client4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -3042,9 +2361,6 @@ zdr_channel_dir_from_client4 (ZDR *zdrs, channel_dir_from_client4 *objp)
 uint32_t
 zdr_BIND_CONN_TO_SESSION4args (ZDR *zdrs, BIND_CONN_TO_SESSION4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_sessionid4 (zdrs, objp->bctsa_sessid))
 		 return FALSE;
 	 if (!zdr_channel_dir_from_client4 (zdrs, &objp->bctsa_dir))
@@ -3057,9 +2373,6 @@ zdr_BIND_CONN_TO_SESSION4args (ZDR *zdrs, BIND_CONN_TO_SESSION4args *objp)
 uint32_t
 zdr_channel_dir_from_server4 (ZDR *zdrs, channel_dir_from_server4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -3068,9 +2381,6 @@ zdr_channel_dir_from_server4 (ZDR *zdrs, channel_dir_from_server4 *objp)
 uint32_t
 zdr_BIND_CONN_TO_SESSION4resok (ZDR *zdrs, BIND_CONN_TO_SESSION4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_sessionid4 (zdrs, objp->bctsr_sessid))
 		 return FALSE;
 	 if (!zdr_channel_dir_from_server4 (zdrs, &objp->bctsr_dir))
@@ -3083,9 +2393,6 @@ zdr_BIND_CONN_TO_SESSION4resok (ZDR *zdrs, BIND_CONN_TO_SESSION4resok *objp)
 uint32_t
 zdr_BIND_CONN_TO_SESSION4res (ZDR *zdrs, BIND_CONN_TO_SESSION4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->bctsr_status))
 		 return FALSE;
 	switch (objp->bctsr_status) {
@@ -3102,9 +2409,6 @@ zdr_BIND_CONN_TO_SESSION4res (ZDR *zdrs, BIND_CONN_TO_SESSION4res *objp)
 uint32_t
 zdr_state_protect_ops4 (ZDR *zdrs, state_protect_ops4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bitmap4 (zdrs, &objp->spo_must_enforce))
 		 return FALSE;
 	 if (!zdr_bitmap4 (zdrs, &objp->spo_must_allow))
@@ -3115,9 +2419,6 @@ zdr_state_protect_ops4 (ZDR *zdrs, state_protect_ops4 *objp)
 uint32_t
 zdr_ssv_sp_parms4 (ZDR *zdrs, ssv_sp_parms4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_state_protect_ops4 (zdrs, &objp->ssp_ops))
 		 return FALSE;
 	 if (!zdr_array (zdrs, (char **)&objp->ssp_hash_algs.ssp_hash_algs_val, (u_int *) &objp->ssp_hash_algs.ssp_hash_algs_len, ~0,
@@ -3136,9 +2437,6 @@ zdr_ssv_sp_parms4 (ZDR *zdrs, ssv_sp_parms4 *objp)
 uint32_t
 zdr_state_protect_how4 (ZDR *zdrs, state_protect_how4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -3147,9 +2445,6 @@ zdr_state_protect_how4 (ZDR *zdrs, state_protect_how4 *objp)
 uint32_t
 zdr_state_protect4_a (ZDR *zdrs, state_protect4_a *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_state_protect_how4 (zdrs, &objp->spa_how))
 		 return FALSE;
 	switch (objp->spa_how) {
@@ -3172,9 +2467,6 @@ zdr_state_protect4_a (ZDR *zdrs, state_protect4_a *objp)
 uint32_t
 zdr_EXCHANGE_ID4args (ZDR *zdrs, EXCHANGE_ID4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_client_owner4 (zdrs, &objp->eia_clientowner))
 		 return FALSE;
 	 if (!zdr_uint32_t (zdrs, &objp->eia_flags))
@@ -3190,9 +2482,6 @@ zdr_EXCHANGE_ID4args (ZDR *zdrs, EXCHANGE_ID4args *objp)
 uint32_t
 zdr_ssv_prot_info4 (ZDR *zdrs, ssv_prot_info4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_state_protect_ops4 (zdrs, &objp->spi_ops))
 		 return FALSE;
 	 if (!zdr_uint32_t (zdrs, &objp->spi_hash_alg))
@@ -3212,9 +2501,6 @@ zdr_ssv_prot_info4 (ZDR *zdrs, ssv_prot_info4 *objp)
 uint32_t
 zdr_state_protect4_r (ZDR *zdrs, state_protect4_r *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_state_protect_how4 (zdrs, &objp->spr_how))
 		 return FALSE;
 	switch (objp->spr_how) {
@@ -3237,9 +2523,6 @@ zdr_state_protect4_r (ZDR *zdrs, state_protect4_r *objp)
 uint32_t
 zdr_EXCHANGE_ID4resok (ZDR *zdrs, EXCHANGE_ID4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_clientid4 (zdrs, &objp->eir_clientid))
 		 return FALSE;
 	 if (!zdr_sequenceid4 (zdrs, &objp->eir_sequenceid))
@@ -3261,9 +2544,6 @@ zdr_EXCHANGE_ID4resok (ZDR *zdrs, EXCHANGE_ID4resok *objp)
 uint32_t
 zdr_EXCHANGE_ID4res (ZDR *zdrs, EXCHANGE_ID4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->eir_status))
 		 return FALSE;
 	switch (objp->eir_status) {
@@ -3280,9 +2560,6 @@ zdr_EXCHANGE_ID4res (ZDR *zdrs, EXCHANGE_ID4res *objp)
 uint32_t
 zdr_channel_attrs4 (ZDR *zdrs, channel_attrs4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_count4 (zdrs, &objp->ca_headerpadsize))
 		 return FALSE;
 	 if (!zdr_count4 (zdrs, &objp->ca_maxrequestsize))
@@ -3304,9 +2581,6 @@ zdr_channel_attrs4 (ZDR *zdrs, channel_attrs4 *objp)
 uint32_t
 zdr_CREATE_SESSION4args (ZDR *zdrs, CREATE_SESSION4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_clientid4 (zdrs, &objp->csa_clientid))
 		 return FALSE;
 	 if (!zdr_sequenceid4 (zdrs, &objp->csa_sequence))
@@ -3328,9 +2602,6 @@ zdr_CREATE_SESSION4args (ZDR *zdrs, CREATE_SESSION4args *objp)
 uint32_t
 zdr_CREATE_SESSION4resok (ZDR *zdrs, CREATE_SESSION4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_sessionid4 (zdrs, objp->csr_sessionid))
 		 return FALSE;
 	 if (!zdr_sequenceid4 (zdrs, &objp->csr_sequence))
@@ -3347,9 +2618,6 @@ zdr_CREATE_SESSION4resok (ZDR *zdrs, CREATE_SESSION4resok *objp)
 uint32_t
 zdr_CREATE_SESSION4res (ZDR *zdrs, CREATE_SESSION4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->csr_status))
 		 return FALSE;
 	switch (objp->csr_status) {
@@ -3366,9 +2634,6 @@ zdr_CREATE_SESSION4res (ZDR *zdrs, CREATE_SESSION4res *objp)
 uint32_t
 zdr_DESTROY_SESSION4args (ZDR *zdrs, DESTROY_SESSION4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_sessionid4 (zdrs, objp->dsa_sessionid))
 		 return FALSE;
 	return TRUE;
@@ -3377,9 +2642,6 @@ zdr_DESTROY_SESSION4args (ZDR *zdrs, DESTROY_SESSION4args *objp)
 uint32_t
 zdr_DESTROY_SESSION4res (ZDR *zdrs, DESTROY_SESSION4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->dsr_status))
 		 return FALSE;
 	return TRUE;
@@ -3388,9 +2650,6 @@ zdr_DESTROY_SESSION4res (ZDR *zdrs, DESTROY_SESSION4res *objp)
 uint32_t
 zdr_FREE_STATEID4args (ZDR *zdrs, FREE_STATEID4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->fsa_stateid))
 		 return FALSE;
 	return TRUE;
@@ -3399,9 +2658,6 @@ zdr_FREE_STATEID4args (ZDR *zdrs, FREE_STATEID4args *objp)
 uint32_t
 zdr_FREE_STATEID4res (ZDR *zdrs, FREE_STATEID4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->fsr_status))
 		 return FALSE;
 	return TRUE;
@@ -3410,9 +2666,6 @@ zdr_FREE_STATEID4res (ZDR *zdrs, FREE_STATEID4res *objp)
 uint32_t
 zdr_attr_notice4 (ZDR *zdrs, attr_notice4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfstime4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -3421,9 +2674,6 @@ zdr_attr_notice4 (ZDR *zdrs, attr_notice4 *objp)
 uint32_t
 zdr_GET_DIR_DELEGATION4args (ZDR *zdrs, GET_DIR_DELEGATION4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->gdda_signal_deleg_avail))
 		 return FALSE;
 	 if (!zdr_bitmap4 (zdrs, &objp->gdda_notification_types))
@@ -3442,9 +2692,6 @@ zdr_GET_DIR_DELEGATION4args (ZDR *zdrs, GET_DIR_DELEGATION4args *objp)
 uint32_t
 zdr_GET_DIR_DELEGATION4resok (ZDR *zdrs, GET_DIR_DELEGATION4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_verifier4 (zdrs, objp->gddr_cookieverf))
 		 return FALSE;
 	 if (!zdr_stateid4 (zdrs, &objp->gddr_stateid))
@@ -3461,9 +2708,6 @@ zdr_GET_DIR_DELEGATION4resok (ZDR *zdrs, GET_DIR_DELEGATION4resok *objp)
 uint32_t
 zdr_gddrnf4_status (ZDR *zdrs, gddrnf4_status *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -3472,9 +2716,6 @@ zdr_gddrnf4_status (ZDR *zdrs, gddrnf4_status *objp)
 uint32_t
 zdr_GET_DIR_DELEGATION4res_non_fatal (ZDR *zdrs, GET_DIR_DELEGATION4res_non_fatal *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_gddrnf4_status (zdrs, &objp->gddrnf_status))
 		 return FALSE;
 	switch (objp->gddrnf_status) {
@@ -3495,9 +2736,6 @@ zdr_GET_DIR_DELEGATION4res_non_fatal (ZDR *zdrs, GET_DIR_DELEGATION4res_non_fata
 uint32_t
 zdr_GET_DIR_DELEGATION4res (ZDR *zdrs, GET_DIR_DELEGATION4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->gddr_status))
 		 return FALSE;
 	switch (objp->gddr_status) {
@@ -3514,9 +2752,6 @@ zdr_GET_DIR_DELEGATION4res (ZDR *zdrs, GET_DIR_DELEGATION4res *objp)
 uint32_t
 zdr_GETDEVICEINFO4args (ZDR *zdrs, GETDEVICEINFO4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_deviceid4 (zdrs, objp->gdia_device_id))
 		 return FALSE;
 	 if (!zdr_layouttype4 (zdrs, &objp->gdia_layout_type))
@@ -3531,9 +2766,6 @@ zdr_GETDEVICEINFO4args (ZDR *zdrs, GETDEVICEINFO4args *objp)
 uint32_t
 zdr_GETDEVICEINFO4resok (ZDR *zdrs, GETDEVICEINFO4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_device_addr4 (zdrs, &objp->gdir_device_addr))
 		 return FALSE;
 	 if (!zdr_bitmap4 (zdrs, &objp->gdir_notification))
@@ -3544,9 +2776,6 @@ zdr_GETDEVICEINFO4resok (ZDR *zdrs, GETDEVICEINFO4resok *objp)
 uint32_t
 zdr_GETDEVICEINFO4res (ZDR *zdrs, GETDEVICEINFO4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->gdir_status))
 		 return FALSE;
 	switch (objp->gdir_status) {
@@ -3567,9 +2796,6 @@ zdr_GETDEVICEINFO4res (ZDR *zdrs, GETDEVICEINFO4res *objp)
 uint32_t
 zdr_GETDEVICELIST4args (ZDR *zdrs, GETDEVICELIST4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_layouttype4 (zdrs, &objp->gdla_layout_type))
 		 return FALSE;
 	 if (!zdr_count4 (zdrs, &objp->gdla_maxdevices))
@@ -3584,9 +2810,6 @@ zdr_GETDEVICELIST4args (ZDR *zdrs, GETDEVICELIST4args *objp)
 uint32_t
 zdr_GETDEVICELIST4resok (ZDR *zdrs, GETDEVICELIST4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_cookie4 (zdrs, &objp->gdlr_cookie))
 		 return FALSE;
 	 if (!zdr_verifier4 (zdrs, objp->gdlr_cookieverf))
@@ -3602,9 +2825,6 @@ zdr_GETDEVICELIST4resok (ZDR *zdrs, GETDEVICELIST4resok *objp)
 uint32_t
 zdr_GETDEVICELIST4res (ZDR *zdrs, GETDEVICELIST4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->gdlr_status))
 		 return FALSE;
 	switch (objp->gdlr_status) {
@@ -3621,9 +2841,6 @@ zdr_GETDEVICELIST4res (ZDR *zdrs, GETDEVICELIST4res *objp)
 uint32_t
 zdr_newtime4 (ZDR *zdrs, newtime4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->nt_timechanged))
 		 return FALSE;
 	switch (objp->nt_timechanged) {
@@ -3642,9 +2859,6 @@ zdr_newtime4 (ZDR *zdrs, newtime4 *objp)
 uint32_t
 zdr_newoffset4 (ZDR *zdrs, newoffset4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->no_newoffset))
 		 return FALSE;
 	switch (objp->no_newoffset) {
@@ -3663,9 +2877,6 @@ zdr_newoffset4 (ZDR *zdrs, newoffset4 *objp)
 uint32_t
 zdr_LAYOUTCOMMIT4args (ZDR *zdrs, LAYOUTCOMMIT4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_offset4 (zdrs, &objp->loca_offset))
 		 return FALSE;
 	 if (!zdr_length4 (zdrs, &objp->loca_length))
@@ -3686,9 +2897,6 @@ zdr_LAYOUTCOMMIT4args (ZDR *zdrs, LAYOUTCOMMIT4args *objp)
 uint32_t
 zdr_newsize4 (ZDR *zdrs, newsize4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->ns_sizechanged))
 		 return FALSE;
 	switch (objp->ns_sizechanged) {
@@ -3707,9 +2915,6 @@ zdr_newsize4 (ZDR *zdrs, newsize4 *objp)
 uint32_t
 zdr_LAYOUTCOMMIT4resok (ZDR *zdrs, LAYOUTCOMMIT4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_newsize4 (zdrs, &objp->locr_newsize))
 		 return FALSE;
 	return TRUE;
@@ -3718,9 +2923,6 @@ zdr_LAYOUTCOMMIT4resok (ZDR *zdrs, LAYOUTCOMMIT4resok *objp)
 uint32_t
 zdr_LAYOUTCOMMIT4res (ZDR *zdrs, LAYOUTCOMMIT4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->locr_status))
 		 return FALSE;
 	switch (objp->locr_status) {
@@ -3737,9 +2939,6 @@ zdr_LAYOUTCOMMIT4res (ZDR *zdrs, LAYOUTCOMMIT4res *objp)
 uint32_t
 zdr_LAYOUTGET4args (ZDR *zdrs, LAYOUTGET4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->loga_signal_layout_avail))
 		 return FALSE;
 	 if (!zdr_layouttype4 (zdrs, &objp->loga_layout_type))
@@ -3762,9 +2961,6 @@ zdr_LAYOUTGET4args (ZDR *zdrs, LAYOUTGET4args *objp)
 uint32_t
 zdr_LAYOUTGET4resok (ZDR *zdrs, LAYOUTGET4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->logr_return_on_close))
 		 return FALSE;
 	 if (!zdr_stateid4 (zdrs, &objp->logr_stateid))
@@ -3778,9 +2974,6 @@ zdr_LAYOUTGET4resok (ZDR *zdrs, LAYOUTGET4resok *objp)
 uint32_t
 zdr_LAYOUTGET4res (ZDR *zdrs, LAYOUTGET4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->logr_status))
 		 return FALSE;
 	switch (objp->logr_status) {
@@ -3801,9 +2994,6 @@ zdr_LAYOUTGET4res (ZDR *zdrs, LAYOUTGET4res *objp)
 uint32_t
 zdr_layoutreturn_type4 (ZDR *zdrs, layoutreturn_type4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -3812,9 +3002,6 @@ zdr_layoutreturn_type4 (ZDR *zdrs, layoutreturn_type4 *objp)
 uint32_t
 zdr_layoutreturn_file4 (ZDR *zdrs, layoutreturn_file4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_offset4 (zdrs, &objp->lrf_offset))
 		 return FALSE;
 	 if (!zdr_length4 (zdrs, &objp->lrf_length))
@@ -3829,9 +3016,6 @@ zdr_layoutreturn_file4 (ZDR *zdrs, layoutreturn_file4 *objp)
 uint32_t
 zdr_layoutreturn4 (ZDR *zdrs, layoutreturn4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_layoutreturn_type4 (zdrs, &objp->lr_returntype))
 		 return FALSE;
 	switch (objp->lr_returntype) {
@@ -3848,9 +3032,6 @@ zdr_layoutreturn4 (ZDR *zdrs, layoutreturn4 *objp)
 uint32_t
 zdr_LAYOUTRETURN4args (ZDR *zdrs, LAYOUTRETURN4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->lora_reclaim))
 		 return FALSE;
 	 if (!zdr_layouttype4 (zdrs, &objp->lora_layout_type))
@@ -3865,9 +3046,6 @@ zdr_LAYOUTRETURN4args (ZDR *zdrs, LAYOUTRETURN4args *objp)
 uint32_t
 zdr_layoutreturn_stateid (ZDR *zdrs, layoutreturn_stateid *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->lrs_present))
 		 return FALSE;
 	switch (objp->lrs_present) {
@@ -3886,9 +3064,6 @@ zdr_layoutreturn_stateid (ZDR *zdrs, layoutreturn_stateid *objp)
 uint32_t
 zdr_LAYOUTRETURN4res (ZDR *zdrs, LAYOUTRETURN4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->lorr_status))
 		 return FALSE;
 	switch (objp->lorr_status) {
@@ -3905,9 +3080,6 @@ zdr_LAYOUTRETURN4res (ZDR *zdrs, LAYOUTRETURN4res *objp)
 uint32_t
 zdr_secinfo_style4 (ZDR *zdrs, secinfo_style4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -3916,9 +3088,6 @@ zdr_secinfo_style4 (ZDR *zdrs, secinfo_style4 *objp)
 uint32_t
 zdr_SECINFO_NO_NAME4args (ZDR *zdrs, SECINFO_NO_NAME4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_secinfo_style4 (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -3927,9 +3096,6 @@ zdr_SECINFO_NO_NAME4args (ZDR *zdrs, SECINFO_NO_NAME4args *objp)
 uint32_t
 zdr_SECINFO_NO_NAME4res (ZDR *zdrs, SECINFO_NO_NAME4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_SECINFO4res (zdrs, objp))
 		 return FALSE;
 	return TRUE;
@@ -3938,9 +3104,6 @@ zdr_SECINFO_NO_NAME4res (ZDR *zdrs, SECINFO_NO_NAME4res *objp)
 uint32_t
 zdr_SEQUENCE4args (ZDR *zdrs, SEQUENCE4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_sessionid4 (zdrs, objp->sa_sessionid))
 		 return FALSE;
 	 if (!zdr_sequenceid4 (zdrs, &objp->sa_sequenceid))
@@ -3957,9 +3120,6 @@ zdr_SEQUENCE4args (ZDR *zdrs, SEQUENCE4args *objp)
 uint32_t
 zdr_SEQUENCE4resok (ZDR *zdrs, SEQUENCE4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_sessionid4 (zdrs, objp->sr_sessionid))
 		 return FALSE;
 	 if (!zdr_sequenceid4 (zdrs, &objp->sr_sequenceid))
@@ -3978,9 +3138,6 @@ zdr_SEQUENCE4resok (ZDR *zdrs, SEQUENCE4resok *objp)
 uint32_t
 zdr_SEQUENCE4res (ZDR *zdrs, SEQUENCE4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->sr_status))
 		 return FALSE;
 	switch (objp->sr_status) {
@@ -3997,9 +3154,6 @@ zdr_SEQUENCE4res (ZDR *zdrs, SEQUENCE4res *objp)
 uint32_t
 zdr_ssa_digest_input4 (ZDR *zdrs, ssa_digest_input4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_SEQUENCE4args (zdrs, &objp->sdi_seqargs))
 		 return FALSE;
 	return TRUE;
@@ -4008,9 +3162,6 @@ zdr_ssa_digest_input4 (ZDR *zdrs, ssa_digest_input4 *objp)
 uint32_t
 zdr_SET_SSV4args (ZDR *zdrs, SET_SSV4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->ssa_ssv.ssa_ssv_val, (u_int *) &objp->ssa_ssv.ssa_ssv_len, ~0))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->ssa_digest.ssa_digest_val, (u_int *) &objp->ssa_digest.ssa_digest_len, ~0))
@@ -4021,9 +3172,6 @@ zdr_SET_SSV4args (ZDR *zdrs, SET_SSV4args *objp)
 uint32_t
 zdr_ssr_digest_input4 (ZDR *zdrs, ssr_digest_input4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_SEQUENCE4res (zdrs, &objp->sdi_seqres))
 		 return FALSE;
 	return TRUE;
@@ -4032,9 +3180,6 @@ zdr_ssr_digest_input4 (ZDR *zdrs, ssr_digest_input4 *objp)
 uint32_t
 zdr_SET_SSV4resok (ZDR *zdrs, SET_SSV4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->ssr_digest.ssr_digest_val, (u_int *) &objp->ssr_digest.ssr_digest_len, ~0))
 		 return FALSE;
 	return TRUE;
@@ -4043,9 +3188,6 @@ zdr_SET_SSV4resok (ZDR *zdrs, SET_SSV4resok *objp)
 uint32_t
 zdr_SET_SSV4res (ZDR *zdrs, SET_SSV4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->ssr_status))
 		 return FALSE;
 	switch (objp->ssr_status) {
@@ -4062,9 +3204,6 @@ zdr_SET_SSV4res (ZDR *zdrs, SET_SSV4res *objp)
 uint32_t
 zdr_TEST_STATEID4args (ZDR *zdrs, TEST_STATEID4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_array (zdrs, (char **)&objp->ts_stateids.ts_stateids_val, (u_int *) &objp->ts_stateids.ts_stateids_len, ~0,
 		sizeof (stateid4), (zdrproc_t) zdr_stateid4))
 		 return FALSE;
@@ -4074,9 +3213,6 @@ zdr_TEST_STATEID4args (ZDR *zdrs, TEST_STATEID4args *objp)
 uint32_t
 zdr_TEST_STATEID4resok (ZDR *zdrs, TEST_STATEID4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_array (zdrs, (char **)&objp->tsr_status_codes.tsr_status_codes_val, (u_int *) &objp->tsr_status_codes.tsr_status_codes_len, ~0,
 		sizeof (nfsstat4), (zdrproc_t) zdr_nfsstat4))
 		 return FALSE;
@@ -4086,9 +3222,6 @@ zdr_TEST_STATEID4resok (ZDR *zdrs, TEST_STATEID4resok *objp)
 uint32_t
 zdr_TEST_STATEID4res (ZDR *zdrs, TEST_STATEID4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->tsr_status))
 		 return FALSE;
 	switch (objp->tsr_status) {
@@ -4105,9 +3238,6 @@ zdr_TEST_STATEID4res (ZDR *zdrs, TEST_STATEID4res *objp)
 uint32_t
 zdr_deleg_claim4 (ZDR *zdrs, deleg_claim4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_open_claim_type4 (zdrs, &objp->dc_claim))
 		 return FALSE;
 	switch (objp->dc_claim) {
@@ -4128,9 +3258,6 @@ zdr_deleg_claim4 (ZDR *zdrs, deleg_claim4 *objp)
 uint32_t
 zdr_WANT_DELEGATION4args (ZDR *zdrs, WANT_DELEGATION4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_uint32_t (zdrs, &objp->wda_want))
 		 return FALSE;
 	 if (!zdr_deleg_claim4 (zdrs, &objp->wda_claim))
@@ -4141,9 +3268,6 @@ zdr_WANT_DELEGATION4args (ZDR *zdrs, WANT_DELEGATION4args *objp)
 uint32_t
 zdr_WANT_DELEGATION4res (ZDR *zdrs, WANT_DELEGATION4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->wdr_status))
 		 return FALSE;
 	switch (objp->wdr_status) {
@@ -4160,9 +3284,6 @@ zdr_WANT_DELEGATION4res (ZDR *zdrs, WANT_DELEGATION4res *objp)
 uint32_t
 zdr_DESTROY_CLIENTID4args (ZDR *zdrs, DESTROY_CLIENTID4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_clientid4 (zdrs, &objp->dca_clientid))
 		 return FALSE;
 	return TRUE;
@@ -4171,9 +3292,6 @@ zdr_DESTROY_CLIENTID4args (ZDR *zdrs, DESTROY_CLIENTID4args *objp)
 uint32_t
 zdr_DESTROY_CLIENTID4res (ZDR *zdrs, DESTROY_CLIENTID4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->dcr_status))
 		 return FALSE;
 	return TRUE;
@@ -4182,9 +3300,6 @@ zdr_DESTROY_CLIENTID4res (ZDR *zdrs, DESTROY_CLIENTID4res *objp)
 uint32_t
 zdr_RECLAIM_COMPLETE4args (ZDR *zdrs, RECLAIM_COMPLETE4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bool (zdrs, &objp->rca_one_fs))
 		 return FALSE;
 	return TRUE;
@@ -4193,9 +3308,6 @@ zdr_RECLAIM_COMPLETE4args (ZDR *zdrs, RECLAIM_COMPLETE4args *objp)
 uint32_t
 zdr_RECLAIM_COMPLETE4res (ZDR *zdrs, RECLAIM_COMPLETE4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->rcr_status))
 		 return FALSE;
 	return TRUE;
@@ -4204,9 +3316,6 @@ zdr_RECLAIM_COMPLETE4res (ZDR *zdrs, RECLAIM_COMPLETE4res *objp)
 uint32_t
 zdr_ILLEGAL4res (ZDR *zdrs, ILLEGAL4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -4215,9 +3324,6 @@ zdr_ILLEGAL4res (ZDR *zdrs, ILLEGAL4res *objp)
 uint32_t
 zdr_nfs_opnum4 (ZDR *zdrs, nfs_opnum4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -4226,9 +3332,6 @@ zdr_nfs_opnum4 (ZDR *zdrs, nfs_opnum4 *objp)
 uint32_t
 zdr_nfs_argop4 (ZDR *zdrs, nfs_argop4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_opnum4 (zdrs, &objp->argop))
 		 return FALSE;
 	switch (objp->argop) {
@@ -4449,9 +3552,6 @@ zdr_nfs_argop4 (ZDR *zdrs, nfs_argop4 *objp)
 uint32_t
 zdr_nfs_resop4 (ZDR *zdrs, nfs_resop4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_opnum4 (zdrs, &objp->resop))
 		 return FALSE;
 	switch (objp->resop) {
@@ -4688,9 +3788,6 @@ zdr_nfs_resop4 (ZDR *zdrs, nfs_resop4 *objp)
 uint32_t
 zdr_COMPOUND4args (ZDR *zdrs, COMPOUND4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_utf8str_cs (zdrs, &objp->tag))
 		 return FALSE;
 	 if (!zdr_uint32_t (zdrs, &objp->minorversion))
@@ -4704,9 +3801,6 @@ zdr_COMPOUND4args (ZDR *zdrs, COMPOUND4args *objp)
 uint32_t
 zdr_COMPOUND4res (ZDR *zdrs, COMPOUND4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	 if (!zdr_utf8str_cs (zdrs, &objp->tag))
@@ -4720,9 +3814,6 @@ zdr_COMPOUND4res (ZDR *zdrs, COMPOUND4res *objp)
 uint32_t
 zdr_CB_GETATTR4args (ZDR *zdrs, CB_GETATTR4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfs_fh4 (zdrs, &objp->fh))
 		 return FALSE;
 	 if (!zdr_bitmap4 (zdrs, &objp->attr_request))
@@ -4733,9 +3824,6 @@ zdr_CB_GETATTR4args (ZDR *zdrs, CB_GETATTR4args *objp)
 uint32_t
 zdr_CB_GETATTR4resok (ZDR *zdrs, CB_GETATTR4resok *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_fattr4 (zdrs, &objp->obj_attributes))
 		 return FALSE;
 	return TRUE;
@@ -4744,9 +3832,6 @@ zdr_CB_GETATTR4resok (ZDR *zdrs, CB_GETATTR4resok *objp)
 uint32_t
 zdr_CB_GETATTR4res (ZDR *zdrs, CB_GETATTR4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	switch (objp->status) {
@@ -4763,9 +3848,6 @@ zdr_CB_GETATTR4res (ZDR *zdrs, CB_GETATTR4res *objp)
 uint32_t
 zdr_CB_RECALL4args (ZDR *zdrs, CB_RECALL4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_stateid4 (zdrs, &objp->stateid))
 		 return FALSE;
 	 if (!zdr_bool (zdrs, &objp->truncate))
@@ -4778,9 +3860,6 @@ zdr_CB_RECALL4args (ZDR *zdrs, CB_RECALL4args *objp)
 uint32_t
 zdr_CB_RECALL4res (ZDR *zdrs, CB_RECALL4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -4789,9 +3868,6 @@ zdr_CB_RECALL4res (ZDR *zdrs, CB_RECALL4res *objp)
 uint32_t
 zdr_CB_ILLEGAL4res (ZDR *zdrs, CB_ILLEGAL4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	return TRUE;
@@ -4800,9 +3876,6 @@ zdr_CB_ILLEGAL4res (ZDR *zdrs, CB_ILLEGAL4res *objp)
 uint32_t
 zdr_nfs_cb_opnum4 (ZDR *zdrs, nfs_cb_opnum4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -4811,9 +3884,6 @@ zdr_nfs_cb_opnum4 (ZDR *zdrs, nfs_cb_opnum4 *objp)
 uint32_t
 zdr_nfs_cb_argop4 (ZDR *zdrs, nfs_cb_argop4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->argop))
 		 return FALSE;
 	switch (objp->argop) {
@@ -4836,9 +3906,6 @@ zdr_nfs_cb_argop4 (ZDR *zdrs, nfs_cb_argop4 *objp)
 uint32_t
 zdr_nfs_cb_resop4 (ZDR *zdrs, nfs_cb_resop4 *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->resop))
 		 return FALSE;
 	switch (objp->resop) {
@@ -4863,9 +3930,6 @@ zdr_nfs_cb_resop4 (ZDR *zdrs, nfs_cb_resop4 *objp)
 uint32_t
 zdr_CB_COMPOUND4args (ZDR *zdrs, CB_COMPOUND4args *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_utf8str_cs (zdrs, &objp->tag))
 		 return FALSE;
 	 if (!zdr_uint32_t (zdrs, &objp->minorversion))
@@ -4881,9 +3945,6 @@ zdr_CB_COMPOUND4args (ZDR *zdrs, CB_COMPOUND4args *objp)
 uint32_t
 zdr_CB_COMPOUND4res (ZDR *zdrs, CB_COMPOUND4res *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_nfsstat4 (zdrs, &objp->status))
 		 return FALSE;
 	 if (!zdr_utf8str_cs (zdrs, &objp->tag))
@@ -4897,9 +3958,6 @@ zdr_CB_COMPOUND4res (ZDR *zdrs, CB_COMPOUND4res *objp)
 uint32_t
 zdr_rpc_gss_proc_t (ZDR *zdrs, rpc_gss_proc_t *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_enum (zdrs, (enum_t *) objp))
 		 return FALSE;
 	return TRUE;
@@ -4908,9 +3966,6 @@ zdr_rpc_gss_proc_t (ZDR *zdrs, rpc_gss_proc_t *objp)
 uint32_t
 zdr_rpc_gss_cred_vers_1_t (ZDR *zdrs, rpc_gss_cred_vers_1_t *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_rpc_gss_proc_t (zdrs, &objp->gss_proc))
 		 return FALSE;
 	 if (!zdr_u_int (zdrs, &objp->seq_num))
@@ -4925,9 +3980,6 @@ zdr_rpc_gss_cred_vers_1_t (ZDR *zdrs, rpc_gss_cred_vers_1_t *objp)
 uint32_t
 zdr_rpc_gss_cred_t (ZDR *zdrs, rpc_gss_cred_t *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_u_int (zdrs, &objp->vers))
 		 return FALSE;
 	switch (objp->vers) {
@@ -4944,9 +3996,6 @@ zdr_rpc_gss_cred_t (ZDR *zdrs, rpc_gss_cred_t *objp)
 uint32_t
 zdr_rpc_gss_init_arg (ZDR *zdrs, rpc_gss_init_arg *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->gss_token.gss_token_val, (u_int *) &objp->gss_token.gss_token_len, ~0))
 		 return FALSE;
 	return TRUE;
@@ -4956,8 +4005,6 @@ uint32_t
 zdr_rpc_gss_init_res (ZDR *zdrs, rpc_gss_init_res *objp)
 {
 	register int32_t *buf;
-    buf = NULL;
-
 
 	if (zdrs->x_op == ZDR_ENCODE) {
 		 if (!zdr_bytes (zdrs, (char **)&objp->handle.handle_val, (u_int *) &objp->handle.handle_len, ~0))
@@ -5017,9 +4064,6 @@ zdr_rpc_gss_init_res (ZDR *zdrs, rpc_gss_init_res *objp)
 uint32_t
 zdr_rpc_gss_integ_data (ZDR *zdrs, rpc_gss_integ_data *objp)
 {
-	register int32_t *buf;
-    buf = NULL;
-
 	 if (!zdr_bytes (zdrs, (char **)&objp->databody_integ.databody_integ_val, (u_int *) &objp->databody_integ.databody_integ_len, ~0))
 		 return FALSE;
 	 if (!zdr_bytes (zdrs, (char **)&objp->checksum.checksum_val, (u_int *) &objp->checksum.checksum_len, ~0))

--- a/nfs4/nfs4.c
+++ b/nfs4/nfs4.c
@@ -324,7 +324,7 @@ struct rpc_pdu *rpc_nfs4_write_task(struct rpc_context *rpc, rpc_cb cb,
         }
 
         /* Add an iovector for the data itself */
-        if (rpc_add_iovector(rpc, &pdu->out, buf, count, NULL) < 0) {
+        if (rpc_add_iovector(rpc, &pdu->out, (char *)buf, count, NULL) < 0) {
 		rpc_free_pdu(rpc, pdu);
 		return NULL;
         }
@@ -332,7 +332,7 @@ struct rpc_pdu *rpc_nfs4_write_task(struct rpc_context *rpc, rpc_cb cb,
         /* We may need to pad this to 4 byte boundary */
         if (count & 0x03) {
                 if (rpc_add_iovector(rpc, &pdu->out, (char *)&zero_padding,
-                                     4 - count & 0x03,
+                                     4 - (count & 0x03),
                                      NULL) < 0) {
                         rpc_free_pdu(rpc, pdu);
                         return NULL;


### PR DESCRIPTION
Most of the warnings are due to -Wunused-but-set-variable, one is due to -Wdiscarded-qualifiers.
There are couple due to -Wparentheses. Those are noteworthy as the default precedence w/o the missing paranthesis is not what we want.

e.g.,
We have : 4 - count & 0x03
We want : 4 - (count & 0x03)
We get  : (4 - count) & 0x03

This is because '-' operator has higher precedence than '&' and they have left-to-right associativity.

Luckily, for the case (count & 0x03), the incorrect precedence also results in the same result, so it should not affect anything.