### PR TITLE
Avoid rpc_mutex deadlock

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -496,7 +496,7 @@ void rpc_set_error(struct rpc_context *rpc, const char *error_string, ...)
  * functions that hold rpc->rpc_mutex. The following nolock version must be
  * used by callers who hold the rpc->rpc_mutex.
  */
-void rpc_set_error_nolock(struct rpc_context *rpc, const char *error_string, ...)
+void rpc_set_error_locked(struct rpc_context *rpc, const char *error_string, ...)
 #ifdef __GNUC__
  __attribute__((format(printf, 2, 3)))
 #endif
@@ -508,7 +508,7 @@ void nfs_set_error(struct nfs_context *nfs, char *error_string, ...)
 #endif
 ;
 
-void nfs_set_error_nolock(struct nfs_context *nfs, char *error_string, ...)
+void nfs_set_error_locked(struct nfs_context *nfs, char *error_string, ...)
 #ifdef __GNUC__
  __attribute__((format(printf, 2, 3)))
 #endif

--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -481,13 +481,34 @@ int rpc_process_pdu(struct rpc_context *rpc, char *buf, int size);
 struct rpc_pdu *rpc_find_pdu(struct rpc_context *rpc, uint32_t xid);
 void rpc_error_all_pdus(struct rpc_context *rpc, const char *error);
 
+/*
+ * XXX This holds rpc->rpc_mutex, so if the caller is already holding
+ *     rpc->rpc_mutex, use the nolock version below.
+ */
 void rpc_set_error(struct rpc_context *rpc, const char *error_string, ...)
 #ifdef __GNUC__
  __attribute__((format(printf, 2, 3)))
 #endif
 ;
 
+/*
+ * rpc_set_error() is a common error path function which is called from many
+ * functions that hold rpc->rpc_mutex. The following nolock version must be
+ * used by callers who hold the rpc->rpc_mutex.
+ */
+void rpc_set_error_nolock(struct rpc_context *rpc, const char *error_string, ...)
+#ifdef __GNUC__
+ __attribute__((format(printf, 2, 3)))
+#endif
+;
+
 void nfs_set_error(struct nfs_context *nfs, char *error_string, ...)
+#ifdef __GNUC__
+ __attribute__((format(printf, 2, 3)))
+#endif
+;
+
+void nfs_set_error_nolock(struct nfs_context *nfs, char *error_string, ...)
 #ifdef __GNUC__
  __attribute__((format(printf, 2, 3)))
 #endif

--- a/lib/init.c
+++ b/lib/init.c
@@ -296,29 +296,39 @@ void rpc_set_auxiliary_gids(struct rpc_context *rpc, uint32_t len, uint32_t* gid
 void rpc_set_error(struct rpc_context *rpc, const char *error_string, ...)
 {
         va_list ap;
-	char *old_error_string;
 
 #ifdef HAVE_MULTITHREADING
         if (rpc->multithreading_enabled) {
                 nfs_mt_mutex_lock(&rpc->rpc_mutex);
         }
 #endif /* HAVE_MULTITHREADING */
-        old_error_string = rpc->error_string;
+
         va_start(ap, error_string);
+	free(rpc->error_string);
 	rpc->error_string = malloc(1024);
 	vsnprintf(rpc->error_string, 1024, error_string, ap);
         va_end(ap);
 
 	RPC_LOG(rpc, 1, "error: %s", rpc->error_string);
 
-	if (old_error_string != NULL) {
-		free(old_error_string);
-	}
 #ifdef HAVE_MULTITHREADING
         if (rpc->multithreading_enabled) {
                 nfs_mt_mutex_unlock(&rpc->rpc_mutex);
         }
 #endif /* HAVE_MULTITHREADING */
+}
+
+void rpc_set_error_nolock(struct rpc_context *rpc, const char *error_string, ...)
+{
+	va_list ap;
+
+	va_start(ap, error_string);
+	free(rpc->error_string);
+	rpc->error_string = malloc(1024);
+	vsnprintf(rpc->error_string, 1024, error_string, ap);
+	va_end(ap);
+
+	RPC_LOG(rpc, 1, "error: %s", rpc->error_string);
 }
 
 char *rpc_get_error(struct rpc_context *rpc)

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -2220,7 +2220,6 @@ void
 nfs_set_error(struct nfs_context *nfs, char *error_string, ...)
 {
         va_list ap;
-	char *str = NULL;
 
 #ifdef HAVE_MULTITHREADING
         /* All thread contexts share the same rpc_context so
@@ -2230,19 +2229,30 @@ nfs_set_error(struct nfs_context *nfs, char *error_string, ...)
                 nfs_mt_mutex_lock(&nfs->rpc->rpc_mutex);
         }
 #endif /* HAVE_MULTITHREADING */
+
         va_start(ap, error_string);
-	str = malloc(1024);
-	vsnprintf(str, 1024, error_string, ap);
-	if (nfs->error_string != NULL) {
-		free(nfs->error_string);
-	}
-	nfs->error_string = str;
-	va_end(ap);
+	free(nfs->error_string);
+	nfs->error_string = malloc(1024);
+	vsnprintf(nfs->error_string, 1024, error_string, ap);
+        va_end(ap);
+
 #ifdef HAVE_MULTITHREADING
         if (nfs->rpc->multithreading_enabled) {
                 nfs_mt_mutex_unlock(&nfs->rpc->rpc_mutex);
         }
 #endif /* HAVE_MULTITHREADING */
+}
+
+void
+nfs_set_error_nolock(struct nfs_context *nfs, char *error_string, ...)
+{
+        va_list ap;
+
+        va_start(ap, error_string);
+        free(nfs->error_string);
+        nfs->error_string = malloc(1024);
+        vsnprintf(nfs->error_string, 1024, error_string, ap);
+        va_end(ap);
 }
 
 struct mount_cb_data {

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -365,7 +365,7 @@ rpc_write_to_socket(struct rpc_context *rpc)
                                  goto finished;
 
                         }
-                        rpc_set_error_nolock(rpc, "Error when writing to "
+                        rpc_set_error_locked(rpc, "Error when writing to "
 					     "socket :%d %s", errno,
 					     rpc_get_error(rpc));
                         ret = -1;
@@ -840,7 +840,7 @@ rpc_timeout_scan(struct rpc_context *rpc)
 			if (!rpc->outqueue.head) {
 				rpc->outqueue.tail = NULL; //done
 			}
-			rpc_set_error_nolock(rpc, "command timed out");
+			rpc_set_error_locked(rpc, "command timed out");
 			pdu->cb(rpc, RPC_STATUS_TIMEOUT,
 				NULL, pdu->private_data);
 			rpc_free_pdu(rpc, pdu);
@@ -900,7 +900,7 @@ rpc_timeout_scan(struct rpc_context *rpc)
 			} else {
 				// qqq move to a temporary queue and process after
 				// we drop the mutex
-				rpc_set_error_nolock(rpc, "command timed out");
+				rpc_set_error_locked(rpc, "command timed out");
 				pdu->cb(rpc, RPC_STATUS_TIMEOUT,
 					NULL, pdu->private_data);
 				rpc_free_pdu(rpc, pdu);

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -365,9 +365,9 @@ rpc_write_to_socket(struct rpc_context *rpc)
                                  goto finished;
 
                         }
-                        rpc_set_error(rpc, "Error when writing to "
-                                      "socket :%d %s", errno,
-                                      rpc_get_error(rpc));
+                        rpc_set_error_nolock(rpc, "Error when writing to "
+					     "socket :%d %s", errno,
+					     rpc_get_error(rpc));
                         ret = -1;
                         goto finished;
                 }
@@ -840,7 +840,7 @@ rpc_timeout_scan(struct rpc_context *rpc)
 			if (!rpc->outqueue.head) {
 				rpc->outqueue.tail = NULL; //done
 			}
-			rpc_set_error(rpc, "command timed out");
+			rpc_set_error_nolock(rpc, "command timed out");
 			pdu->cb(rpc, RPC_STATUS_TIMEOUT,
 				NULL, pdu->private_data);
 			rpc_free_pdu(rpc, pdu);
@@ -900,7 +900,7 @@ rpc_timeout_scan(struct rpc_context *rpc)
 			} else {
 				// qqq move to a temporary queue and process after
 				// we drop the mutex
-				rpc_set_error(rpc, "command timed out");
+				rpc_set_error_nolock(rpc, "command timed out");
 				pdu->cb(rpc, RPC_STATUS_TIMEOUT,
 					NULL, pdu->private_data);
 				rpc_free_pdu(rpc, pdu);


### PR DESCRIPTION
rpc_set_error() holds the rpc_mutex so it cannot be called by any function which already holds the mutex. In this case rpc_write_to_socket() was calling rpc_set_error() resulting in a deadlock. This was detected when running the stress test suite where I continously keep killing the connectiong with "ss -K" while data xfer is on.

To solve this I defined a nolock version for both the rpc and nfs set error functions. Audited the code and fixed one more occurrence. The audit may not be complete so created "error checking" mutex to catch such locking violations.

Didn't use recursive mutex as those encourage bad programming practice and such bugs may silently get hidden.

Testing done:
With this fix ran 100+ iterations of 100GB file xfer while killing all connections every 5 seconds.