### PR TITLE
With nfs_ftruncate_async(), the file must be open for writing

### DIFF
--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -1643,6 +1643,10 @@ int
 nfs_ftruncate_async(struct nfs_context *nfs, struct nfsfh *nfsfh,
                     uint64_t length, nfs_cb cb, void *private_data)
 {
+        if (nfsfh->is_readonly) {
+                nfs_set_error(nfs, "Trying to truncate to read-only file");
+                return -1;
+        }
 	switch (nfs->nfsi->version) {
         case NFS_V3:
                 return nfs3_ftruncate_async(nfs, nfsfh, length,


### PR DESCRIPTION
[#524](https://github.com/sahlberg/libnfs/issues/524) I have verified that the file cannot be written to when is_readonly is set.  By looking at `man 2 ftruncate`, this rule should also apply to ftruncate.
<img width="1505" alt="截屏2025-02-25 21 31 24" src="https://github.com/user-attachments/assets/72846f5d-3673-4ee3-99ed-120a72a9080f" />
