### PR TITLE
fix(macos): add RPATH configuration for macOS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ option(ENABLE_UTILS "Build util programs" OFF)
 option(ENABLE_EXAMPLES "Build example programs" OFF)
 option(ENABLE_MULTITHREADING "Enable multithreading support" OFF)
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(CMAKE_INSTALL_RPATH "${INSTALL_LIB_DIR}")
+  set(CMAKE_SKIP_INSTALL_RPATH FALSE)
+endif()
+
 if(ENABLE_TESTS)
   set(ENABLE_UTILS ON CACHE BOOL "Building utils required by tests" FORCE)
 endif()

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -7,6 +7,14 @@ endif()
 foreach(TARGET ${UTILITIES})
   add_executable(${TARGET} ${TARGET}.c)
   target_link_libraries(${TARGET} nfs nfs_mount)
+
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set_target_properties(${TARGET} PROPERTIES
+      INSTALL_RPATH "${INSTALL_LIB_DIR}"
+      BUILD_RPATH "${INSTALL_LIB_DIR}"
+    )
+  endif()
+
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}
           DESTINATION ${INSTALL_BIN_DIR})
 endforeach()


### PR DESCRIPTION
👋 while using cmake for [libnfs 6.0.0 release build PR](https://github.com/Homebrew/homebrew-core/pull/200785), I found some rpath issue

```
$ /opt/homebrew/Cellar/libnfs/6.0.0/bin/nfs-ls --help
dyld[84612]: Library not loaded: @rpath/libnfs.16.0.0.dylib
  Referenced from: <D1E1ABB2-ABAB-30FD-BC8D-E797B4E5282E> /opt/homebrew/Cellar/libnfs/6.0.0/bin/nfs-ls
  Reason: no LC_RPATH's found
Abort trap: 6
```

thus adding some macos cmake build settings.