### PR TITLE
[cmake] set PROJECT_VERSION to match "release" version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(libnfs
         LANGUAGES C
-        VERSION 16.2.0)
+        VERSION 6.0.2)
 
 set(SOVERSION 16.2.0 CACHE STRING "" FORCE)
 


### PR DESCRIPTION
Currently the 6.x release series has the VERSION to match the SOVERSION This has the knock on effect of a pkg config returning the below for a build of libnfs 6.0.2

```
  <snip>

  Name: libnfs
  Description: libnfs is a client library for accessing NFS shares over a network.
  Version: 16.2.0
  Requires:
  Conflicts:
  Libs: -L${libdir} -lnfs
  Cflags: -I${includedir}
```

And also the cmake config version being 16.2.0 (in tagged release of 6.0.2)