### PR TITLE
[Cmake] Match WindowsStore for windows based definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if(WIN32 AND BUILD_SHARED_LIBS)
   add_definitions(-Dlibnfs_EXPORTS)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows OR CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
   add_definitions("-D_U_=" -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
   list(APPEND SYSTEM_LIBRARIES ws2_32)
   add_subdirectory(win32)


### PR DESCRIPTION
We have been using libnfs in Kodi UWP platforms for quite a while. We have been updating our cmake build system recently, and are looking to use upstream build as much as we can.

For us, this means passing through CMAKE_SYSTEM_NAME (among others) through to the library being built, and therefore when we are targeting the UWP build, it has a CMAKE_SYSTEM_NAME of WindowsStore.

libnfs has worked, and continues to work for us on UWP platforms after this change.

I was going to do a MATCHES "Windows", but there are other system names (eg WindowsCE, WindowsPhone) that i dont know about functionality, so for now, just explicitly STREQUAL the two name system names.