### PR TITLE
cmake: export the necessary library in the pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,14 @@ install(FILES cmake/FindNFS.cmake
         DESTINATION ${INSTALL_CMAKE_DIR})
 
 # handle pc-config files
+set(PKG_LIBLIST "")
+foreach(LIB ${SYSTEM_LIBRARIES})
+  if(IS_ABSOLUTE ${LIB} AND EXISTS ${LIB})
+    list(APPEND PKG_LIBLIST "${LIB}")
+  else()
+    list(APPEND PKG_LIBLIST "-l${LIB}")
+  endif()
+endforeach()
 configure_file(cmake/libnfs.pc.cmake
                ${CMAKE_CURRENT_BINARY_DIR}/libnfs.pc @ONLY)
 

--- a/cmake/libnfs.pc.cmake
+++ b/cmake/libnfs.pc.cmake
@@ -10,5 +10,5 @@ Description: libnfs is a client library for accessing NFS shares over a network.
 Version: @PROJECT_VERSION@
 Requires:
 Conflicts:
-Libs: -L${libdir} -lnfs
+Libs: -L${libdir} -lnfs @PKG_LIBLIST@
 Cflags: -I${includedir}


### PR DESCRIPTION
That includes gnutls on Linux if it's used.