### PR TITLE
Fix compiler warning with gcc 11.4

### DIFF
--- a/tls/ktls.c
+++ b/tls/ktls.c
@@ -131,7 +131,7 @@ static int ktls_set_##CIPHER##_info(gnutls_session_t session) 		\
 						    : TLS_1_3_VERSION), \
 		.info.cipher_type       = TLS_CIPHER_##CIPHER, 		\
 	}; 								\
-	unsigned char seq_number[8]; 					\
+	unsigned char seq_number[12]; 					\
 	gnutls_datum_t cipher_key; 					\
 	gnutls_datum_t mac_key; 					\
 	gnutls_datum_t iv;						\


### PR DESCRIPTION
When building with gcc 11.4 it complained of size mismatch in memcpy when copying the seq_number into info.iv for CHACHA20_POLY1305 with size argument as TLS_CIPHER_CHACHA20_POLY1305_IV_SIZE.

All the cipher including chacha20 were tested and working but still the compiler warning is correct. The reason the code works is because gnutls_record_get_state() never returns a seq number more than 8 bytes, yet for chacha20 TLS_CIPHER_CHACHA20_POLY1305_IV_SIZE is defined as 12, though looks like only first 8 bytes are actually used.

Looked up the gnutls code and they simply define seq_number as a 12 byte array. We also do the same.