### PR TITLE
Allocate memory for correct number of ops

### DIFF
--- a/lib/nfs_v4.c
+++ b/lib/nfs_v4.c
@@ -1139,7 +1139,7 @@ nfs4_allocate_op(struct nfs_context *nfs, nfs_argop4 **op,
 
         count = nfs4_num_path_components(nfs, path);
 
-        *op = malloc(sizeof(**op) * (2 + 2 * count + num_extra));
+        *op = malloc(sizeof(**op) * (2 + count + num_extra));
         if (*op == NULL) {
                 nfs_set_error(nfs, "Failed to allocate op array");
                 return -1;


### PR DESCRIPTION
- 1 for PUTFH or PUTROOTFH
- 1 LOOKUP for each path component
- 1 for GETATTR
- Additional as specified with num_extra by caller

* This calculation has allocated 2 ops per path component since 3ced39f5
* Perhaps there was originally a plan to perform 2 ops per path component, LOOKUP and GETATTR, for filehandle caching purposes, that was not completed