### PR TITLE
Add RPC-with-TLS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.16)
 
 project(libnfs
         LANGUAGES C
@@ -32,7 +32,7 @@ if(IOS)
         add_definitions(-DHAVE_LIBKRB5)
     endif()
 endif()
-    
+
 include(cmake/ConfigureChecks.cmake)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR}
@@ -49,7 +49,38 @@ if(WIN32 AND BUILD_SHARED_LIBS)
   add_definitions(-Dlibnfs_EXPORTS)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL Windows OR CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  add_definitions("-D_U_=__attribute__((unused))")
+  #
+  # Currently RPC-with-TLS support is only available on Linux since it depends on kTLS support
+  # on Linux.
+  #
+  # TODO: BSD also has kTLS support, but that will need separate validation.
+  #
+  find_package(GnuTLS "3.4.6")
+  if(GNUTLS_FOUND)
+    #
+    # Make sure the two most important header files are present before we enable TLS support,
+    # to avoid running into issues later during build. GnuTLS package found but gnutls/gnutls.h
+    # not found is a serious issue while if linux/tls.h is not found it would likely mean that
+    # user is using a kernel not supporting kTLS so we simply don't turn on TLS support.
+    #
+    check_include_file("gnutls/gnutls.h" HAVE_GNUTLS_H)
+    if(NOT HAVE_GNUTLS_H EQUAL "1")
+      message(FATAL_ERROR "GnuTLS found but gnutls/gnutls.h not found, GNUTLS_INCLUDE_DIR is ${GNUTLS_INCLUDE_DIR}")
+    endif()
+
+    check_include_file("linux/tls.h" HAVE_LINUX_TLS_H)
+    if(NOT HAVE_LINUX_TLS_H EQUAL "1")
+      message(STATUS "GnuTLS found but linux/tls.h not found, likely a kernel w/o kTLS support, can't enable TLS support")
+    else()
+      message(STATUS "Using ${GNUTLS_LIBRARIES}")
+      add_definitions(-DHAVE_TLS)
+      list(APPEND SYSTEM_LIBRARIES ${GNUTLS_LIBRARIES})
+      add_subdirectory(tls)
+    endif()
+  endif()
+elseif(CMAKE_SYSTEM_NAME STREQUAL Windows OR CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
   add_definitions("-D_U_=" -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
   list(APPEND SYSTEM_LIBRARIES ws2_32)
   add_subdirectory(win32)

--- a/README
+++ b/README
@@ -77,8 +77,18 @@ Arguments supported by libnfs are :
                      default it 65534 on Windows and getuid() on unixen.
  gid=<int>         : GID value to use when talking to the server.
                      default it 65534 on Windows and getgid() on unixen.
+ debug=<int>       : Debug level used by libnfs. Default is 0 which is quiet.
+                     Higher values increase verbosity.
  sec=<krb5|krb5i|krb5p>
                    : Specify the security mode.
+ xprtsec=<none|tls|mtls>
+                   : Specify the transport security mode.
+                     none : No TLS security.
+                     tls  : TLS with server authentication only.
+                     mtls : Mutual TLS, both server and client authentication.
+
+                     See CERTIFICATES for details about specifying certificates/keys
+                     that libnfs must use when using "tls" or "mtls" security.
  auto-traverse-mounts=<0|1>
                    : Should libnfs try to traverse across nested mounts
                      automatically or not. Default is 1 == enabled.
@@ -145,6 +155,23 @@ you no longer need to edit the export on the NFS server to set "insecure".
 I do not know what equivalent "capability" support is available on other
 platforms. Please drop me an email if your os of choice has something similar
 and I can add it to the README.
+
+
+CERTIFICATES
+============
+libnfs reads CA certs from the following places, so make sure your server's CA
+cert is present in at least one of these:
+
+- default system trust store (/etc/ssl/certs/ca-certificates.crt on most systems).
+- all PEM format certs in the directory specified by env variable LIBNFS_TLS_TRUSTED_CA_DIR.
+- cert(s) present in the PEM file specified by env variable LIBNFS_TLS_TRUSTED_CA_PEM.
+
+If you want to use mutual TLS (xprtsec=mtls) then you will need a client certificate
+too. You need to provide the client's public certificate and the private key using
+the following environment variables.
+
+- LIBNFS_TLS_CLIENT_CERT_PEM - this is the public certificate.
+- LIBNFS_TLS_CLIENT_KEY_PEM  - this is the private key.
 
 
 DOCUMENTATION

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -32,6 +32,7 @@ check_include_file("sys/uio.h" HAVE_SYS_UIO_H)
 check_include_file("sys/vfs.h" HAVE_SYS_VFS_H)
 check_include_file("unistd.h" HAVE_UNISTD_H)
 check_include_file("utime.h" HAVE_UTIME_H)
+check_include_file("sys/utsname.h" HAVE_SYS_UTSNAME_H)
 
 include(CheckStructHasMember)
 check_struct_has_member("struct sockaddr" sa_len sys/socket.h HAVE_SOCKADDR_LEN)
@@ -70,6 +71,19 @@ check_c_source_compiles("#include <sys/types.h>
                            return 0;
                          }"
                         NO_LFS_REQUIRED)
+
+#
+# Find out if gnutls exports the function gnutls_transport_is_ktls_enabled().
+# This tells whether the gnutls library has kTLS support.
+#
+set(CMAKE_REQUIRED_LIBRARIES gnutls)
+check_c_source_compiles("#include <gnutls/socket.h>
+                         int main()
+                         {
+                                gnutls_session_t session;
+                                gnutls_transport_is_ktls_enabled(session);
+                         }"
+                        HAVE_GNUTLS_TRANSPORT_IS_KTLS_ENABLED)
 
 if(NOT NO_LFS_REQUIRED)
   check_c_source_compiles("#include <sys/types.h>

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -32,6 +32,7 @@ check_include_file("sys/uio.h" HAVE_SYS_UIO_H)
 check_include_file("sys/vfs.h" HAVE_SYS_VFS_H)
 check_include_file("unistd.h" HAVE_UNISTD_H)
 check_include_file("utime.h" HAVE_UTIME_H)
+check_include_file("signal.h" HAVE_SIGNAL_H)
 check_include_file("sys/utsname.h" HAVE_SYS_UTSNAME_H)
 
 include(CheckStructHasMember)

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -11,6 +11,7 @@ function(core_add_library name)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   add_library(${name} OBJECT ${SOURCES} ${HEADERS})
   target_include_directories(${name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+  target_include_directories(${name} PRIVATE ${INCLUDEDIRS})
   set(CORE_LIBRARIES "${name};${CORE_LIBRARIES}" CACHE INTERNAL "")
 
   # no need to install core libs if we build shared library

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -6,6 +6,9 @@
 /* Whether we have clock_gettime */
 #cmakedefine HAVE_CLOCK_GETTIME
 
+/* Whether gnutls exports the function gnutls_transport_is_ktls_enabled() */
+#cmakedefine HAVE_GNUTLS_TRANSPORT_IS_KTLS_ENABLED
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #cmakedefine HAVE_DLFCN_H
 
@@ -104,6 +107,9 @@
 
 /* Define to 1 if you have the <utime.h> header file. */
 #cmakedefine HAVE_UTIME_H
+
+/* Define to 1 if you have the <sys/utsname.h> header file. */
+#cmakedefine HAVE_SYS_UTSNAME_H
 
 /* Define to 1 if `major', `minor', and `makedev' are declared in <mkdev.h>.
    */

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -108,6 +108,9 @@
 /* Define to 1 if you have the <utime.h> header file. */
 #cmakedefine HAVE_UTIME_H
 
+/* Define to 1 if you have the <signal.h> header file. */
+#cmakedefine HAVE_SIGNAL_H
+
 /* Define to 1 if you have the <sys/utsname.h> header file. */
 #cmakedefine HAVE_SYS_UTSNAME_H
 

--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -35,6 +35,10 @@
 #include "lib/krb5-wrapper.h"
 #endif
 
+#ifdef HAVE_TLS
+#include <gnutls/gnutls.h>
+#endif
+
 #if defined(WIN32) && !defined(IFNAMSIZ)
 #define IFNAMSIZ 255
 #endif
@@ -172,6 +176,35 @@ enum input_state {
         READ_UNKNOWN = 5,
 };
 
+#ifdef HAVE_TLS
+struct tls_cb_data {
+	rpc_cb cb;
+	void *private_data;
+};
+
+typedef enum tls_handshake_state {
+	TLS_HANDSHAKE_UNDEFINED = 0,
+	TLS_HANDSHAKE_WAITING_FOR_STARTTLS,
+	TLS_HANDSHAKE_IN_PROGRESS,
+	TLS_HANDSHAKE_COMPLETED,
+	TLS_HANDSHAKE_FAILED,
+} tls_handshake_state_t;
+
+/*
+ * TLS handshake context information.
+ */
+struct tls_context {
+	/* Current TLS handshake state */
+	enum tls_handshake_state state;
+
+	/* Callback to be called on handshake completion (or failure) */
+	struct tls_cb_data data;
+
+	/* gnutls session used for the handshake */
+	gnutls_session_t session;
+};
+#endif /* HAVE_TLS */
+
 struct gss_ctx_id_struct;
 struct rpc_context {
 	uint32_t magic;
@@ -235,6 +268,42 @@ struct rpc_context {
 	char ifname[IFNAMSIZ];
 	int poll_timeout;
 
+#ifdef HAVE_TLS
+	/*
+	 * Transport level security as selected by the xprtsec=[none,tls,mtls]
+	 * mount option.
+	 */
+	enum rpc_xprtsec wanted_xprtsec;
+
+	/*
+	 * Do we need to send AUTH_TLS NULL RPC on connect/reconnect?
+	 * Note that we need this even with wanted_xprtsec as we use TLS only
+	 * for connections to NFS program and not for MOUNT or PORTMAP programs.
+	 * Once set, this remains set for the life of the rpc_context as we need
+	 * it for reconnect also. Note that this is fine for NFSv4 clients as they
+	 * only ever make RPC calls to NFS_PROGRAM. This is fine for NFSv3 clients
+	 * as we turn it on after we are done talking to the PORTMAP and MOUNT
+	 * programs and after that we only talk to NFS_PROGRAM using this rpc_context.
+	 *
+	 * Note: If the rpc_context is again used for talking to PORTMAP/MOUNT
+	 *       programs, use_tls must be cleared.
+	 */
+	bool_t use_tls;
+
+	/* NFS version to use when sending the AUTH_TLS NULL RPC */
+	int nfs_version;
+
+	/*
+	 * Server name to be used for certificate verification.
+	 * Since at RPC layer we don't have access to struct nfs_context, we instead
+	 * save a copy here from nfs_get_server().
+	 */
+	char *server;
+
+	/* Context used for performing TLS handshake with the server */
+	struct tls_context tls_context;
+#endif /* HAVE_TLS */
+
 #ifdef HAVE_LIBKRB5
         const char *username;
         enum rpc_sec wanted_sec;
@@ -242,7 +311,7 @@ struct rpc_context {
         uint32_t gss_seqno;
         int context_len;
         char *context;
-        
+
         void *auth_data; /* for krb5 */
         struct gss_ctx_id_struct *gss_context;
 #endif /* HAVE_LIBKRB5 */
@@ -297,15 +366,20 @@ struct rpc_pdu {
         int start_of_payload;
         gss_buffer_desc output_buffer;
 #endif
+
+#ifdef HAVE_TLS
+	/* Set by rpc_allocate_pdu2() when we use AUTH_TLS for a NULL RPC request */
+	bool_t expect_starttls;
+#endif
 };
 
 void rpc_reset_queue(struct rpc_queue *q);
 void rpc_enqueue(struct rpc_queue *q, struct rpc_pdu *pdu);
 void rpc_return_to_queue(struct rpc_queue *q, struct rpc_pdu *pdu);
 unsigned int rpc_hash_xid(struct rpc_context *rpc, uint32_t xid);
-
 struct rpc_pdu *rpc_allocate_pdu(struct rpc_context *rpc, int program, int version, int procedure, rpc_cb cb, void *private_data, zdrproc_t zdr_decode_fn, int zdr_bufsize);
 struct rpc_pdu *rpc_allocate_pdu2(struct rpc_context *rpc, int program, int version, int procedure, rpc_cb cb, void *private_data, zdrproc_t zdr_decode_fn, int zdr_bufsize, size_t alloc_hint);
+
 void rpc_free_pdu(struct rpc_context *rpc, struct rpc_pdu *pdu);
 int rpc_queue_pdu(struct rpc_context *rpc, struct rpc_pdu *pdu);
 int rpc_process_pdu(struct rpc_context *rpc, char *buf, int size);
@@ -324,13 +398,13 @@ void nfs_set_error(struct nfs_context *nfs, char *error_string, ...)
 #endif
 ;
 
-#if defined(PS2_EE)        
+#if defined(PS2_EE)
 #define RPC_LOG(rpc, level, format, ...) ;
-#else        
+#else
 #define RPC_LOG(rpc, level, format, ...) \
 	do { \
 		if (level <= rpc->debug) { \
-			fprintf(stderr, "libnfs:%d " format "\n", level, ## __VA_ARGS__); \
+			fprintf(stderr, "libnfs:%d rpc %p " format "\n", level, rpc, ## __VA_ARGS__); \
 		} \
 	} while (0)
 #endif
@@ -430,7 +504,7 @@ struct nfs_context_internal {
        struct nfs_thread_context *thread_ctx;
 #endif /* HAVE_MULTITHREADING */
 };
-        
+
 struct nfs_context {
        struct rpc_context *rpc;
        struct nfs_context_internal *nfsi;
@@ -448,7 +522,7 @@ struct nfs_thread_context {
         struct nfs_context nfs;
 };
 #endif /* HAVE_MULTITHREADING */
-        
+
 typedef int (*continue_func)(struct nfs_context *nfs, struct nfs_attr *attr,
 			     struct nfs_cb_data *data);
 
@@ -465,7 +539,7 @@ struct nfs_cb_data {
        void *continue_data;
        void (*free_continue_data)(void *);
        uint64_t continue_int;
-        
+
        struct nfs_fh fh;
 
        /* for multi-read/write calls. */
@@ -615,7 +689,7 @@ int nfs3_utimes_async_internal(struct nfs_context *nfs, const char *path,
 int nfs3_write_async(struct nfs_context *nfs, struct nfsfh *nfsfh,
                      const void *buf, size_t count, nfs_cb cb,
                      void *private_data);
-   
+
 int nfs4_access_async(struct nfs_context *nfs, const char *path, int mode,
                       nfs_cb cb, void *private_data);
 int nfs4_access2_async(struct nfs_context *nfs, const char *path, nfs_cb cb,
@@ -699,7 +773,12 @@ int rpc_write_to_socket(struct rpc_context *rpc);
 int _nfs_mount_async(struct nfs_context *nfs, const char *server,
                      const char *exportname, nfs_cb cb,
                      void *private_data);
-        
+
+#ifdef HAVE_TLS
+int tls_global_init(struct rpc_context *rpc);
+enum tls_handshake_state do_tls_handshake(struct rpc_context *rpc);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/nfsc/libnfs-raw.h
+++ b/include/nfsc/libnfs-raw.h
@@ -56,7 +56,7 @@ EXTERN void rpc_destroy_context(struct rpc_context *rpc);
  * before you connect to the remote service.
  */
 EXTERN int rpc_set_hash_size(struct rpc_context *rpc, int hashes);
-        
+
 EXTERN void rpc_set_auth(struct rpc_context *rpc, struct AUTH *auth);
 
 /*
@@ -83,7 +83,7 @@ EXTERN void rpc_set_auth(struct rpc_context *rpc, struct AUTH *auth);
  * Thus, if using rpc timeouts, you will need to ensure that rpc_service()
  * is invoked on a regular basis so that the timeout processing can take place.
  * The easiest way to do this is to call rpc_service() once every 100ms from
- * your event system and passing revents as 0. 
+ * your event system and passing revents as 0.
  */
 EXTERN int rpc_get_fd(struct rpc_context *rpc);
 EXTERN int rpc_which_events(struct rpc_context *rpc);
@@ -318,7 +318,7 @@ EXTERN int rpc_disconnect(struct rpc_context *rpc, const char *error);
  */
 struct rpc_pdu;
 int rpc_cancel_pdu(struct rpc_context *rpc, struct rpc_pdu *pdu);
-        
+
 /*
  * PORTMAP v2 FUNCTIONS
  */
@@ -2315,7 +2315,7 @@ rpc_nsm1_unmonall_task(struct rpc_context *rpc, rpc_cb cb,
 EXTERN struct rpc_pdu *
 rpc_nsm1_simucrash_task(struct rpc_context *rpc, rpc_cb cb,
                          void *private_data);
-        
+
 /*
  * Call NSM/NOTIFY
  *
@@ -2464,7 +2464,7 @@ rpc_nfs4_write_task(struct rpc_context *rpc, rpc_cb cb,
                      const void *buf, size_t count,
                      struct COMPOUND4args *args,
                      void *private_data);
-        
+
 /*
  * Call <generic>/NULL
  * Function returns
@@ -2484,6 +2484,32 @@ rpc_nfs4_write_task(struct rpc_context *rpc, rpc_cb cb,
 EXTERN struct rpc_pdu *
 rpc_null_task(struct rpc_context *rpc, int program, int version,
                rpc_cb cb, void *private_data);
+
+#ifdef HAVE_TLS
+/*
+ * Call <generic>/NULL RPC with AUTH_TLS in order to probe RPC-with-TLS
+ * support from the server, and if server supports RPC-with-TLS, initiate a TLS
+ * handshake. Callback will be called after TLS handshake completes (success or
+ * failure) and not just after we get a response for this NULL RPC.
+ * Function returns
+ * pdu  : The command was queued successfully. The callback will be invoked once
+ *        the command completes.
+ * NULL : An error occured when trying to queue the command.
+ *        The callback will not be invoked.
+ *
+ * When the callback is invoked, status indicates the result:
+ * RPC_STATUS_SUCCESS : We got a successful response from the server.
+ *                      data is NULL.
+ * RPC_STATUS_ERROR   : The command failed with an error, either server doesn't
+ *                      support TLS or the TLS handshake failed.
+ *                      data is the error string.
+ * RPC_STATUS_CANCEL  : The command was cancelled.
+ *                      data is NULL.
+ */
+EXTERN struct rpc_pdu *
+rpc_null_task_authtls(struct rpc_context *rpc, int nfs_version, rpc_cb cb,
+		      void *private_data);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/nfsc/libnfs-zdr.h
+++ b/include/nfsc/libnfs-zdr.h
@@ -108,6 +108,10 @@ typedef uint32_t (*zdrproc_t) (ZDR *, void *,...);
 #define AUTH_UNIX 1
 #define AUTH_GSS  6
 
+#ifdef HAVE_TLS
+#define AUTH_TLS  7
+#endif
+
 struct opaque_cred {
 	uint32_t oa_flavor;
 	caddr_t  oa_base;

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -149,7 +149,21 @@ enum rpc_sec {
 };
 EXTERN void nfs_set_security(struct nfs_context *nfs, enum rpc_sec sec);
         
-        
+#ifdef HAVE_TLS
+/*
+ * Various transport level security values that map to the mount option
+ * xprtsec=[none,tls,mtls].
+ */
+enum rpc_xprtsec {
+	RPC_XPRTSEC_UNDEFINED = 0,
+	RPC_XPRTSEC_NONE,	/* No transport security */
+	RPC_XPRTSEC_TLS,	/* TLS, with server authentication */
+	RPC_XPRTSEC_MTLS,	/* Mutual TLS, with both server and client authentication */
+};
+
+EXTERN void nfs_set_xprtsecurity(struct nfs_context *nfs, enum rpc_xprtsec xprtsec);
+#endif /* HAVE_TLS */
+
 /*
  * Used if you need to bind to a specific interface.
  * Only available on platforms that support SO_BINDTODEVICE.
@@ -227,6 +241,13 @@ EXTERN int nfs_set_hash_size(struct nfs_context *nfs, int hashes);
  *                     default is 65534 on Windows and getuid() on unixen.
  * gid=<int>         : GID value to use when talking to the server.
  *                     default is 65534 on Windows and getgid() on unixen.
+ * sec=<krb5|krb5i|krb5p>
+ *                   : Specify the security mode.
+ * xprtsec=<none|tls|mtls>
+ *                   : Specify the transport security mode.
+ *                     none : No TLS security.
+ *                     tls  : TLS with server authentication only.
+ *                     mtls : Mutual TLS, both server and client authentication.
  * auto-traverse-mounts=<0|1>
  *                   : Should libnfs try to traverse across nested mounts
  *                     automatically or not. Default is 1 == enabled.

--- a/lib/init.c
+++ b/lib/init.c
@@ -464,6 +464,9 @@ void rpc_destroy_context(struct rpc_context *rpc)
         free(discard_const(rpc->username));
         free(rpc->context);
 #endif /* HAVE_LIBKRB5 */
+#ifdef HAVE_TLS
+	free(rpc->server);
+#endif
 	free(rpc);
 }
 

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -169,6 +169,19 @@ nfs_set_security(struct nfs_context *nfs, enum rpc_sec sec)
 #endif
 }
 
+#ifdef HAVE_TLS
+void
+nfs_set_xprtsecurity(struct nfs_context *nfs, enum rpc_xprtsec xprtsec)
+{
+	/* Ensure only permissible values are being set */
+	assert(xprtsec == RPC_XPRTSEC_NONE ||
+	       xprtsec == RPC_XPRTSEC_TLS ||
+	       xprtsec == RPC_XPRTSEC_MTLS);
+
+	nfs->rpc->wanted_xprtsec = xprtsec;
+}
+#endif /* HAVE_TLS */
+
 int
 nfs_get_fd(struct nfs_context *nfs)
 {
@@ -207,7 +220,7 @@ nfs_get_error(struct nfs_context *nfs)
                         }
                 }
         }
-#endif        
+#endif
 	return nfs->error_string ? nfs->error_string : "";
 };
 
@@ -259,6 +272,19 @@ nfs_set_context_args(struct nfs_context *nfs, const char *arg, const char *val)
 		} else {
 			nfs_set_readdir_max_buffer_size(nfs, atoi(val), atoi(val));
 		}
+#ifdef HAVE_TLS
+	} else if (nfs->rpc && !strcmp(arg, "xprtsec")) {
+		if (!strcmp(val, "none")) {
+			nfs_set_xprtsecurity(nfs, RPC_XPRTSEC_NONE);
+		} else if (!strcmp(val, "tls")) {
+			nfs_set_xprtsecurity(nfs, RPC_XPRTSEC_TLS);
+		} else  if (!strcmp(val, "mtls")) {
+			nfs_set_xprtsecurity(nfs, RPC_XPRTSEC_MTLS);
+		} else {
+			nfs_set_error(nfs, "Unknown/unsupported xprtsec type : %s", val);
+			return -1;
+		}
+#endif /* HAVE_TLS */
 #ifdef HAVE_LIBKRB5
 	} else if (nfs->rpc && !strcmp(arg, "sec")) {
                 /*
@@ -346,7 +372,7 @@ nfs_parse_url(struct nfs_context *nfs, const char *url, int dir, int incomplete)
                 strcpy(strp + 1, strp + 3);
                 strp++;
         }
-       
+
 	if (urls->server[0] == '/' || urls->server[0] == '\0' ||
 		urls->server[0] == '?') {
 		if (incomplete) {
@@ -433,7 +459,8 @@ flags:
 		if (strp2) {
 			*strp2 = 0;
 			strp2++;
-			nfs_set_context_args(nfs, strp, strp2);
+			if (nfs_set_context_args(nfs, strp, strp2) != 0)
+				return NULL;
 		}
 	}
 
@@ -447,6 +474,21 @@ flags:
 		free(urls->server);
 		urls->server = NULL;
 	}
+
+#ifdef HAVE_TLS
+	/*
+	 * Call this in the end after all options are processed, as it uses
+	 * rpc->debug.
+	 */
+	if (nfs->rpc->wanted_xprtsec != RPC_XPRTSEC_NONE) {
+		/* tls_global_init() MUST succeed for us to use TLS security */
+		if (tls_global_init(nfs->rpc) != 0) {
+			nfs_set_error(nfs, "tls_global_init() failed!");
+			nfs_destroy_url(urls);
+			return NULL;
+		}
+	}
+#endif
 
 	return urls;
 }
@@ -498,7 +540,7 @@ nfs_init_context(void)
 		return NULL;
 	}
 	memset(nfsi, 0, sizeof(struct nfs_context_internal));
-        
+
 	nfs = malloc(sizeof(struct nfs_context));
 	if (nfs == NULL) {
                 free(nfsi);
@@ -544,6 +586,7 @@ nfs_init_context(void)
         nfs_mt_mutex_init(&nfs->nfsi->nfs4_open_counter_mutex);
         nfs_mt_mutex_init(&nfs->nfsi->nfs4_open_call_mutex);
 #endif /* HAVE_MULTITHREADING */
+
 	return nfs;
 }
 
@@ -576,7 +619,7 @@ nfs_destroy_context(struct nfs_context *nfs)
 
         free(nfs->error_string);
         nfs->error_string = NULL;
-        
+
         free(nfs->nfsi->server);
         free(nfs->nfsi->export);
         free(nfs->nfsi->cwd);
@@ -629,7 +672,7 @@ rpc_null_task_gss(struct rpc_context *rpc, int program, int version,
                   rpc_cb cb, void *private_data)
 {
 	struct rpc_pdu *pdu;
-        
+
 	pdu = rpc_allocate_pdu(rpc, program, version, 0, cb, private_data,
                                (zdrproc_t)zdr_rpc_gss_init_res, sizeof(struct rpc_gss_init_res));
 	if (pdu == NULL) {
@@ -667,11 +710,72 @@ rpc_connect_program_6_cb(struct rpc_context *rpc, int status,
 		free_rpc_cb_data(data);
 		return;
 	}
-        
+
 	data->cb(rpc, status, NULL, data->private_data);
 	free_rpc_cb_data(data);
 }
 #endif /* HAVE_LIBKRB5 */
+
+#ifdef HAVE_TLS
+void free_tls_cb_data(struct tls_cb_data *data)
+{
+	free(data);
+}
+
+/*
+ * Callback function called when we get a response for an AUTH_TLS NULL RPC
+ * that we sent to the server.
+ * On a successful response confirming server support for TLS, this will
+ * initiate an async TLS handshake process.
+ */
+static void
+rpc_connect_program_4_1_cb(struct rpc_context *rpc, int status,
+			   void *command_data, void *private_data)
+{
+	struct tls_cb_data *data = private_data;
+
+	assert(rpc->magic == RPC_CONTEXT_MAGIC);
+
+	RPC_LOG(rpc, 2, "Got AUTH_TLS response, status=%d", status);
+
+	if (status != RPC_STATUS_SUCCESS) {
+		data->cb(rpc, status, command_data, data->private_data);
+		free_tls_cb_data(data);
+		return;
+	}
+
+	/*
+	 * Ok, server supports RPC-with-TLS, start handshake.
+	 */
+	rpc->tls_context.data = *data;
+	free_tls_cb_data(data);
+	data = &rpc->tls_context.data;
+
+	rpc->tls_context.state = do_tls_handshake(rpc);
+
+	switch (rpc->tls_context.state) {
+		case TLS_HANDSHAKE_IN_PROGRESS:
+			/*
+			 * We will continue this asynchronously in rpc_service(), as we
+			 * hear from the peer.
+			 */
+			return;
+		case TLS_HANDSHAKE_COMPLETED:
+			RPC_LOG(rpc, 2, "do_tls_handshake: TLS handshake completed "
+					"synchronously on fd %d", rpc->fd);
+			data->cb(rpc, RPC_STATUS_SUCCESS, NULL, data->private_data);
+			break;
+		case TLS_HANDSHAKE_FAILED:
+			RPC_LOG(rpc, 2, "do_tls_handshake: Failed to start TLS handshake, or "
+					"TLS handshake failed synchronously on fd %d", rpc->fd);
+			data->cb(rpc, RPC_STATUS_ERROR, rpc_get_error(rpc), data->private_data);
+			break;
+		default:
+			/* Should not return any other status */
+			assert(0);
+	}
+}
+#endif /* HAVE_TLS */
 
 static void
 rpc_connect_program_5_cb(struct rpc_context *rpc, int status,
@@ -750,6 +854,27 @@ rpc_connect_program_4_cb(struct rpc_context *rpc, int status,
 		return;
 	}
 
+#ifdef HAVE_TLS
+	/*
+	 * Connected to RPC endpoint, for NFS connections see if we need to secure them.
+	 * If yes, we query the server TLS support by sending a NULL RPC with auth flavor
+	 * AUTH_TLS and if server supports RPC-with-TLS we initiate the TLS handshake.
+	 */
+	rpc->use_tls = (data->program == NFS_PROGRAM) &&
+				(rpc->wanted_xprtsec == RPC_XPRTSEC_TLS ||
+				 rpc->wanted_xprtsec == RPC_XPRTSEC_MTLS);
+	if (rpc->use_tls) {
+		/* We should not use TLS for anything other than NFS */
+		assert(data->program == NFS_PROGRAM);
+
+		if (rpc_null_task_authtls(rpc, data->version,
+					  rpc_connect_program_5_cb, data) == NULL) {
+			data->cb(rpc, RPC_STATUS_ERROR, command_data, data->private_data);
+			free_rpc_cb_data(data);
+			return;
+		}
+	} else
+#endif
         if (rpc_null_task(rpc, data->program, data->version,
                           rpc_connect_program_5_cb, data) == NULL) {
                 data->cb(rpc, RPC_STATUS_ERROR, command_data, data->private_data);
@@ -1993,6 +2118,9 @@ nfs_set_version(struct nfs_context *nfs, int version) {
 	switch (version) {
 	case NFS_V3:
 	case NFS_V4:
+#ifdef HAVE_TLS
+		nfs->rpc->nfs_version = version;
+#endif
 		nfs->nfsi->version = version;
 		nfs->nfsi->default_version = 0;
 		break;
@@ -2238,3 +2366,59 @@ rpc_null_task(struct rpc_context *rpc, int program, int version, rpc_cb cb,
 
 	return pdu;
 }
+
+#ifdef HAVE_TLS
+/*
+ * Call this in place of rpc_null_task() if user wants TLS security for the RPC
+ * connection. Since we only ever send AUTH_TLS NULL RPC for NFS_PROGRAM it does
+ * not need the program parameter.
+ * Callback 'cb' is called not after we get the reply for this AUTH_TLS NULL RPC,
+ * but after the TLS handshake completes (success or failure).
+ */
+struct rpc_pdu *
+rpc_null_task_authtls(struct rpc_context *rpc, int nfs_version, rpc_cb cb,
+		      void *private_data)
+{
+	struct rpc_pdu *pdu;
+	struct tls_cb_data *data;
+
+	/* Must be called only for secure connections to NFS_PROGRAM version 3 or 4 */
+	assert(rpc->use_tls);
+	assert(nfs_version == NFS_V3 || nfs_version == NFS_V4);
+
+	data = calloc(1, sizeof(*data));
+	if (data == NULL) {
+		rpc_set_error(rpc, "Out of memory. Failed to allocate tls_cb_data "
+			      "for AUTH_TLS NULL call");
+		return NULL;
+	}
+	data->cb 	   = cb;
+	data->private_data = private_data;
+
+	/*
+	 * Set MSbit in procedure number to convey use of AUTH_TLS
+	 * This should not interfere with valid procedure numbers as they are all
+	 * small numbers.
+	 */
+	pdu = rpc_allocate_pdu(rpc, NFS_PROGRAM, nfs_version, (0 | (1U << 31)),
+			       rpc_connect_program_4_1_cb, data,
+			       (zdrproc_t)zdr_void, 0);
+	if (pdu == NULL) {
+		rpc_set_error(rpc, "Out of memory. Failed to allocate pdu "
+			      "for AUTH_TLS NULL call");
+		free_tls_cb_data(data);
+		return NULL;
+	}
+
+	rpc->tls_context.state = TLS_HANDSHAKE_WAITING_FOR_STARTTLS;
+
+	if (rpc_queue_pdu(rpc, pdu) != 0) {
+		rpc_set_error(rpc, "Out of memory. Failed to queue pdu "
+				"for AUTH_TLS NULL call");
+		free_tls_cb_data(data);
+		return NULL;
+	}
+
+	return pdu;
+}
+#endif /* HAVE_TLS */

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -2417,7 +2417,7 @@ rpc_null_task_authtls(struct rpc_context *rpc, int nfs_version, rpc_cb cb,
 	 * This should not interfere with valid procedure numbers as they are all
 	 * small numbers.
 	 */
-	pdu = rpc_allocate_pdu(rpc, NFS_PROGRAM, nfs_version, (0 | (1U << 31)),
+	pdu = rpc_allocate_pdu(rpc, NFS_PROGRAM, nfs_version, (0 | 0x80000000U),
 			       rpc_connect_program_4_1_cb, data,
 			       (zdrproc_t)zdr_void, 0);
 	if (pdu == NULL) {

--- a/lib/nfs_v3.c
+++ b/lib/nfs_v3.c
@@ -1063,6 +1063,7 @@ nfs3_mount_2_cb(struct rpc_context *rpc, int status, void *command_data,
 	}
 
 	rpc_disconnect(rpc, "normal disconnect");
+
         if (nfs->nfsi->nfsport) {
                 if (rpc_connect_port_async(nfs->rpc, nfs_get_server(nfs),
                                            nfs->nfsi->nfsport,
@@ -1128,6 +1129,11 @@ nfs3_mount_async(struct nfs_context *nfs, const char *server,
         free(nfs->nfsi->server);
 	nfs->nfsi->server = new_server;
         
+#ifdef HAVE_TLS
+	free(nfs->rpc->server);
+	nfs->rpc->server = strdup(nfs->nfsi->server);
+#endif
+
 	new_export = strdup(export);
 	if (new_export == NULL) {
 		nfs_set_error(nfs, "out of memory. failed to allocate "

--- a/lib/nfs_v4.c
+++ b/lib/nfs_v4.c
@@ -1625,6 +1625,11 @@ nfs4_mount_async(struct nfs_context *nfs, const char *server,
         free(nfs->nfsi->server);
         nfs->nfsi->server = new_server;
 
+#ifdef HAVE_TLS
+	free(nfs->rpc->server);
+	nfs->rpc->server = strdup(nfs->nfsi->server);
+#endif
+
         new_export = strdup(export);
 	if (new_export == NULL) {
 		nfs_set_error(nfs, "out of memory. failed to allocate "

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -551,11 +551,17 @@ rpc_read_from_socket(struct rpc_context *rpc)
 			if (errno == EINTR || errno == EAGAIN) {
 				break;
 			}
-			rpc_set_error(rpc, "Read from socket failed, errno:%d. "
-                                      "Closing socket.", errno);
+			rpc_set_error(rpc, "Read from socket(%d) failed, errno:%d (%s). "
+                                      "Closing socket.", rpc->fd, errno, strerror(errno));
+			RPC_LOG(rpc, 2, "Read from socket(%d) failed, errno:%d (%s). "
+				"Closing socket.", rpc->fd, errno, strerror(errno));
 			return -1;
 		}
 		if (count == 0) {
+			rpc_set_error(rpc, "Remote side closed connection for socket fd %d",
+				      rpc->fd);
+			RPC_LOG(rpc, 2, "Remote side closed connection for socket fd %d",
+				rpc->fd);
 			/* remote side has closed the socket. Reconnect. */
 			return -1;
 		}
@@ -841,15 +847,93 @@ rpc_service(struct rpc_context *rpc, int revents)
 		return 0;
 	}
 
+#ifdef HAVE_TLS
+	/*
+	 * We perform TLS handshake in a nonblocking fashion, i.e., we don't
+	 * block on recv() and send(), so if we get a POLLIN or POLLOUT event
+	 * during TLS handshake we must advance the TLS handshake process by
+	 * calling do_tls_handshake() again. do_tls_handshake() will return
+	 * TLS_HANDSHAKE_IN_PROGRESS if it needs to wait for network IO, o/w
+	 * it'll complete the handshake process.
+	 * Note that do_tls_handshake() can correctly handle multiple calls and
+	 * it can advance the handshake process till it either completes successfully
+	 * or fails.
+	 */
+	if (rpc->tls_context.state == TLS_HANDSHAKE_IN_PROGRESS &&
+			(revents & (POLLOUT | POLLIN))) {
+		struct tls_cb_data *data = &rpc->tls_context.data;
+
+		/* Should be only doing this for secure transport */
+		assert(rpc->use_tls);
+
+		rpc->tls_context.state = do_tls_handshake(rpc);
+
+		switch (rpc->tls_context.state) {
+			case TLS_HANDSHAKE_IN_PROGRESS:
+				RPC_LOG(rpc, 2, "do_tls_handshake() returned "
+						"TLS_HANDSHAKE_IN_PROGRESS on fd %d",
+					rpc->fd);
+				break;
+			case TLS_HANDSHAKE_COMPLETED:
+				RPC_LOG(rpc, 2, "do_tls_handshake() returned "
+						"TLS_HANDSHAKE_COMPLETED on fd %d",
+					rpc->fd);
+				data->cb(rpc, RPC_STATUS_SUCCESS, NULL, data->private_data);
+				break;
+			case TLS_HANDSHAKE_FAILED:
+				RPC_LOG(rpc, 1, "do_tls_handshake() returned "
+						"TLS_HANDSHAKE_FAILED on fd %d",
+					rpc->fd);
+				data->cb(rpc, RPC_STATUS_ERROR, "TLS_HANDSHAKE_FAILED",
+					 data->private_data);
+				break;
+			default:
+				/* Should not return any other status */
+				assert(0);
+		}
+
+		return 0;
+	}
+#endif /* HAVE_TLS */
+
 	if (revents & POLLIN) {
 		if (rpc_read_from_socket(rpc) != 0) {
                         if (rpc->is_server_context) {
                                 return -1;
                         } else {
+#ifdef HAVE_TLS
+				/*
+				 * TODO: read from ktls sockets will fail with EIO
+				 *       if TLS records of type other than data
+				 *       (e.g., alert or handshake) are received.
+				 *       We will need to issue a recvmsg() call
+				 *       with enough cmsg space to fetch the
+				 *       record type and data correctly.
+				 *       We can then log that here to help the
+				 *       user. In any case the only valid course
+				 *       of action is to terminate the connection
+				 *       and reconnect so that we can correctly
+				 *       re-auth.
+				 */
+#endif /* HAVE_TLS */
                                 return rpc_reconnect_requeue(rpc);
                         }
 		}
 	}
+
+#ifdef HAVE_TLS
+	/*
+	 * For secure NFS connections we should never write to the socket w/o
+	 * properly completing the TLS handshake. Note that we do allow reads
+	 * from the socket as we would want to read response to the AUTH_TLS
+	 * NULL RPC.
+	 */
+	if (rpc->use_tls && (rpc->tls_context.state != TLS_HANDSHAKE_COMPLETED)) {
+                RPC_LOG(rpc, 2, "TLS handshake state %d on fd %d, skipping socket write!",
+			rpc->tls_context.state, rpc->fd);
+                return 0;
+        }
+#endif
 
 	if (revents & POLLOUT && rpc_has_queue(&rpc->outqueue)) {
 		if (rpc_write_to_socket(rpc) != 0) {
@@ -1146,8 +1230,47 @@ rpc_disconnect(struct rpc_context *rpc, const char *error)
 	return 0;
 }
 
+#ifdef HAVE_TLS
+/*
+ * During TCP reconnection (either server or client closes connection) for secure
+ * transport we need to perform the TLS handshake. This is the callback function
+ * called when a TLS handshake performed during reconnection completes.
+ */
 static void
-reconnect_cb(struct rpc_context *rpc, int status, void *data _U_,
+reconnect_cb_tls(struct rpc_context *rpc, int status,
+		 void *command_data, void *private_data)
+{
+	assert(rpc->magic == RPC_CONTEXT_MAGIC);
+
+	/* Must be called only for TLS transport */
+	assert(rpc->use_tls);
+
+	/* Must be called only after TLS handshake completes/fails */
+	assert(rpc->tls_context.state == TLS_HANDSHAKE_COMPLETED ||
+	       rpc->tls_context.state == TLS_HANDSHAKE_FAILED);
+
+	/*
+	 * If handshake failed, restart the entire TCP connection not just the handshake.
+	 * This will create a new connection and perform the handshake.
+	 */
+	if (rpc->tls_context.state == TLS_HANDSHAKE_FAILED) {
+		RPC_LOG(rpc, 1, "reconnect_cb_tls: TLS handshake failed, restarting connection!");
+
+		if (rpc->fd != -1) {
+			close(rpc->fd);
+			rpc->fd  = -1;
+		}
+		rpc->is_connected = 0;
+		rpc_reconnect_requeue(rpc);
+		return;
+	}
+
+	RPC_LOG(rpc, 2, "reconnect_cb_tls: TLS handshake completed successfully!");
+}
+#endif
+
+static void
+reconnect_cb(struct rpc_context *rpc, int status, void *data,
              void *private_data)
 {
 	assert(rpc->magic == RPC_CONTEXT_MAGIC);
@@ -1161,6 +1284,34 @@ reconnect_cb(struct rpc_context *rpc, int status, void *data _U_,
 	rpc->is_connected = 1;
 	rpc->connect_cb   = NULL;
 	rpc->old_fd = 0;
+
+#ifdef HAVE_TLS
+	/*
+	 * For secure NFS connections, we need to setup TLS session now.
+	 */
+	RPC_LOG(rpc, 2, "reconnect_cb called with status %d", status);
+	if (rpc->use_tls) {
+		if (rpc_null_task_authtls(rpc, rpc->nfs_version,
+					  reconnect_cb_tls, NULL) == NULL) {
+			RPC_LOG(rpc, 1, "reconnect_cb: rpc_null_task_authtls() failed, "
+				"restarting connection!");
+			/*
+			 * Force reconnect so that we can time the retries using
+			 * the existing rpc->num_retries. Forcing reconnect also
+			 * has the advantage that it sets up a fresh TCP connection
+			 * in case the older connection had some issues preventing
+			 * successful TLS handshake.
+			 */
+			if (rpc->fd != -1) {
+				close(rpc->fd);
+				rpc->fd  = -1;
+			}
+			rpc->is_connected = 0;
+			rpc_reconnect_requeue(rpc);
+			return;
+		}
+	}
+#endif /* HAVE_TLS */
 }
 
 /* Disconnect but do not error all PDUs, just move pdus in-flight back to the

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -1023,6 +1023,7 @@ rpc_connect_sockaddr_async(struct rpc_context *rpc)
 	if (rpc->old_fd) {
 #if !defined(WIN32) && !defined(PS3_PPU) && !defined(PS2_EE)
 		if (dup2(rpc->fd, rpc->old_fd) == -1) {
+			rpc_set_error(rpc, "dup2() failed: %s", strerror(errno));
 			return -1;
 		}
 		close(rpc->fd);

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(SOURCES handshake.c
+            ktls.c)
+set(INCLUDEDIRS ${GNUTLS_INCLUDE_DIR})
+core_add_library(tls)

--- a/tls/handshake.c
+++ b/tls/handshake.c
@@ -1,4 +1,20 @@
 /* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:nil;  -*- */
+/*
+   Copyright (C) 2024 by Linuxsmiths <linuxsmiths@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation; either version 2.1 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE

--- a/tls/handshake.c
+++ b/tls/handshake.c
@@ -1,0 +1,457 @@
+/* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:nil;  -*- */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <netinet/tcp.h>
+#include <linux/in.h>
+
+#ifdef HAVE_SYS_UTSNAME_H
+#include <sys/utsname.h>
+#endif
+
+#include <gnutls/gnutls.h>
+
+#include "libnfs.h"
+#include "libnfs-raw.h"
+#include "libnfs-private.h"
+#include "tls-private.h"
+
+#ifdef _GNU_SOURCE
+#define GETENV secure_getenv
+#else
+#define GETENV getenv
+#endif
+
+/*
+ * This is a safe version we choose. Technically the support was added in kernel
+ * 4.17.
+ *
+ * XXX This can be udpated after enough validation.
+ */
+#define MIN_KERNEL_VERSION_FOR_KTLS	"5.10"
+
+static bool_t global_init_done;
+static gnutls_certificate_credentials_t xcred;
+static bool_t tls_global_init_done;
+
+int tls_log_level;
+
+static void libnfs_gnutls_audit_func(gnutls_session_t session, const char *msg)
+{
+	fprintf(stderr, "gnutls audit [%p]: %s\n", session, msg);
+}
+
+#ifdef HAVE_SYS_UTSNAME_H
+bool kernel_version_at_least(const char *min_version)
+{
+	struct utsname utsname;
+
+	if (GETENV("KTLS_SKIP_KERNEL_VERSION_CHECK") != NULL) {
+		TLS_LOG(2, "Skipping kernel version check, RPC-with-TLS may not work!");
+		return true;
+	}
+
+	if (uname(&utsname) < 0) {
+		TLS_LOG(1, "uname() failed: %s", strerror(errno));
+		return false;
+	}
+
+	TLS_LOG(2, "%s kernel version %s detected", utsname.sysname, utsname.release);
+
+	if (strcmp(utsname.sysname, "Linux") != 0) {
+		TLS_LOG(1, "RPC-with-TLS only supported on Linux");
+		return false;
+	}
+
+	if (strverscmp(utsname.release, min_version) < 0) {
+		TLS_LOG(1, "Kernel version %s less than min version known to work %s",
+				utsname.release, min_version);
+		return false;
+	}
+
+	return true;
+}
+#else
+bool kernel_version_at_least(const char *min_version _U_)
+{
+	TLS_LOG(2, "uname() not found, cannot perform kernel min version check");
+	return true;
+}
+#endif
+
+/*
+ * Global/onetime TLS specific initializations.
+ * MUST be called if user selected xprtsec=[tls,mtls] mount option.
+ */
+int tls_global_init(struct rpc_context *rpc)
+{
+	const char *trusted_ca_file;
+	const char *trusted_ca_dir;
+	const char *client_cert_file;
+	const char *client_key_file;
+	int total_certs_loaded = 0;
+	int ret;
+
+	/* All but the first successful call will be a no-op */
+	if (tls_global_init_done)
+		return 0;
+
+	/* Based on various gnutls functions we call this is the min version */
+	if (gnutls_check_version("3.4.6") == NULL) {
+		TLS_LOG(1, "tls_global_init: GnuTLS 3.4.6 or later is required");
+		return -1;
+	}
+
+	/* Bail out if kernel version detected is not known to work */
+	if (!kernel_version_at_least(MIN_KERNEL_VERSION_FOR_KTLS)) {
+		return -1;
+	}
+
+	/*
+	 * XXX See if we need a separate log level for gnutls, but for now
+	 *     let's use the libnfs debug level which is still pretty usable
+	 *     as it allows us to control the loglevel using debug= option.
+	 *
+	 *     This can be overridden using env variable "GNUTLS_DEBUG_LEVEL".
+	 */
+	tls_log_level = rpc->debug;
+	gnutls_global_set_log_level(tls_log_level);
+	gnutls_global_set_audit_log_function(libnfs_gnutls_audit_func);
+
+	TLS_LOG(2, "Using GnuTLS version %s", gnutls_check_version("0.0.0"));
+
+	/* For backwards compatibility with gnutls < 3.3.0 */
+	ret = gnutls_global_init();
+	if (ret < 0) {
+		TLS_LOG(1, "tls_global_init: gnutls_global_init() failed (%d): %s",
+			ret, gnutls_strerror(ret));
+		return -1;
+	}
+	/* Now gnutls_global_deinit() can be safely called */
+	global_init_done = TRUE;
+
+	/* X509 stuff */
+	ret = gnutls_certificate_allocate_credentials(&xcred);
+	if (ret < 0) {
+		TLS_LOG(1, "tls_global_init: gnutls_certificate_allocate_credentials() "
+			"failed (%d): %s", ret, gnutls_strerror(ret));
+		goto failed;
+	}
+
+	total_certs_loaded = 0;
+
+	/* Load trusted CA certs from system trust store for Internet PKI */
+	ret = gnutls_certificate_set_x509_system_trust(xcred);
+	if (ret < 0) {
+		TLS_LOG(1, "tls_global_init: gnutls_certificate_set_x509_system_trust() "
+			"failed (%d): %s", ret, gnutls_strerror(ret));
+		/*
+		 * Don't fail as yet, we fail if we are not able to load any certs
+		 * from any sources.
+		 */
+	} else {
+		TLS_LOG(2, "tls_global_init: Loaded %d certificate(s) from system "
+			"trust store", ret);
+		total_certs_loaded += ret;
+	}
+
+	/* Load from LIBNFS_TLS_TRUSTED_CA_DIR if user has provided */
+	trusted_ca_dir = GETENV("LIBNFS_TLS_TRUSTED_CA_DIR");
+	if (trusted_ca_dir != NULL) {
+		ret = gnutls_certificate_set_x509_trust_dir(xcred,
+							    trusted_ca_dir,
+							    GNUTLS_X509_FMT_PEM);
+		if (ret < 0) {
+			TLS_LOG(1, "tls_global_init: gnutls_certificate_set_x509_trust_dir(%s) "
+				"failed (%d): %s", trusted_ca_dir, ret, gnutls_strerror(ret));
+			/* Don't fail as yet */
+		} else {
+			TLS_LOG(2, "tls_global_init: Loaded %d certificate(s) from dir %s",
+				ret, trusted_ca_dir);
+			total_certs_loaded += ret;
+		}
+	}
+
+	/* Load from LIBNFS_TLS_TRUSTED_CA_PEM if user has provided */
+	trusted_ca_file = GETENV("LIBNFS_TLS_TRUSTED_CA_PEM");
+	if (trusted_ca_file != NULL) {
+		ret = gnutls_certificate_set_x509_trust_file(xcred,
+							     trusted_ca_file,
+							     GNUTLS_X509_FMT_PEM);
+		if (ret < 0) {
+			TLS_LOG(1, "tls_global_init: gnutls_certificate_set_x509_trust_file(%s) "
+				"failed (%d): %s", trusted_ca_file, ret, gnutls_strerror(ret));
+			/* Don't fail as yet */
+		} else {
+			TLS_LOG(2, "tls_global_init: Loaded %d certificate(s) from file %s",
+				ret, trusted_ca_file);
+			total_certs_loaded += ret;
+		}
+	}
+
+	/* If no certs loaded, there's no point in proceeding */
+	if (total_certs_loaded == 0) {
+		TLS_LOG(1, "tls_global_init: No CA certs loaded, make sure your system trust "
+			"store is setup correctly and/or you have correctly set the "
+			"LIBNFS_TLS_TRUSTED_CA_DIR and/or LIBNFS_TLS_TRUSTED_CA_PEM "
+			"env variables!");
+		goto failed;
+	}
+
+	/*
+	 * Set the client cert and key if user has provided.
+	 * This is required for mtls. User must provide both or none.
+	 */
+	client_cert_file = GETENV("LIBNFS_TLS_CLIENT_CERT_PEM");
+	client_key_file = GETENV("LIBNFS_TLS_CLIENT_KEY_PEM");
+
+	if (client_cert_file && client_key_file) {
+		ret = gnutls_certificate_set_x509_key_file(xcred,
+							   client_cert_file,
+							   client_key_file,
+							   GNUTLS_X509_FMT_PEM);
+		if (ret < 0) {
+			TLS_LOG(1, "tls_global_init: gnutls_certificate_set_x509_key_file(%s, %s) "
+				"failed (%d): %s",
+				client_cert_file, client_key_file, ret, gnutls_strerror(ret));
+			goto failed;
+		}
+	} else if (client_cert_file) {
+		TLS_LOG(1, "tls_global_init: Client cert specified (%s) but not key, "
+			"mtls cannot be used", client_cert_file);
+	} else if (client_key_file) {
+		TLS_LOG(1, "tls_global_init: Client key specified (%s) but not cert, "
+			"mtls cannot be used", client_key_file);
+	} else {
+		TLS_LOG(2, "tls_global_init: Client cert and key not specified, mtls "
+			"cannot be used");
+	}
+
+	tls_global_init_done = TRUE;
+	return 0;
+
+failed:
+	gnutls_certificate_free_credentials(xcred);
+
+	if (global_init_done) {
+		gnutls_global_deinit();
+		global_init_done = FALSE;
+	}
+
+	return -1;
+}
+
+/*
+ * Sets nagle to 'val' and returns the existing value.
+ * val==0 will turn off nagle and value==1 will turn it on.
+ */
+static int tls_set_nagle(int sockfd, int val)
+{
+	int saved_nagle;
+	socklen_t len = sizeof(saved_nagle);
+
+	if (getsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &saved_nagle, &len) != 0) {
+		TLS_LOG(1, "getsockopt(TCP_NODELAY) failed(%d): %s",
+			errno, strerror(errno));
+		return -1;
+	}
+
+	if (setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val)) != 0) {
+		TLS_LOG(1, "setsockopt(TCP_NODELAY, %d) failed(%d): %s",
+			val, errno, strerror(errno));
+		return -1;
+	}
+
+	return saved_nagle;
+}
+
+/*
+ * This is the TLS handshake routine. It can be called after the TCP connection
+ * is established. It performs TLS handshake with the server in async manner,
+ * so this can return TLS_HANDSHAKE_IN_PROGRESS multiple times and it's safe to
+ * call it till it returns TLS_HANDSHAKE_COMPLETED or TLS_HANDSHAKE_FAILED.
+ */
+enum tls_handshake_state
+do_tls_handshake(struct rpc_context *rpc)
+{
+	const int sd = rpc_get_fd(rpc);
+	const char *const server_sni = rpc->server;
+	const char *priority_string;
+	/* gnutls session performing the handshake */
+	gnutls_session_t session = rpc->tls_context.session;
+	int ret, saved_nagle;
+
+	if (!tls_global_init_done) {
+		TLS_LOG(1, "do_tls_handshake: tls_global_init() not done!");
+		/* Should not happen */
+		assert(0);
+		return TLS_HANDSHAKE_FAILED;
+	}
+
+	/* XXX: Are people still using NFS over UDP? */
+	if (rpc->is_udp) {
+		TLS_LOG(1, "do_tls_handshake: UDP transport not supported");
+		return TLS_HANDSHAKE_FAILED;
+	}
+
+	/* do_tls_handshake() must be called only after server name is set */
+	if (server_sni == NULL) {
+		TLS_LOG(1, "do_tls_handshake: Server name not set!");
+		return TLS_HANDSHAKE_FAILED;
+	}
+
+	/* and we are connected */
+	if (sd == -1) {
+		TLS_LOG(1, "do_tls_handshake: rpc->fd is -1");
+		return TLS_HANDSHAKE_FAILED;
+	}
+
+	if (!rpc->is_connected) {
+		TLS_LOG(1, "do_tls_handshake: rpc is not connected");
+		return TLS_HANDSHAKE_FAILED;
+	}
+
+	/*
+	 * rpc->tls_context.session will be non NULL only for inprogress handshakes.
+	 */
+	assert((rpc->tls_context.session == NULL) ||
+		(rpc->tls_context.state == TLS_HANDSHAKE_IN_PROGRESS));
+
+	if (session == NULL) {
+		/* Initialize TLS session */
+		ret = gnutls_init(&rpc->tls_context.session, GNUTLS_CLIENT);
+		if (ret < 0) {
+			TLS_LOG(1, "do_tls_handshake: gnutls_init() failed(%d): %s",
+				ret, gnutls_strerror(ret));
+			return TLS_HANDSHAKE_FAILED;
+		}
+
+		session = rpc->tls_context.session;
+
+		ret = gnutls_server_name_set(session, GNUTLS_NAME_DNS, server_sni,
+					     strlen(server_sni));
+		if (ret < 0) {
+			TLS_LOG(1, "do_tls_handshake: gnutls_server_name_set(%s) failed(%d): %s",
+				server_sni, ret, gnutls_strerror(ret));
+			goto handshake_failed;
+		}
+
+		/*
+		 * LIBNFS_TLS_GNUTLS_PRIORITY_STRING should be set to a valid gnutls priority
+		 * string. Make sure the following confirms validity of the priority string:
+		 * # gnutls-cli -l --priority="$LIBNFS_TLS_GNUTLS_PRIORITY_STRING"
+		 */
+		priority_string = GETENV("LIBNFS_TLS_GNUTLS_PRIORITY_STRING");
+		if (priority_string == NULL) {
+			/* Default priority string we use favors performance */
+			priority_string = "PERFORMANCE:-CIPHER-ALL:+AES-128-GCM";
+			ret = gnutls_priority_set_direct(session, priority_string, NULL);
+			if (ret < 0) {
+				TLS_LOG(1, "do_tls_handshake: gnutls_priority_set_direct(%s) "
+					"failed(%d): %s",
+					priority_string, ret, gnutls_strerror(ret));
+				goto handshake_failed;
+			}
+		} else if (strcmp(priority_string, "default") == 0) {
+			ret = gnutls_set_default_priority(session);
+			if (ret < 0) {
+				TLS_LOG(1, "do_tls_handshake: gnutls_set_default_priority() "
+					"failed(%d): %s", ret, gnutls_strerror(ret));
+				goto handshake_failed;
+			}
+		} else {
+			/* User specified priority_string */
+			ret = gnutls_priority_set_direct(session, priority_string, NULL);
+			if (ret < 0) {
+				TLS_LOG(1, "do_tls_handshake: gnutls_priority_set_direct(%s) "
+					"failed(%d): %s",
+					priority_string, ret, gnutls_strerror(ret));
+				goto handshake_failed;
+			}
+		}
+
+		/* Put the x509 credentials to the current session */
+		ret = gnutls_credentials_set(session, GNUTLS_CRD_CERTIFICATE, xcred);
+		if (ret < 0) {
+			TLS_LOG(1, "do_tls_handshake: gnutls_credentials_set() failed(%d): %s",
+				ret, gnutls_strerror(ret));
+			goto handshake_failed;
+		}
+
+		TLS_LOG(2, "gnutls_session_set_verify_cert(), SNI set to %s", server_sni);
+
+		gnutls_session_set_verify_cert(session, server_sni, 0);
+		gnutls_handshake_set_timeout(session, GNUTLS_DEFAULT_HANDSHAKE_TIMEOUT);
+	}
+
+	/* Associate socket fd with the gnutls session */
+	gnutls_transport_set_int(session, sd);
+
+	/* Disable nagle for faster handshake */
+	saved_nagle = tls_set_nagle(sd, 0);
+	/* Perform the TLS handshake */
+	ret = gnutls_handshake(session);
+	tls_set_nagle(sd, saved_nagle);
+
+	TLS_LOG(2, "gnutls_handshake() returned %d: %s", ret, gnutls_strerror(ret));
+
+	if (ret < 0) {
+		if (ret == GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR) {
+			/* check certificate verification status */
+			const int type = gnutls_certificate_type_get(session);
+			const unsigned int status = gnutls_session_get_verify_cert_status(session);
+			gnutls_datum_t out;
+			const int ret1 = gnutls_certificate_verification_status_print(
+							status, type, &out, 0);
+			if (ret1 == GNUTLS_E_SUCCESS) {
+				TLS_LOG(1, "cert verify output: %s", out.data);
+				gnutls_free(out.data);
+			}
+			TLS_LOG(1, "*** Handshake failed: %s", gnutls_strerror(ret));
+			goto handshake_failed;
+		} else if (gnutls_error_is_fatal(ret)) {
+			/* some error other than cert verify */
+			TLS_LOG(1, "*** Handshake failed: %s", gnutls_strerror(ret));
+			goto handshake_failed;
+		} else {
+			return TLS_HANDSHAKE_IN_PROGRESS;
+		}
+	} else {
+		char *desc = gnutls_session_get_desc(session);
+
+		TLS_LOG(2, "+++ Handshake successful +++");
+		TLS_LOG(2, "Session info: %s", desc);
+
+		gnutls_free(desc);
+	}
+
+	/* Install the security parameters into kTLS */
+	ret = setup_ktls(session);
+	if (ret < 0) {
+		TLS_LOG(1, "do_tls_handshake: setup_ktls() failed(%d)", ret);
+		goto handshake_failed;
+	}
+
+	/* Free the session object, now that the handshake is complete */
+	gnutls_deinit(rpc->tls_context.session);
+	rpc->tls_context.session = NULL;
+
+	return TLS_HANDSHAKE_COMPLETED;
+
+handshake_failed:
+	gnutls_deinit(rpc->tls_context.session);
+	rpc->tls_context.session = NULL;
+	return TLS_HANDSHAKE_FAILED;
+}

--- a/tls/ktls.c
+++ b/tls/ktls.c
@@ -1,4 +1,20 @@
 /* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:nil;  -*- */
+/*
+   Copyright (C) 2024 by Linuxsmiths <linuxsmiths@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation; either version 2.1 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE

--- a/tls/ktls.c
+++ b/tls/ktls.c
@@ -1,0 +1,229 @@
+/* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:nil;  -*- */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <netinet/tcp.h>
+#include <gnutls/gnutls.h>
+#include <gnutls/socket.h>
+#include <linux/tls.h>
+
+#include "libnfs.h"
+#include "libnfs-raw.h"
+#include "libnfs-private.h"
+#include "tls-private.h"
+
+/*
+ * Older gnutls versions don't have kTLS support and don't export
+ * gnutls_transport_is_ktls_enabled().
+ */
+#ifdef HAVE_GNUTLS_TRANSPORT_IS_KTLS_ENABLED
+/*
+ * Check if gnutls_handshake() has enabled kTLS (and installed security keys)
+ * for this sesssion for the given direction identified by 'read'.
+ */
+static bool tls_is_ktls_enabled(gnutls_session_t session, bool read)
+{
+	const int ret = gnutls_transport_is_ktls_enabled(session);
+
+	if (ret == GNUTLS_E_UNIMPLEMENTED_FEATURE) {
+		TLS_LOG(1, "gnutls version %s has kTLS support but kTLS is not "
+			"enabled! Try building gnutls with kTLS support.",
+			gnutls_check_version("0.0.0"));
+		return false;
+	}
+
+	if (read) {
+		if (!(ret & GNUTLS_KTLS_RECV)) {
+			/*
+			 * If gnutls has kTLS support there's no reason it'll
+			 * not enable kTLS in both send and recv direction so
+			 * log with higher priority.
+			 * Note that Linux kernel versions >= 4.13 and < 4.17
+			 * didn't have TLS_RX support so they don't support TLS
+			 * recv offload. We need both TLS_TX and TLS_RX offload.
+			 */
+			TLS_LOG(1, "gnutls has *NOT* enabled receive kTLS for this session");
+			return false;
+		}
+		TLS_LOG(2, "gnutls has enabled receive kTLS for this session");
+	} else {
+		if (!(ret & GNUTLS_KTLS_SEND)) {
+			TLS_LOG(1, "gnutls has *NOT* enabled send kTLS for this session");
+			return false;
+		}
+		TLS_LOG(2, "gnutls has enabled send kTLS for this session");
+	}
+
+	return true;
+}
+#else
+static bool tls_is_ktls_enabled(gnutls_session_t session _U_, bool read _U_)
+{
+	return false;
+}
+#endif
+
+static int ktls_setsockopt(int sock, bool read, const void *info, socklen_t infolen)
+{
+	const int ret = setsockopt(sock, SOL_TLS, read ? TLS_RX : TLS_TX, info, infolen);
+	if (!ret) {
+		TLS_LOG(2, "setsockopt(%s) success", read ? "TLS_RX" : "TLS_TX");
+		return 0;
+	}
+
+	if (errno == EBUSY) {
+		/*
+		 * EBUSY indicates crypto info is already set for the socket in the
+		 * given direction. Treat it as success.
+		 *
+		 * Note: Unless gnutls_transport_is_ktls_enabled() lies to us this
+		 *       shouldn't happen but take care just in case.
+		 */
+		TLS_LOG(1, "setsockopt(%s) returned(%d): %s. Treating as success!",
+			read ? "TLS_RX" : "TLS_TX", errno, strerror(errno));
+		return 0;
+	}
+
+	TLS_LOG(1, "setsockopt(%s) failed(%d): %s",
+		read ? "TLS_RX" : "TLS_TX", errno, strerror(errno));
+
+	return -1;
+}
+
+#define tls12_crypto_info_AES_GCM_128 		tls12_crypto_info_aes_gcm_128
+#define tls12_crypto_info_AES_GCM_256 		tls12_crypto_info_aes_gcm_256
+#define tls12_crypto_info_AES_CCM_128 		tls12_crypto_info_aes_ccm_128
+#define tls12_crypto_info_CHACHA20_POLY1305	tls12_crypto_info_chacha20_poly1305
+
+#define GENERATE_SET_CRYPTO_INFO(CIPHER) 				\
+static int ktls_set_##CIPHER##_info(gnutls_session_t session) 		\
+{ 									\
+	const bool is_tls12 = 						\
+		(gnutls_protocol_get_version(session) == GNUTLS_TLS1_2);\
+	struct tls12_crypto_info_##CIPHER info = { 			\
+		.info.version           = (is_tls12 ? TLS_1_2_VERSION	\
+						    : TLS_1_3_VERSION), \
+		.info.cipher_type       = TLS_CIPHER_##CIPHER, 		\
+	}; 								\
+	unsigned char seq_number[8]; 					\
+	gnutls_datum_t cipher_key; 					\
+	gnutls_datum_t mac_key; 					\
+	gnutls_datum_t iv;						\
+	int ret, read;							\
+	const int sockfd = gnutls_transport_get_int(session);		\
+									\
+	/* (read == 0) => send, (read == 1) => recv */			\
+	for (read = 0; read <= 1; read++) {				\
+		if (tls_is_ktls_enabled(session, read))			\
+			continue;					\
+									\
+		ret = gnutls_record_get_state(session,			\
+					      read, 			\
+					      &mac_key, 		\
+					      &iv, 			\
+					      &cipher_key, 		\
+					      seq_number);		\
+		if (ret != GNUTLS_E_SUCCESS) { 				\
+			TLS_LOG(1, "gnutls_record_get_state "		\
+				"failed(%d): %s",			\
+				ret, gnutls_strerror(ret));		\
+			return -1;					\
+		}							\
+									\
+		/* for TLS 1.2 IV is generated in kernel */		\
+		if (is_tls12) {						\
+			memcpy(info.iv, seq_number,			\
+			       TLS_CIPHER_##CIPHER##_IV_SIZE);		\
+		} else {						\
+			memcpy(info.iv,					\
+			       iv.data + TLS_CIPHER_##CIPHER##_SALT_SIZE,\
+			       TLS_CIPHER_##CIPHER##_IV_SIZE);		\
+		}							\
+		memcpy(info.salt, iv.data,				\
+		       TLS_CIPHER_##CIPHER##_SALT_SIZE);		\
+		memcpy(info.key, cipher_key.data,			\
+		       TLS_CIPHER_##CIPHER##_KEY_SIZE);			\
+		memcpy(info.rec_seq, seq_number,			\
+		       TLS_CIPHER_##CIPHER##_REC_SEQ_SIZE);		\
+									\
+		if (ktls_setsockopt(sockfd, read, &info,		\
+				    sizeof(info)) != 0) {		\
+			TLS_LOG(1, "Failed to set crypto info for %s",	\
+				#CIPHER);				\
+			return -1;					\
+		}							\
+	}								\
+	return 0;							\
+}
+
+#define SET_CRYPTO_INFO(CIPHER, session) ktls_set_##CIPHER##_info(session)
+
+#if defined(TLS_CIPHER_AES_GCM_128)
+GENERATE_SET_CRYPTO_INFO(AES_GCM_128)
+#endif
+
+#if defined(TLS_CIPHER_AES_GCM_256)
+GENERATE_SET_CRYPTO_INFO(AES_GCM_256)
+#endif
+
+#if defined(TLS_CIPHER_AES_CCM_128)
+GENERATE_SET_CRYPTO_INFO(AES_CCM_128)
+#endif
+
+#if defined(TLS_CIPHER_CHACHA20_POLY1305)
+GENERATE_SET_CRYPTO_INFO(CHACHA20_POLY1305)
+#endif
+
+int setup_ktls(gnutls_session_t session)
+{
+	const gnutls_cipher_algorithm_t cipher = gnutls_cipher_get(session);
+
+	TLS_LOG(2, "setup_ktls(session=%p, fd=%d)",
+		session, gnutls_transport_get_int(session));
+
+	/*
+	 * Before we can set crypto info, need to set ULP=TLS.
+	 */
+	if (setsockopt(gnutls_transport_get_int(session), SOL_TCP, TCP_ULP,
+		       "tls", sizeof("tls")) == -1) {
+		TLS_LOG(1, "setsockopt(TLS_ULP) failed(%d): %s", errno, strerror(errno));
+		return -1;
+	}
+
+	switch (cipher) {
+#if defined(TLS_CIPHER_AES_GCM_128)
+		case GNUTLS_CIPHER_AES_128_GCM:
+			TLS_LOG(2, "Got cipher AES_GCM_128");
+			return SET_CRYPTO_INFO(AES_GCM_128, session);
+#endif
+#if defined(TLS_CIPHER_AES_GCM_256)
+		case GNUTLS_CIPHER_AES_256_GCM:
+			TLS_LOG(2, "Got cipher AES_GCM_256");
+			return SET_CRYPTO_INFO(AES_GCM_256, session);
+#endif
+#if defined(TLS_CIPHER_AES_CCM_128)
+		case GNUTLS_CIPHER_AES_128_CCM:
+			TLS_LOG(2, "Got cipher AES_CCM_128");
+			return SET_CRYPTO_INFO(AES_CCM_128, session);
+#endif
+#if defined(TLS_CIPHER_CHACHA20_POLY1305)
+		case GNUTLS_CIPHER_CHACHA20_POLY1305:
+			TLS_LOG(2, "Got cipher CHACHA20_POLY1305");
+			return SET_CRYPTO_INFO(CHACHA20_POLY1305, session);
+#endif
+		default:
+			TLS_LOG(1, "Unsupported cipher %d", cipher);
+	}
+
+	return -1;
+}

--- a/tls/tls-private.h
+++ b/tls/tls-private.h
@@ -1,0 +1,30 @@
+/* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:nil;  -*- */
+
+#ifndef __TLS_PRIVATE_H__
+#define __TLS_PRIVATE_H__
+
+/*
+ * Use this instead of RPC_LOG() inside this file as we don't want to pass around
+ * rpc_context structure to various functions here as they don't really need the
+ * rpc_context.
+ * Note that just like RPC_LOG TLS_LOG() is also controlled by debug= libnfs option.
+ */
+#define TLS_LOG(level, format, ...) \
+	do { \
+		if (level <= tls_log_level) { \
+			fprintf(stderr, "libnfs(tls):%d " format "\n", level, ## __VA_ARGS__); \
+		} \
+	} while (0)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int tls_log_level;
+extern int setup_ktls(gnutls_session_t session);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TLS_PRIVATE_H__ */

--- a/tls/tls-private.h
+++ b/tls/tls-private.h
@@ -1,4 +1,20 @@
 /* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:nil;  -*- */
+/*
+   Copyright (C) 2024 by Linuxsmiths <linuxsmiths@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation; either version 2.1 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
 
 #ifndef __TLS_PRIVATE_H__
 #define __TLS_PRIVATE_H__


### PR DESCRIPTION
This PR adds RPC-with-TLS (RFC 9289) support to libnfs. It depends on the following:
- GnuTLS version 3.4.6+
- Linux kernel 5.10+

It adds a new mount option - xprtsec=[none,tls,mtls] (similar to Linux NFS client)

I've currently enabled it only on Linux since that's what my target system is. BSD should be easy to make work if someone has a system they can try out.
Also, this change only adds client support.
I've only made changes to the CMake build files.

Tested to make sure it works fine with reconnects.

Sample command:

./examples/nfs-writefile /mnt/random 'nfs://nfsserver/mnt/testfile?version=3&xprtsec=tls&debug=1'

Performance testing:
With AES-128-GCM there's almost no overhead and I could get ~1GBps/core which is same as w/o TLS.
This is because kTLS does the encryption while copying data from user to kernel (so there's no extra copy) and encryption is accelerated by the CPU. 
