### PR TITLE
Allow getexports to use a different mountport

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -350,6 +350,8 @@ struct rpc_context {
 	 */
 	char *server;
 
+	int mountport;
+
 	/* fragment reassembly */
 	struct rpc_fragment *fragments;
 
@@ -653,6 +655,8 @@ void rpc_set_resiliency(struct rpc_context *rpc,
 void rpc_set_interface(struct rpc_context *rpc, const char *ifname);
 
 void rpc_set_tcp_syncnt(struct rpc_context *rpc, int v);
+void rpc_set_mountport(struct rpc_context *rpc, int port);
+int rpc_get_mountport(struct rpc_context *rpc);
 void rpc_set_poll_timeout(struct rpc_context *rpc, int poll_timeout);
 int rpc_get_poll_timeout(struct rpc_context *rpc);
 void rpc_set_timeout(struct rpc_context *rpc, int timeout);

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -51,6 +51,7 @@ struct rpc_context;
 
 struct nfs_url {
 	char *server;
+	int  port;
 	char *path;
 	char *file;
 };
@@ -1999,6 +2000,15 @@ EXTERN int mount_getexports_async(struct rpc_context *rpc, const char *server,
  */
 EXTERN struct exportnode *mount_getexports(const char *server);
 
+/*
+ * Sync getexports_mountport(<server>, <mountport>)
+ * Function returns
+ *            NULL : something failed
+ *  exports export : a linked list of exported directories
+ *
+ * returned data must be freed by calling mount_free_export_list(exportnode);
+ */
+EXTERN struct exportnode *mount_getexports_mountport(const char *server, int mountport);
 /*
  * Sync getexports_timeout(<server>, <timeout>)
  * Function returns

--- a/lib/init.c
+++ b/lib/init.c
@@ -572,6 +572,20 @@ void rpc_destroy_context(struct rpc_context *rpc)
 	free(rpc);
 }
 
+void rpc_set_mountport(struct rpc_context *rpc, int port)
+{
+	assert(rpc->magic == RPC_CONTEXT_MAGIC);
+
+	rpc->mountport = port;
+}
+
+int rpc_get_mountport(struct rpc_context *rpc)
+{
+	assert(rpc->magic == RPC_CONTEXT_MAGIC);
+
+	return rpc->mountport;
+}
+
 void rpc_set_poll_timeout(struct rpc_context *rpc, int poll_timeout)
 {
 	assert(rpc->magic == RPC_CONTEXT_MAGIC);

--- a/lib/libnfs-sync.c
+++ b/lib/libnfs-sync.c
@@ -2382,6 +2382,34 @@ mount_getexports_cb(struct rpc_context *mount_context, int status, void *data,
 }
 
 struct exportnode *
+mount_getexports_mountport(const char *server, int mountport)
+{
+	struct sync_cb_data cb_data;
+	struct rpc_context *rpc;
+
+
+	cb_data.return_data = NULL;
+        if (nfs_init_cb_data(NULL, &cb_data)) {
+                return NULL;
+        }
+
+	rpc = rpc_init_context();
+	rpc_set_mountport(rpc, mountport);
+	if (mount_getexports_async(rpc, server, mount_getexports_cb,
+                                   &cb_data) != 0) {
+		rpc_destroy_context(rpc);
+                nfs_destroy_cb_sem(&cb_data);
+		return NULL;
+	}
+
+	wait_for_reply(rpc, &cb_data);
+        nfs_destroy_cb_sem(&cb_data);
+	rpc_destroy_context(rpc);
+
+	return cb_data.return_data;
+}
+
+struct exportnode *
 mount_getexports_timeout(const char *server, int timeout)
 {
 	struct sync_cb_data cb_data;

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -417,6 +417,15 @@ nfs_parse_url(struct nfs_context *nfs, const char *url, int dir, int incomplete)
 		return NULL;
 	}
 
+	strp = strchr(urls->server, ':');
+        if (strp) {
+                *strp++ = 0;
+		nfs->nfsi->nfsport =  atoi(strp);
+        }
+
+	if (strp == NULL)
+		strp = urls->server;
+
 	strp = strchr(urls->server, '/');
 	if (strp == NULL) {
 		if (incomplete) {
@@ -435,12 +444,6 @@ nfs_parse_url(struct nfs_context *nfs, const char *url, int dir, int incomplete)
 		return NULL;
 	}
 	*strp = 0;
-
-	strp = strchr(urls->server, ':');
-        if (strp) {
-                *strp++ = 0;
-		nfs->nfsi->nfsport =  atoi(strp);
-        }
 
 	if (dir) {
 		flagsp = strchr(urls->path, '?');
@@ -519,6 +522,10 @@ flags:
 		free(urls->server);
 		urls->server = NULL;
 	}
+
+	urls->port = nfs->nfsi->nfsport;
+	if (nfs->nfsi->mountport)
+		urls->port = nfs->nfsi->mountport;
 
 #ifdef HAVE_TLS
 	/*

--- a/utils/nfs-ls.c
+++ b/utils/nfs-ls.c
@@ -73,11 +73,14 @@ void print_usage(void)
 	fprintf(stderr, "Usage: nfs-ls [-?|--help|--usage] [-R|--recursive] [-s|--summary] [-D|--discovery] <url>\n");
 }
 
-int process_server(const char *server) {
+int process_server(const char *server, int mountport) {
 	struct exportnode *exports;
 	struct exportnode *export;
 
-	exports = mount_getexports(server);
+	if (mountport)
+		exports = mount_getexports_mountport(server, mountport);
+	else
+		exports = mount_getexports(server);
 	if (exports == NULL) {
 		fprintf(stderr, "Failed to get exports for server %s.\n", server);
 		return -1;
@@ -220,7 +223,7 @@ int main(int argc, char *argv[])
 			}
 			for (srv=srvrs; srv; srv = srv->next) {
 				if (recursive) {
-					process_server(srv->addr);
+					process_server(srv->addr, 0);
 				} else {
 					printf("nfs://%s\n", srv->addr);
 				}
@@ -230,7 +233,7 @@ int main(int argc, char *argv[])
 			goto finished;
 		}
 		if (url->server && !url->path) {
-			ret = process_server(url->server);
+			ret = process_server(url->server, url->port);
 			goto finished;
 		}
 		nfs_destroy_url(url);


### PR DESCRIPTION
This is so that args such as mountport can be used, previously it would ignore them and always use 111.