### PR TITLE
Fix release build which requires mode for create call

### DIFF
--- a/examples/nfs-pthreads-async-readfile.c
+++ b/examples/nfs-pthreads-async-readfile.c
@@ -274,7 +274,7 @@ int main(int argc, char *argv[])
          * Now create the local file and truncate it to the same size as the
          * nfs file.
          */
-        fd = open(argv[2], O_RDWR|O_CREAT|O_TRUNC);
+        fd = open(argv[2], O_RDWR|O_CREAT|O_TRUNC, 0644);
         if (fd < 0) {
                 fprintf(stderr, "Failed to open dest file %s\n", argv[2]);
                 exit(1);


### PR DESCRIPTION
This is the error it fails with

In file included from /usr/include/fcntl.h:301,
                 from /home/tomar/linuxsmiths_azure-storage-fuse/nfs/extern/libnfs/examples/nfs-pthreads-async-readfile.c:56:
In function ‘open’,
    inlined from ‘main’ at /home/tomar/linuxsmiths_azure-storage-fuse/nfs/extern/libnfs/examples/nfs-pthreads-async-readfile.c:277:14:
/usr/include/x86_64-linux-gnu/bits/fcntl2.h:50:4: error: call to ‘__open_missing_mode’ declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
   50 |    __open_missing_mode ();
      |    ^~~~~~~~~~~~~~~~~~~~~~