### PR TITLE
Add req_size and resp_size to PDU.

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -458,6 +458,26 @@ struct rpc_pdu {
                                         * Used to clamp long reads.
                                         */
 
+        /*
+         * Total request bytes sent out for this PDU.
+         * This includes RPC header + NFS header + optional data (for WRITE).
+         * This can be queried using rpc_pdu_get_req_size(pdu) after the
+         * rpc_<protocol>_  API returns the to-be-sent PDU.
+         * This can be used by applications that want to provide mountstats
+         * style "avg bytes sent" telemetry.
+         */
+        uint32_t req_size;
+
+        /*
+         * Total response bytes received for this PDU.
+         * This includes RPC header + NFS header + optional data (for READ).
+         * This can be queried using rpc_pdu_get_resp_size(rpc_get_pdu(rpc))
+         * inside the rpc_<protocol>_  callback.
+         * This can be used by applications that want to provide mountstats
+         * style "avg bytes received" telemetry.
+         */
+        uint32_t resp_size;
+
 	rpc_cb cb;
 	void *private_data;
 

--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -478,6 +478,19 @@ struct rpc_pdu {
          */
         uint32_t resp_size;
 
+#ifdef HAVE_CLOCK_GETTIME
+        /*
+         * Microseconds since epoch when this PDU was completely written to
+         * the socket. Note that due to TCP connection b/w and sndbuf size
+         * limitations this time can be very different from the time the PDU
+         * was queued to rpc->outqueue for sending, using rpc_queue_pdu().
+         * Applications can use this to find the "rtt taken by the server to
+         * execute this RPC" by diff'ing this with the time when the callback
+         * is called.
+         */
+        uint64_t dispatch_usecs;
+#endif
+
 	rpc_cb cb;
 	void *private_data;
 
@@ -653,6 +666,9 @@ int rpc_add_fragment(struct rpc_context *rpc, char *data, uint32_t size);
 void rpc_free_all_fragments(struct rpc_context *rpc);
 int rpc_is_udp_socket(struct rpc_context *rpc);
 uint64_t rpc_current_time(void);
+#ifdef HAVE_CLOCK_GETTIME
+uint64_t rpc_wallclock_time(void);
+#endif
 
 void *zdr_malloc(ZDR *zdrs, uint32_t size);
 

--- a/include/nfsc/libnfs-raw.h
+++ b/include/nfsc/libnfs-raw.h
@@ -165,6 +165,41 @@ EXTERN int rpc_get_fd(struct rpc_context *rpc);
 EXTERN int rpc_which_events(struct rpc_context *rpc);
 EXTERN int rpc_service(struct rpc_context *rpc, int revents);
 
+/*
+ * Returns the request PDU (rpc->pdu) inside a rpc_cb callback called after
+ * receiving the response from the server for a RPC request sent by us.
+ * User can pass this to rpc_pdu_get_resp_size() to find the total response
+ * size in bytes, which includes the RPC header, the NFS header and data bytes
+ * if any.
+ *
+ * Note: This can be legitimately called *only* inside the callback function
+ *       where we are certain that the response was received, and hence
+ *       rpc->pdu would be valid. Once the callback returns, rpc->pdu would
+ *       be freed by libnfs so don't access the returned pdu outside the
+ *       callback
+ */
+EXTERN struct rpc_pdu *rpc_get_pdu(struct rpc_context *rpc);
+
+/*
+ * Get the size in bytes of the RPC request that libnfs will send out for
+ * this PDU. The size includes the RPC header, the NFS header and any data
+ * bytes sent (only WRITE RPC request will send data bytes).
+ * The PDU passed to it would be the one returned by any of the rpc_<protocol>_
+ * functions.
+ */
+EXTERN uint32_t rpc_pdu_get_req_size(struct rpc_pdu *pdu);
+
+/*
+ * Get the size in bytes of the RPC response that libnfs received for this
+ * request PDU. The size includes the RPC header, the NFS header and any data
+ * bytes received (only READ RPC response will contain data bytes).
+ * The PDU passed to it would be the one returned by rpc_get_pdu() called
+ * inside a callback function.
+ *
+ * Note: This can be legitimately called *only* inside a callback function.
+ *       See rpc_get_pdu() for more details.
+ */
+EXTERN uint32_t rpc_pdu_get_resp_size(struct rpc_pdu *pdu);
 
 /*
  * Returns the number of commands in-flight. Can be used by the application

--- a/include/nfsc/libnfs-raw.h
+++ b/include/nfsc/libnfs-raw.h
@@ -202,6 +202,22 @@ EXTERN uint32_t rpc_pdu_get_req_size(struct rpc_pdu *pdu);
 EXTERN uint32_t rpc_pdu_get_resp_size(struct rpc_pdu *pdu);
 
 /*
+ * Get the wallclock time in microseconds since epoch when this request PDU
+ * was dispatched, i.e., fully sent out of the socket. Applications can use
+ * this to find out the time taken by the server to execute the PDU by finding
+ * the difference between this and the time when the response is received, and
+ * the callback is called.
+ * The PDU passed to it would be the one returned by rpc_get_pdu() called
+ * inside a callback function.
+ *
+ * Note: This can be legitimately called *only* inside a callback function.
+ *       See rpc_get_pdu() for more details.
+ * Note: This only works on systems with clock_gettime() defined, else it
+ *       returns 0.
+ */
+EXTERN uint64_t rpc_pdu_get_dispatch_usecs(struct rpc_pdu *pdu);
+
+/*
  * Returns the number of commands in-flight. Can be used by the application
  * to check if there are any more responses we are awaiting from the server
  * or if the connection is completely idle.

--- a/lib/init.c
+++ b/lib/init.c
@@ -70,6 +70,9 @@
 
 static const char *oom = "out of memory";
 
+/*
+ * This returns time in millseconds since system boot.
+ */
 uint64_t rpc_current_time(void)
 {
 #ifdef HAVE_CLOCK_GETTIME
@@ -81,6 +84,19 @@ uint64_t rpc_current_time(void)
 	return (uint64_t)time(NULL) * 1000;
 #endif
 }
+
+#ifdef HAVE_CLOCK_GETTIME
+/*
+ * This returns time in microseconds since epoch.
+ */
+uint64_t rpc_wallclock_time(void)
+{
+	struct timespec tp;
+
+	clock_gettime(CLOCK_REALTIME, &tp);
+	return (uint64_t)tp.tv_sec * 1000000 + tp.tv_nsec / 1000;
+}
+#endif
 
 int rpc_set_hash_size(struct rpc_context *rpc, int hashes)
 {

--- a/lib/init.c
+++ b/lib/init.c
@@ -376,6 +376,13 @@ char *rpc_get_error(struct rpc_context *rpc)
 	return rpc->error_string ? rpc->error_string : "";
 }
 
+struct rpc_pdu *rpc_get_pdu(struct rpc_context *rpc)
+{
+        assert(rpc->magic == RPC_CONTEXT_MAGIC);
+
+        return rpc->pdu;
+}
+
 void rpc_get_stats(struct rpc_context *rpc, struct rpc_stats *stats)
 {
 	assert(rpc->magic == RPC_CONTEXT_MAGIC);

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -1031,6 +1031,15 @@ uint32_t rpc_pdu_get_resp_size(struct rpc_pdu *pdu)
         return pdu->resp_size;
 }
 
+uint64_t rpc_pdu_get_dispatch_usecs(struct rpc_pdu *pdu)
+{
+#ifdef HAVE_CLOCK_GETTIME
+        return pdu->dispatch_usecs;
+#else
+        return 0;
+#endif
+}
+
 int rpc_cancel_pdu(struct rpc_context *rpc, struct rpc_pdu *pdu)
 {
         /*

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -411,6 +411,14 @@ rpc_write_to_socket(struct rpc_context *rpc)
                                 /* RPC sent, original or retransmit */
                                 INC_STATS(rpc, num_req_sent);
 
+#ifdef HAVE_CLOCK_GETTIME
+                                /*
+                                 * Now this RPC is completely written over the socket.
+                                 * Note current wallclock time as the dispatch time.
+                                 */
+                                pdu->dispatch_usecs = rpc_wallclock_time();
+#endif
+
                                 if (pdu->flags & PDU_DISCARD_AFTER_SENDING) {
                                         rpc_free_pdu(rpc, pdu);
                                         ret = 0;


### PR DESCRIPTION
These will be updated when we create the RPC request and when we receive the RPC response bytes, respectively. The req and resp size containg the RPC header, the NFS header and optional data bytes.
This is for supporting mountstats style "avg bytes sent" and "avg bytes received".

User can query the req and resp bytes using the two newly added APIs

rpc_pdu_get_req_size()
rpc_pdu_get_resp_size()