### PR TITLE
Change rpc_pdu.zdr_decode_buf to void*

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -499,7 +499,7 @@ struct rpc_pdu {
 
 	/* function to decode the zdr reply data and buffer to decode into */
 	zdrproc_t zdr_decode_fn;
-	caddr_t zdr_decode_buf;
+	void *zdr_decode_buf;
 	uint32_t zdr_decode_bufsize;
 
         uint32_t discard_after_sending:1;

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -858,7 +858,7 @@ rpc_read_from_socket(struct rpc_context *rpc)
                                                  * If the READ failed, bail out here as there is no
                                                  * data.
                                                  */
-                                                const READ3res *res = (READ3res *)(void *) rpc->pdu->zdr_decode_buf;
+                                                const READ3res *res = (READ3res *) rpc->pdu->zdr_decode_buf;
                                                 if (res->status != NFS3_OK) {
                                                         goto payload_finished;
                                                 }


### PR DESCRIPTION
caddr_t is usually char*, which causes "cast increases required alignment" error on riscv64 (https://archriscv.felixc.at/.status/log.htm?url=logs/libnfs/libnfs-6.0.2-3.log), but the buffer is actually suitably aligned to at least 8 bytes.

Change the type of zdr_decode_buf to void* to fix it.