### PR TITLE
Fix include sys/time.h

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -28,8 +28,7 @@
 #endif
 
 #include <stdint.h>
-#if defined(__ANDROID__) || defined(AROS) || defined(__PPU__) \
- || ( defined(__APPLE__) && defined(__MACH__) ) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(_WIN32)
 #include <sys/time.h>
 #else
 #include <time.h>


### PR DESCRIPTION
POSIX says `struct timeval` is defined if `<sys/time.h>` is included.

Instead of the mess that is currently done based on the system on which the stuff is being compiled, always include it except when `_WIN32` is defined.

This will fix the following build failure on musl for any applications using libnfs (e.g., mpd):

```
$SYSROOT/usr/include/nfsc/libnfs.h:965:23: error: field 'atime' has incomplete type 'timeval'
        struct timeval atime;
```

Fix #272