### PR TITLE
Fix size of arguments

### DIFF
--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -700,7 +700,7 @@ int rpc_queue_pdu(struct rpc_context *rpc, struct rpc_pdu *pdu)
 			assert(!rpc->is_udp);
 			assert(!rpc->is_broadcast);
 
-			RPC_LOG(rpc, 2, "Sending AUTH_TLS NULL RPC (%lu bytes)",
+			RPC_LOG(rpc, 2, "Sending AUTH_TLS NULL RPC (%u bytes)",
 					pdu->out.total_size);
 		}
 #endif


### PR DESCRIPTION
libnfs 6.0.1
i386
GCC 14.2.0
Debian unstable

This commit fix the build with the following error.

```
pdu.c: In function 'rpc_queue_pdu':
/build/libnfs-dmo-6.0.1/include/libnfs-private.h:633:49: error: format '%llu' expects argument of type 'long long unsigned int', but argument 6 has type 'size_t' {aka 'unsigned int'} [-Werror=format=]
  633 |                         snprintf(xxlogbuf, 255, "libnfs:%d rpc %p " format, level, rpc, ## __VA_ARGS__); \
      |                                                 ^~~~~~~~~~~~~~~~~~~
pdu.c:703:25: note: in expansion of macro 'RPC_LOG'
  703 |                         RPC_LOG(rpc, 2, "Sending AUTH_TLS NULL RPC (%llu bytes)",
      |                         ^~~~~~~
cc1: all warnings being treated as errors
```