### PR TITLE
Fix cmakelists for Windows utilities

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,12 +1,12 @@
-set(UTILITIES nfs-cat nfs-ls)
+set(UTILITIES nfs-cat nfs-ls nfs-cp nfs-stat)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
-  list(APPEND UTILITIES nfs-cp nfs-stat)
-endif()
 
 foreach(TARGET ${UTILITIES})
   add_executable(${TARGET} ${TARGET}.c)
-  target_link_libraries(${TARGET} nfs nfs_mount)
+  target_link_libraries(${TARGET} nfs)
+  target_include_directories(${TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../mount")
+
+  
 
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set_target_properties(${TARGET} PROPERTIES


### PR DESCRIPTION
Fix the build and compilation process for Windows

We don't need to link against the nfs_mount library, but only the nfs library.
However, we need the mount header files for the compilation (therefore target_include_directories)