### PR TITLE
Add nfs4_getattr function

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -309,11 +309,17 @@ EXTERN const struct sockaddr_storage *nfs_get_server_address(struct nfs_context 
 
 /*
  * Get the maximum supported READ size by the server
+ *
+ * Notice that in case of NFSv4 it may not get you a proper configuration of server.
+ * You can call nfs4_getattr to retrieve it.
  */
 EXTERN size_t nfs_get_readmax(struct nfs_context *nfs);
 
 /*
  * Get the maximum supported WRITE size by the server
+ *
+ * Notice that in case of NFSv4 it may not get you a proper configuration of server.
+ * You can call nfs4_getattr to retrieve it.
  */
 EXTERN size_t nfs_get_writemax(struct nfs_context *nfs);
 

--- a/lib/libnfs-win32.def
+++ b/lib/libnfs-win32.def
@@ -134,6 +134,8 @@ nfs4_set_verifier
 nfs4_acl_free
 nfs4_getacl
 nfs4_getacl_async
+nfs4_getattr
+nfs4_getattr_async
 win32_poll
 rpc_cancel_pdu
 rpc_connect_async

--- a/nfs4/libnfs-raw-nfs4.h
+++ b/nfs4/libnfs-raw-nfs4.h
@@ -487,6 +487,18 @@ typedef nfstime4 fattr4_time_metadata;
 typedef nfstime4 fattr4_time_modify;
 
 typedef settime4 fattr4_time_modify_set;
+
+typedef struct {
+	fattr4_maxread maxread;
+	fattr4_maxwrite maxwrite;
+} fattr4_attr;
+
+enum fattr4_attr_type {
+    FATTR4_ATTR_TYPE_MAXREAD = (1u << 0),
+    FATTR4_ATTR_TYPE_MAXWRITE = (1u << 1),
+};
+typedef enum fattr4_attr_type fattr4_attr_type;
+
 #define FATTR4_SUPPORTED_ATTRS 0
 #define FATTR4_TYPE 1
 #define FATTR4_FH_EXPIRE_TYPE 2
@@ -3081,6 +3093,34 @@ EXTERN int nfs4_getacl(struct nfs_context *nfs, struct nfsfh *nfsfh,
                        fattr4_acl *nfs4acl);
 
 EXTERN void nfs4_acl_free(fattr4_acl *nfs4acl);
+
+/*
+ * NFSv4 get some of attributes
+ */
+/*
+ * get some of attributes
+ * Function returns
+ *  0 : The command was queued successfully. The callback will be invoked once
+ *      the command completes.
+ * <0 : An error occured when trying to queue the command.
+ *      The callback will not be invoked.
+ *
+ * When the callback is invoked, status indicates the result:
+ *      0 : Success.
+ * -errno : An error occured.
+ *          data is the error string.
+ */
+EXTERN int nfs4_getattr_async(struct nfs_context *nfs, fattr4_attr_type attrtype,
+							  nfs_cb cb, void *private_data);
+
+/*
+ * Sync nfs4 get some of attributes
+ * Function returns
+ *      0 : The operation was successful.
+ * -errno : The command failed.
+ */
+EXTERN int nfs4_getattr(struct nfs_context *nfs, fattr4_attr_type attrtype,
+						fattr4_attr *attr);
 
 #ifdef __cplusplus
 }

--- a/nfs4/libnfs-raw-nfs4.h.extra
+++ b/nfs4/libnfs-raw-nfs4.h.extra
@@ -42,6 +42,31 @@ EXTERN int nfs4_getacl(struct nfs_context *nfs, struct nfsfh *nfsfh,
 
 EXTERN void nfs4_acl_free(fattr4_acl *nfs4acl);
 
+/*
+ * NFSv4 get some of attributes
+ * Function returns
+ *  0 : The command was queued successfully. The callback will be invoked once
+ *      the command completes.
+ * <0 : An error occured when trying to queue the command.
+ *      The callback will not be invoked.
+ *
+ * When the callback is invoked, status indicates the result:
+ *      0 : Success.
+ * -errno : An error occured.
+ *          data is the error string.
+ */
+EXTERN int nfs4_getattr_async(struct nfs_context *nfs, fattr4_attr_type attrtype,
+							  nfs_cb cb, void *private_data);
+
+/*
+ * NFSv4 Syncroniasly get some of attributes
+ * Function returns
+ *      0 : The operation was successful.
+ * -errno : The command failed.
+ */
+EXTERN int nfs4_getattr(struct nfs_context *nfs, fattr4_attr_type attrtype,
+						fattr4_attr *attr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/nfs4/nfs4.x
+++ b/nfs4/nfs4.x
@@ -448,6 +448,16 @@ typedef nfstime4        fattr4_time_metadata;
 typedef nfstime4        fattr4_time_modify;
 typedef settime4        fattr4_time_modify_set;
 
+typedef struct {
+	fattr4_maxread maxread;
+	fattr4_maxwrite maxwrite;
+} fattr4_attr;
+
+enum fattr4_attr_type {
+    FATTR4_ATTR_TYPE_MAXREAD = (1u << 0),
+    FATTR4_ATTR_TYPE_MAXWRITE = (1u << 1),
+};
+typedef enum fattr4_attr_type fattr4_attr_type;
 
 /*
  * Mandatory Attributes


### PR DESCRIPTION
Hi @sahlberg 

It was noticed that `nfs_get_writemax` does not work properly with NFSv4.
Which is in my opinion correct cause protocol is pretty different and it would require unnecessary rpc calls, which not everybody needs.

This patch adds a function to obtain a proper attributes from server.

Function declaration intentionally made more generic then ought to, so more attributes could be added later on with no change to interface.

```c
struct nfs_context *nfs;
fattr4_attr nfsattr;

nfs4_getattr(nfs, FATTR4_ATTR_TYPE_MAXREAD | FATTR4_ATTR_TYPE_MAXWRITE, &nfsattr);
```

Let me know if I got something wrong.
Take care.