### PR TITLE
Fix compilation failure when multi-threading option is enabled

### DIFF
--- a/lib/multithreading.c
+++ b/lib/multithreading.c
@@ -170,7 +170,7 @@ int nfs_mt_sem_wait(libnfs_sem_t* sem)
     return 0;
 }
 
-#elif HAVE_PTHREAD /* WIN32 */
+#elif defined(HAVE_PTHREAD) /* WIN32 */
 
 #include <unistd.h>
 #include <sys/syscall.h>


### PR DESCRIPTION
Hi Ronnie,

Compilation fails when multithreading is enabled.

Environment description:
platform: centos7
gcc version: 9.3.1
 

![截屏2025-03-06 18 40 25](https://github.com/user-attachments/assets/209a6d48-5389-4a7f-b135-16c328760aa6)

`config.h` file automatically generated by cmake
![image](https://github.com/user-attachments/assets/e179fb52-96a8-4690-b6ff-92760bd9b9a5)

