### PR TITLE
Misc changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,14 @@ option(ENABLE_TESTS "Build and run test programs" OFF)
 option(ENABLE_DOCUMENTATION "Build Documentation" OFF)
 option(ENABLE_UTILS "Build util programs" OFF)
 option(ENABLE_EXAMPLES "Build example programs" OFF)
+option(ENABLE_MULTITHREADING "Enable multithreading support" OFF)
 
 if(ENABLE_TESTS)
   set(ENABLE_UTILS ON CACHE BOOL "Building utils required by tests" FORCE)
+endif()
+
+if(ENABLE_MULTITHREADING)
+  add_definitions(-DHAVE_MULTITHREADING)
 endif()
 
 include(cmake/Macros.cmake)

--- a/INSTALL
+++ b/INSTALL
@@ -12,5 +12,8 @@ To build with support debugging that enable example and test cases.
       -DENABLE_TESTS=yes \
       -DCMAKE_BUILD_TYPE=Debug \
       -DCMAKE_VERBOSE_MAKEFILE=yes ..
+
+To build with multithreading support add -DENABLE_MULTITHREADING=yes
+
 - make 
 - make test

--- a/README.multithreading
+++ b/README.multithreading
@@ -8,6 +8,10 @@ configured using --enable-pthread
 
 $ ./configure --prefix=/usr --enable-examples --enable-pthread
 
+or, for cmake
+
+$ cmake -DENABLE_MULTITHREADING=yes ..
+
 It is not supported to mix the eventdriven ASYNC interface with multithreading
 thus once multithreading is enabled from the application you can not use
 the async interface any more and must only use the multithread safe

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -19,6 +19,7 @@ endif()
 check_include_file("poll.h" HAVE_POLL_H)
 check_include_file("stdint.h" HAVE_STDINT_H)
 check_include_file("stdlib.h" HAVE_STDLIB_H)
+check_include_file("stdatomic.h" HAVE_STDATOMIC_H)
 check_include_file("strings.h" HAVE_STRINGS_H)
 check_include_file("string.h" HAVE_STRING_H)
 check_include_file("sys/filio.h" HAVE_SYS_FILIO_H)
@@ -85,6 +86,21 @@ check_c_source_compiles("#include <gnutls/socket.h>
                                 gnutls_transport_is_ktls_enabled(session);
                          }"
                         HAVE_GNUTLS_TRANSPORT_IS_KTLS_ENABLED)
+
+#
+# Test for pthread availability.
+#
+set(CMAKE_REQUIRED_LIBRARIES pthread)
+check_c_source_compiles("#include <pthread.h>
+                         int main()
+                         {
+                                pthread_t thread;
+                                if (pthread_create(&thread, NULL, NULL, NULL) != 0) {
+                                        return -1;
+                                }
+                                return 0;
+                         }"
+                        HAVE_PTHREAD)
 
 if(NOT NO_LFS_REQUIRED)
   check_c_source_compiles("#include <sys/types.h>

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -9,6 +9,9 @@
 /* Whether gnutls exports the function gnutls_transport_is_ktls_enabled() */
 #cmakedefine HAVE_GNUTLS_TRANSPORT_IS_KTLS_ENABLED
 
+/* Whether pthread library is present */
+#cmakedefine HAVE_PTHREAD
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #cmakedefine HAVE_DLFCN_H
 
@@ -56,6 +59,9 @@
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #cmakedefine HAVE_STDLIB_H
+
+/* Define to 1 if you have the <stdatomic.h> header file. */
+#cmakedefine HAVE_STDATOMIC_H
 
 /* Define to 1 if you have the <strings.h> header file. */
 #cmakedefine HAVE_STRINGS_H

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,6 +14,12 @@ set(EXAMPLES nfsclient-async
             nfs-writefile
             portmap-client)
 
+if (ENABLE_MULTITHREADING)
+  list(APPEND EXAMPLES nfs-pthreads-writefile
+	  		nfs-pthreads-async-writefile)
+  list(APPEND EXTRA_LIBRARIES pthread)
+endif()
+
 if(HAVE_TALLOC_TEVENT)
   list(APPEND EXAMPLES nfs4-cat-talloc)
   list(APPEND EXTRA_LIBRARIES ${TALLOC_EVENT_LIBRARY} ${TALLOC_LIBRARY})

--- a/examples/nfs-pthreads-async-writefile.c
+++ b/examples/nfs-pthreads-async-writefile.c
@@ -1,20 +1,20 @@
-/* 
+/*
    Copyright (C) by Ronnie Sahlberg <ronniesahlberg@gmail.com> 2024
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
-    
+
 #define _FILE_OFFSET_BITS 64
 #define _GNU_SOURCE
 
@@ -35,7 +35,7 @@ WSADATA wsaData;
 #include <sys/stat.h>
 #include <string.h>
 #endif
- 
+
 #ifdef HAVE_POLL_H
 #include <poll.h>
 #endif
@@ -60,8 +60,23 @@ WSADATA wsaData;
 #include "libnfs-raw.h"
 #include "libnfs-raw-mount.h"
 
+/*
+ * Number of RPC transports to the server.
+ * We will have these many connections to the NFS server carrying RPC
+ * requests.
+ */
 #define NUM_CONTEXTS 4
-#define CHUNK_SIZE (10*1024*1024)
+
+/*
+ * Number of threads parallely writing file data.
+ * Usually one thread per context should be sufficient, but here we use more
+ * threads to demonstrate that multiple threads can very well write to the same
+ * context.
+ *
+ * Note: Don't set very high number of threads else it'll negatively impact
+ *       performance.
+ */
+#define NUM_THREADS  8
 
 void usage(void)
 {
@@ -96,7 +111,7 @@ void write_async_cb(int status, struct nfs_context *nfs,
 }
 
 /*
- * Thread that is created to write an up to CHUNK_SIZE prt of the file.
+ * Thread that is created to write an up to chunk_size part of the file.
  */
 static void *nfs_write_thread(void *arg)
 {
@@ -104,7 +119,7 @@ static void *nfs_write_thread(void *arg)
 	ssize_t count;
 	struct write_cb_data write_cb_data;
 	struct timespec ts;
-	
+
 	write_cb_data.status = 0;
 	write_cb_data.calls_in_flight = 0;
 	while (wd->len) {
@@ -137,8 +152,9 @@ static void *nfs_write_thread(void *arg)
 
 int main(int argc, char *argv[])
 {
-	int i, num_threads;
+	int i;
 	int fd = -1;
+	uint64_t chunk_size;
 	struct nfs_context *nfs[NUM_CONTEXTS] = {NULL,};
 	struct nfs_url *url = NULL;
 	struct stat st;
@@ -222,7 +238,7 @@ int main(int argc, char *argv[])
 				exit(1);
 			}
 		}
-		  
+
 		/*
 		 * Before we can use multithreading we must initialize and
 		 * start the service thread.
@@ -236,29 +252,30 @@ int main(int argc, char *argv[])
 
 	/*
 	 * Create threads to write the file. Each thread will write a
-	 * CHUNK_SIZE portion of the file.
+	 * chunk_size portion of the file.
 	 */
-	printf("Size of file:%s is %d bytes\n", argv[1], st.st_size);
-	num_threads = (st.st_size + CHUNK_SIZE - 1) / CHUNK_SIZE;
-	printf("Need %d threads to write %d bytes each\n", num_threads, CHUNK_SIZE);
-        if ((write_threads = malloc(sizeof(pthread_t) * num_threads)) == NULL) {
+	printf("Size of file:%s is %ld bytes\n", argv[1], st.st_size);
+	chunk_size = (st.st_size + NUM_THREADS - 1) / NUM_THREADS;
+
+	printf("Using %d threads writing %lu bytes each\n", NUM_THREADS, chunk_size);
+	if ((write_threads = malloc(sizeof(pthread_t) * NUM_THREADS)) == NULL) {
 		fprintf(stderr, "Failed to allocated stat_thread\n");
                 exit(10);
         }
-        if ((wd = malloc(sizeof(struct write_data) * num_threads)) == NULL) {
+	if ((wd = malloc(sizeof(struct write_data) * NUM_THREADS)) == NULL) {
 		fprintf(stderr, "Failed to allocated write_data\n");
                 exit(10);
         }
-        for (i = 0; i < num_threads; i++) {
+        for (i = 0; i < NUM_THREADS; i++) {
                 wd[i].nfs = nfs[i % NUM_CONTEXTS];
 		wd[i].ptr = ptr;
                 wd[i].nfsfh = nfsfh;
-		wd[i].offset = i * CHUNK_SIZE;
+		wd[i].offset = i * chunk_size;
 		wd[i].len = st.st_size - wd[i].offset;
-		if (wd[i].len > CHUNK_SIZE) {
-			wd[i].len = CHUNK_SIZE;
+		if (wd[i].len > chunk_size) {
+			wd[i].len = chunk_size;
 		}
-		  
+
                 if (pthread_create(&write_threads[i], NULL,
                                    &nfs_write_thread, &wd[i])) {
                         printf("Failed to create stat thread %d\n", i);
@@ -269,7 +286,7 @@ int main(int argc, char *argv[])
 	/*
 	 * Wait for all threads to complete
 	 */
-        for (i = 0; i < num_threads; i++) {
+        for (i = 0; i < NUM_THREADS; i++) {
                 pthread_join(write_threads[i], NULL);
         }
 

--- a/examples/nfsclient-async.c
+++ b/examples/nfsclient-async.c
@@ -276,7 +276,7 @@ int main(int argc _U_, char *argv[] _U_)
 			pfds[1].events = rpc_which_events(mount_context);
 			num_fds = 2;
 		}
-		if (poll(&pfds[0], 2, -1) < 0) {
+		if (poll(&pfds[0], num_fds, -1) < 0) {
 			printf("Poll failed");
 			exit(10);
 		}

--- a/examples/nfsclient-raw.c
+++ b/examples/nfsclient-raw.c
@@ -449,7 +449,7 @@ int main(int argc _U_, char *argv[] _U_)
 		pfd.fd = rpc_get_fd(rpc);
 		pfd.events = rpc_which_events(rpc);
 
-		if (poll(&pfd, 1, rpc_get_poll_timeout(rpc)) < 0) {
+		if (poll(&pfd, 1, -1) < 0) {
 			printf("Poll failed");
 			exit(10);
 		}

--- a/examples/nfsclient-sync.c
+++ b/examples/nfsclient-sync.c
@@ -74,15 +74,11 @@ void print_usage(void)
 int main(int argc, char *argv[])
 {
 	struct nfs_context *nfs = NULL;
-	int i, ret, res;
-	uint64_t offset;
+	int ret;
 	struct client client;
 	struct nfs_stat_64 st;
-	struct nfsfh  *nfsfh;
 	struct nfsdir *nfsdir;
 	struct nfsdirent *nfsdirent;
-	struct statvfs svfs;
-	exports export, tmp;
 	const char *url = NULL;
 	char *server = NULL, *path = NULL, *strp;
 

--- a/examples/portmap-client.c
+++ b/examples/portmap-client.c
@@ -462,6 +462,14 @@ int main(int argc _U_, char *argv[] _U_)
 			set3addr  = argv[++i];
 			set3owner = argv[++i];
 			command_found++;
+		} else if (!strcmp(argv[i], "unset3")) {
+			unset3 = 1;
+			unset3prog = atoi(argv[++i]);
+			unset3vers = atoi(argv[++i]);
+			unset3netid = argv[++i];
+			unset3addr  = argv[++i];
+			unset3owner = argv[++i];
+			command_found++;
 		} else if (!strcmp(argv[i], "null3")) {
 			null3 = 1;
 			command_found++;

--- a/include/nfsc/libnfs-raw.h
+++ b/include/nfsc/libnfs-raw.h
@@ -89,6 +89,7 @@ EXTERN int rpc_get_fd(struct rpc_context *rpc);
 EXTERN int rpc_which_events(struct rpc_context *rpc);
 EXTERN int rpc_service(struct rpc_context *rpc, int revents);
 
+
 /*
  * Returns the number of commands in-flight. Can be used by the application
  * to check if there are any more responses we are awaiting from the server

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -629,7 +629,7 @@ nfs_init_context(void)
 	 * the door on us, rather write()/dup2() should fail with EPIPE which
 	 * we can gracefully handle.
 	 */
-	if (signal(SIGPIPE, SIG_IGN) != 0) {
+	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
 		nfs_destroy_context(nfs);
 		return NULL;
 	}

--- a/tls/handshake.c
+++ b/tls/handshake.c
@@ -124,6 +124,15 @@ int tls_global_init(struct rpc_context *rpc)
 	if (tls_global_init_done)
 		return 0;
 
+	/*
+	 * XXX See if we need a separate log level for gnutls, but for now
+	 *     let's use the libnfs debug level which is still pretty usable
+	 *     as it allows us to control the loglevel using debug= option.
+	 *
+	 *     This can be overridden using env variable "GNUTLS_DEBUG_LEVEL".
+	 */
+	tls_log_level = rpc->debug;
+
 	/* Based on various gnutls functions we call this is the min version */
 	if (gnutls_check_version("3.4.6") == NULL) {
 		TLS_LOG(1, "tls_global_init: GnuTLS 3.4.6 or later is required");
@@ -135,14 +144,6 @@ int tls_global_init(struct rpc_context *rpc)
 		return -1;
 	}
 
-	/*
-	 * XXX See if we need a separate log level for gnutls, but for now
-	 *     let's use the libnfs debug level which is still pretty usable
-	 *     as it allows us to control the loglevel using debug= option.
-	 *
-	 *     This can be overridden using env variable "GNUTLS_DEBUG_LEVEL".
-	 */
-	tls_log_level = rpc->debug;
 	gnutls_global_set_log_level(tls_log_level);
 	gnutls_global_set_audit_log_function(libnfs_gnutls_audit_func);
 

--- a/utils/nfs-cat.c
+++ b/utils/nfs-cat.c
@@ -147,7 +147,6 @@ static char buf[BUFSIZE];
 
 int main(int argc, char *argv[])
 {
-	int ret;
 	struct file_context *nf;
 	struct nfs_stat_64 st;
 	uint64_t off;

--- a/utils/nfs-stat.c
+++ b/utils/nfs-stat.c
@@ -237,16 +237,10 @@ char *get_access_bits(int mode)
 	return access_bits;
 }
 
-#define BUFSIZE 1024*1024
-static char buf[BUFSIZE];
-
 int main(int argc, char *argv[])
 {
-	int ret;
 	struct file_context *nf;
 	struct nfs_stat_64 st;
-	uint64_t off;
-	int64_t count;
 	
 #ifdef WIN32
 	if (WSAStartup(MAKEWORD(2,2), &wsaData) != 0) {


### PR DESCRIPTION
- Update nfs-pthreads examples to specify number of threads and not chunk size per thread. This is more practical and works well for very lareg file sizes too.
- Added multithreading and pthread detection to cmake.
- Misc compiler warning fixes in examples code which was left from last time.

Testing done:
- Validated nfs-pthreads-writefile and nfs-pthreads-async-writefile by transferring and checksumming 25GB file.