### PR TITLE
Fix pkg-config file created by CMake not using the installed libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,10 @@ project(libnfs
 
 set(SOVERSION 16.2.0 CACHE STRING "" FORCE)
 
+include(cmake/GNUInstallDirs.cmake)
+
 set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for binaries")
-set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
+set(INSTALL_LIB_DIR "${CMAKE_INSTALL_FULL_LIBDIR}" CACHE PATH "Installation directory for libraries")
 set(INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "Installation directory for headers")
 set(INSTALL_MAN_DIR "${CMAKE_INSTALL_PREFIX}/share/man" CACHE PATH "Installation directory for manual pages")
 set(INSTALL_PKGCONFIG_DIR "${INSTALL_LIB_DIR}/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
@@ -44,7 +46,6 @@ if(IOS)
 endif()
 
 include(cmake/ConfigureChecks.cmake)
-include(cmake/GNUInstallDirs.cmake)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR}
                     include


### PR DESCRIPTION
The directory used to install the library has been configurable since:
20971de ("Use GNUInstallDirs for CMake to install the library in the right place", 2025-02-10)

---

cmake/libnfs.pc.cmake uses `libdir=@INSTALL_LIB_DIR@`
