### PR TITLE
Added rpc_stats for maintaining stats for each rpc_context

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -205,6 +205,8 @@ struct tls_context {
 };
 #endif /* HAVE_TLS */
 
+#define INC_STATS(rpc, stat) ++((rpc)->stats.stat)
+
 struct gss_ctx_id_struct;
 struct rpc_context {
 	uint32_t magic;
@@ -360,6 +362,9 @@ struct rpc_context {
         /* Is a server context ? */
         int is_server_context;
         struct rpc_endpoint *endpoints;
+
+        /* Per-transport RPC stats */
+        struct rpc_stats stats;
 };
 
 struct rpc_pdu {

--- a/include/nfsc/libnfs-raw.h
+++ b/include/nfsc/libnfs-raw.h
@@ -39,6 +39,8 @@ struct rpc_data {
  * Stats maintained per RPC transport.
  * User can query these using get_rpc_stats().
  *
+ * Note: If you add more counters, make sure they are updated atomically.
+ *
  * TODO: These are currently updated only for the client.
  */
 struct rpc_stats {

--- a/lib/init.c
+++ b/lib/init.c
@@ -376,6 +376,27 @@ char *rpc_get_error(struct rpc_context *rpc)
 	return rpc->error_string ? rpc->error_string : "";
 }
 
+void rpc_get_stats(struct rpc_context *rpc, struct rpc_stats *stats)
+{
+	assert(rpc->magic == RPC_CONTEXT_MAGIC);
+
+#ifdef HAVE_MULTITHREADING
+        if (rpc->multithreading_enabled) {
+                nfs_mt_mutex_lock(&rpc->rpc_mutex);
+        }
+#endif /* HAVE_MULTITHREADING */
+
+        *stats = rpc->stats;
+
+#ifdef HAVE_MULTITHREADING
+        if (rpc->multithreading_enabled) {
+                nfs_mt_mutex_unlock(&rpc->rpc_mutex);
+        }
+#endif /* HAVE_MULTITHREADING */
+
+        return;
+}
+
 static void rpc_purge_all_pdus(struct rpc_context *rpc, int status, const char *error)
 {
 	struct rpc_queue outqueue;

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -644,6 +644,9 @@ static int rpc_process_reply(struct rpc_context *rpc, ZDR *zdr)
 
 	assert(rpc->magic == RPC_CONTEXT_MAGIC);
 
+	// Client got a response for its request.
+	INC_STATS(rpc, num_resp_rcvd);
+
 	memset(&msg, 0, sizeof(struct rpc_msg));
 	msg.body.rbody.reply.areply.verf = _null_auth;
 	if (pdu->zdr_decode_bufsize > 0) {

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -644,7 +644,7 @@ static int rpc_process_reply(struct rpc_context *rpc, ZDR *zdr)
 
 	assert(rpc->magic == RPC_CONTEXT_MAGIC);
 
-	// Client got a response for its request.
+	/* Client got a response for its request */
 	INC_STATS(rpc, num_resp_rcvd);
 
 	memset(&msg, 0, sizeof(struct rpc_msg));

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -386,7 +386,7 @@ rpc_write_to_socket(struct rpc_context *rpc)
                                 if (pdu->next == NULL)
                                         rpc->outqueue.tail = NULL;
 
-                                // RPC sent, original or retransmit.
+                                /* RPC sent, original or retransmit */
                                 INC_STATS(rpc, num_req_sent);
 
                                 if (pdu->flags & PDU_DISCARD_AFTER_SENDING) {
@@ -812,7 +812,7 @@ rpc_timeout_scan(struct rpc_context *rpc)
 			continue;
 		}
 
-		// Timed out w/o being sent.
+		/* Timed out w/o being sent */
 		INC_STATS(rpc, num_timedout);
 
 		/*
@@ -825,7 +825,7 @@ rpc_timeout_scan(struct rpc_context *rpc)
 			pdu->timeout = 0;
 
 			if (t >= pdu->major_timeout) {
-				// Timed out w/o being sent.
+				/* Timed out w/o being sent */
 				INC_STATS(rpc, num_major_timedout);
 
 				/* Ask pdu_set_timeout() to set pdu->major_timeout */
@@ -870,7 +870,7 @@ rpc_timeout_scan(struct rpc_context *rpc)
 				continue;
 			}
 
-			// Timed out waiting for response.
+			/* Timed out waiting for response */
 			INC_STATS(rpc, num_timedout);
 
 			LIBNFS_LIST_REMOVE(&q->head, pdu);
@@ -889,7 +889,7 @@ rpc_timeout_scan(struct rpc_context *rpc)
 				pdu->timeout = 0;
 
 				if (t >= pdu->major_timeout) {
-					// Timed out waiting for response.
+					/* Timed out waiting for response */
 					INC_STATS(rpc, num_major_timedout);
 
 					/* Ask pdu_set_timeout() to set pdu->major_timeout */
@@ -911,7 +911,7 @@ rpc_timeout_scan(struct rpc_context *rpc)
 				/* queue it back to outqueue for retransmit */
 				rpc_return_to_queue(&rpc->outqueue, pdu);
 
-				// Retransmit on timeout.
+				/* Retransmit on timeout */
 				INC_STATS(rpc, num_retransmitted);
 
 				/* we have to re-send the whole pdu again */
@@ -1566,7 +1566,7 @@ rpc_reconnect_requeue(struct rpc_context *rpc)
 		for (pdu = q->head; pdu; pdu = next) {
 			next = pdu->next;
 			rpc_return_to_queue(&rpc->outqueue, pdu);
-			// Retransmit on reconnect.
+			/* Retransmit on reconnect */
 			INC_STATS(rpc, num_retransmitted);
 			/* we have to re-send the whole pdu again */
 			pdu->out.num_done = 0;


### PR DESCRIPTION
This is required since RPC layer performs retransmits, timeout handling, reconnect, etc, so user won't know those. get_rpc_stats() is the new API added for fetching stats for an rpc contect.