### PR TITLE
CMakeLists.txt, configure.ac: increment VERSION and SOVERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.16)
 
 project(libnfs
         LANGUAGES C
-        VERSION 5.0.3)
+        VERSION 6.0.0)
 
-set(SOVERSION 11.2.0 CACHE STRING "" FORCE)
+set(SOVERSION 12.0.0 CACHE STRING "" FORCE)
 
 set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for binaries")
 set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.71])
-AC_INIT([libnfs],[5.0.3],[ronniesahlberg@gmail.com])
+AC_INIT([libnfs],[6.0.0],[ronniesahlberg@gmail.com])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([-Wall foreign subdir-objects])
 AC_CANONICAL_HOST

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -27,7 +27,7 @@ libnfs_la_SOURCES = \
 	socket.c \
 	../win32/win32_compat.c
 
-SOCURRENT=14
+SOCURRENT=15
 SOREVISION=0
 SOAGE=0
 libnfs_la_LDFLAGS = -version-info $(SOCURRENT):$(SOREVISION):$(SOAGE) \


### PR DESCRIPTION
Commit 5e8f7ce27330 ("Add (almost) Zero-Copy for READ3") introduced a new API+ABI version that is incompatible with previous libnfs versions.

To avoid runtime breakages due to the new ABI, we must increment SOVERSION.

To avoid build-time breakages due to the new API, applications must be able to detec the new API.  Since libnfs has no version macro, they cannot do this at compile time; the only way to detect the new API is to check the version number in the pkg-config file at configure time.