### PR TITLE
Fix win32 build of installed package

### DIFF
--- a/include/nfsc/libnfs-raw.h
+++ b/include/nfsc/libnfs-raw.h
@@ -39,10 +39,6 @@
 #include "ps3_compat.h"
 #endif
 
-#ifdef WIN32
-#include <win32/win32_compat.h>
-#endif
-
 #include <stdint.h>
 
 #if defined(HAVE_SYS_UIO_H) || (defined(__APPLE__) && defined(__MACH__))

--- a/include/win32/win32_compat.h
+++ b/include/win32/win32_compat.h
@@ -163,7 +163,7 @@ int     win32_gettimeofday(struct timeval *tv, struct timezone *tz);
 
 #define DllExport
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) || defined(_MSC_VER)
 char* libnfs_strndup(const char *s, size_t n);
 #define strndup libnfs_strndup
 #endif

--- a/include/win32/win32_compat.h
+++ b/include/win32/win32_compat.h
@@ -150,9 +150,15 @@ struct pollfd {
 int     getpid(void);
 int     win32_inet_pton(int af, const char * src, void * dst);
 int     win32_poll(struct pollfd *fds, unsigned int nfsd, int timeout);
-int     win32_gettimeofday(struct timeval *tv, struct timezone *tz);
 #ifdef __MINGW32__
 # define win32_gettimeofday mingw_gettimeofday
+#else
+struct timezone
+{
+  int  tz_minuteswest; /* minutes W of Greenwich */
+  int  tz_dsttime;     /* type of dst correction */
+};
+int     win32_gettimeofday(struct timeval *tv, struct timezone *tz);
 #endif
 
 #define DllExport

--- a/lib/nfs_v4.c
+++ b/lib/nfs_v4.c
@@ -88,6 +88,10 @@
 #include <pwd.h>
 #endif
 
+#ifdef WIN32
+#include <win32/win32_compat.h>
+#endif
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdarg.h>

--- a/win32/win32_compat.c
+++ b/win32/win32_compat.c
@@ -157,12 +157,6 @@ int win32_poll(struct pollfd *fds, unsigned int nfds, int timo)
 #endif
  
 #ifndef __MINGW32__
-struct timezone 
-{
-  int  tz_minuteswest; /* minutes W of Greenwich */
-  int  tz_dsttime;     /* type of dst correction */
-};
- 
 int win32_gettimeofday(struct timeval *tv, struct timezone *tz)
 {
   FILETIME ft;


### PR DESCRIPTION
`win32_compat.h` is not installed so it should not be included from an installed header.

Also includes other fixes for mingw-w64 and MSVC.

Fixes #507