### PR TITLE
Added (more) TCP and RPC resiliency.

### DIFF
--- a/README
+++ b/README
@@ -79,6 +79,25 @@ Arguments supported by libnfs are :
                      default it 65534 on Windows and getgid() on unixen.
  debug=<int>       : Debug level used by libnfs. Default is 0 which is quiet.
                      Higher values increase verbosity.
+ timeo=<int>       : The time in deciseconds (tenths of a second) libnfs client
+                     will wait for a response before it retries an RPC request.
+                     Default value of 'timeo' is 600, i.e., 60 seconds.
+                     Values less than 100, i.e., 10 seconds, are not allowed.
+ retrans=<int>     : After 'retrans' failed retries libnfs will generate a
+                     "server not responding" message and then attempt further
+                     recovery action. If no successful RPC response has been
+                     received over the connection for the last 'timeo' period,
+                     then the connection would be terminated and all queued RPCs
+                     will be retried over the new connection. If other RPC
+                     responses are being received then it means connection is
+                     fine and this is likely a problem with this specific RPC,
+                     in that case it'll simply keep retrying the RPC for ever at
+                     'timeo' interval. This mimics the 'hard' mount behaviour of
+                     NFS clients.
+                     If 'retrans' is 0, then RPC is not retried on timeout but
+                     instead failed with RPC_STATUS_TIMEOUT. This will roughly
+                     mimic the 'soft' mount behaviour of NFS clients.
+                     Default value of 'retrans' is 2.
  sec=<krb5|krb5i|krb5p>
                    : Specify the security mode.
  xprtsec=<none|tls|mtls>

--- a/examples/nfsclient-raw.c
+++ b/examples/nfsclient-raw.c
@@ -449,7 +449,7 @@ int main(int argc _U_, char *argv[] _U_)
 		pfd.fd = rpc_get_fd(rpc);
 		pfd.events = rpc_which_events(rpc);
 
-		if (poll(&pfd, 1, -1) < 0) {
+		if (poll(&pfd, 1, rpc_get_poll_timeout(rpc)) < 0) {
 			printf("Poll failed");
 			exit(10);
 		}

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -336,6 +336,7 @@ EXTERN void nfs_set_debug(struct nfs_context *nfs, int level);
 EXTERN void nfs_set_auto_traverse_mounts(struct nfs_context *nfs, int enabled);
 EXTERN void nfs_set_dircache(struct nfs_context *nfs, int enabled);
 EXTERN void nfs_set_autoreconnect(struct nfs_context *nfs, int num_retries);
+EXTERN void nfs_set_retrans(struct nfs_context *nfs, int retrans);
 EXTERN void nfs_set_nfsport(struct nfs_context *nfs, int port);
 EXTERN void nfs_set_mountport(struct nfs_context *nfs, int port);
 EXTERN void nfs_set_readdir_max_buffer_size(struct nfs_context *nfs, uint32_t dircount, uint32_t maxcount);
@@ -1996,6 +1997,9 @@ EXTERN int nfs_get_poll_timeout(struct nfs_context *nfs);
  * int milliseconds : timeout to be applied in milliseconds (-1 no timeout)
  *                    timeouts must currently be set in whole seconds,
  *                    i.e. units of 1000
+ *
+ * Note: Prefer the mount option timeo=<int> to set the timeout over directly
+ *       calling nfs_set_timeout().
  */
 EXTERN void nfs_set_timeout(struct nfs_context *nfs, int milliseconds);
 

--- a/lib/nfs_v4.c
+++ b/lib/nfs_v4.c
@@ -1494,6 +1494,23 @@ nfs4_mount_4_cb(struct rpc_context *rpc, int status, void *command_data,
                gfhresok->object.nfs_fh4_val,
                nfs->nfsi->rootfh.len);
 
+	/*
+	 * Now the entire mount process (including the NFS FSINFO and GETATTR)
+	 * has completed. Any RPC failure till now would have caused the mount
+	 * process to fail. Note that it's desirable for the mount process to
+	 * fail upfront if it encounters any errors (TCP or RPC), rather than
+	 * keep trying indefinitely causing the mount process to "hang", but
+	 * from now on the RPC transport will be used to carry NFS RPCs issued
+	 * by the application which may not be equipped to handle TCP connection
+	 * failure and RPC timeouts, so we set the resiliency parameters of the
+	 * rpc_context as selected by the user using the mount options. The
+	 * default resiliency parameters emulate the common "hard" mount and
+	 * we are resilient to any TCP or RPC connectivity issues.
+         */
+	rpc_set_resiliency(rpc,
+			   nfs->nfsi->auto_reconnect,
+			   nfs->nfsi->timeout,
+			   nfs->nfsi->retrans);
 
         data->cb(0, nfs, NULL, data->private_data);
         free_nfs4_cb_data(data);
@@ -1625,10 +1642,8 @@ nfs4_mount_async(struct nfs_context *nfs, const char *server,
         free(nfs->nfsi->server);
         nfs->nfsi->server = new_server;
 
-#ifdef HAVE_TLS
 	free(nfs->rpc->server);
 	nfs->rpc->server = strdup(nfs->nfsi->server);
-#endif
 
         new_export = strdup(export);
 	if (new_export == NULL) {


### PR DESCRIPTION
This change adds the following resiliency to libnfs clients.

1. Set TCP keepalive to recognize servers that silently go away or stop responding to TCP.
2. Add RPC timeout and retransmit support. Added following two mount options to control RPC retransmit behaviour:
   - timeo=< int >
   - retrans=< int >
   As we can see these are deliberately named similar to the Linux NFS mount options for ease of use/understanding.

Testing done:
Tested by blocking TCP usign iptables to induce retransmit and make sure data xfer is valid.
Various stress runs while constantly killing/blocking connections.