### PR TITLE
Misc improvements in the nfs-pthreads-*writefile examples

### DIFF
--- a/examples/nfs-pthreads-writefile.c
+++ b/examples/nfs-pthreads-writefile.c
@@ -98,13 +98,14 @@ static void *nfs_write_thread(void *arg)
 	char *buf;
 	ssize_t count;
 
-	buf = malloc(65536);
+	/* 1MB write RPC is fair size */
+	buf = malloc(1048576);
 	if (buf == NULL) {
 		fprintf(stderr, "Failed to allocate buffer\n");
 		exit(1);
 	}
 	while (wd->len) {
-		count = 65536;
+		count = 1048576;
 		if (count > wd->len) {
 			count = wd->len;
 		}


### PR DESCRIPTION
- Use 1MB write size
- Limit max outstanding in case of async writes, else it can grow unbounded for very large files