### PR TITLE
Fix memory leak around username handling

### DIFF
--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -375,7 +375,7 @@ static struct nfs_url *
 nfs_parse_url(struct nfs_context *nfs, const char *url, int dir, int incomplete)
 {
 	struct nfs_url *urls;
-	char *strp, *flagsp, *strp2, ch;
+	char *strp, *flagsp, *strp2, ch, *original_server;
         int tmp;
 
 	if (strncmp(url, "nfs://", 6)) {
@@ -528,14 +528,17 @@ flags:
                         nfs_destroy_url(urls);
                         return NULL;
                 }
+                original_server = urls->server;
                 urls->server = strdup(strp);
 		if (urls->server == NULL) {
+                        urls->server = original_server;
 			nfs_destroy_url(urls);
 			rpc_set_error(nfs->rpc,
 				      "Out of memory: Failed to allocate "
 				      "server name");
 			return NULL;
 		}
+                free(original_server);
         }
 	if (urls->server && strlen(urls->server) <= 1) {
 		free(urls->server);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TEST_PROGS prog_access
                prog_open_read
                prog_open_write
                prog_opendir
+               prog_parse_url_full
                prog_read_update_pos
                prog_rename
                prog_rmdir

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,7 +10,7 @@ noinst_PROGRAMS = prog_access prog_access2 prog_chmod prog_chown prog_create \
 	prog_mknod prog_mount prog_opendir prog_open_read prog_open_write \
 	prog_rename prog_rmdir prog_stat prog_statvfs prog_symlink \
 	prog_timeout prog_truncate prog_unlink prog_utimes \
-	prog_read_update_pos prog_readonly
+	prog_read_update_pos prog_readonly prog_parse_url_full
 
 EXTRA_PROGRAMS = ld_timeout
 CLEANFILES = ld_timeout.o ld_timeout.so

--- a/tests/prog_parse_url_full.c
+++ b/tests/prog_parse_url_full.c
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libnfs.h"
+
+void usage(void)
+{
+    fprintf(stderr, "Usage: prog_parse_url_full <url> <server> <port> <path> <file>\n");
+    exit(1);
+}
+
+int main(int argc, char *argv[])
+{
+    struct nfs_context *nfs;
+    struct nfs_url *nfs_url;
+    int ret = 0;
+    int expected_port;
+
+    if (argc != 6)
+    {
+        usage();
+    }
+
+    nfs = nfs_init_context();
+    if (nfs == NULL) {
+        fprintf(stderr, "failed to init context\n");
+        return 1;
+    }
+
+    nfs_url = nfs_parse_url_full(nfs, argv[1]);
+    if (nfs_url == NULL) {
+        fprintf(stderr, "Failed to parse URL: %s\n", nfs_get_error(nfs));
+        nfs_destroy_context(nfs);
+        return 1;
+    }
+
+    if (strcmp(nfs_url->server, argv[2]) != 0) {
+        fprintf(stderr, "Unexpected server name: %s (expected: %s)\n", 
+                nfs_url->server ? nfs_url->server : "(null)", argv[2]);
+        ret = 1;
+    }
+
+    expected_port = atoi(argv[3]);
+    if (nfs_url->port != expected_port) {
+        fprintf(stderr, "Unexpected port: %d (expected: %d)\n", 
+                nfs_url->port, expected_port);
+        ret = 1;
+    }
+
+    if (strcmp(nfs_url->path, argv[4]) != 0) {
+        fprintf(stderr, "Unexpected path: %s (expected: %s)\n", 
+                nfs_url->path ? nfs_url->path : "(null)", argv[4]);
+        ret = 1;
+    }
+
+    if (strcmp(nfs_url->file, argv[5]) != 0) {
+        fprintf(stderr, "Unexpected file: %s (expected: %s)\n", 
+                nfs_url->file ? nfs_url->file : "(null)", argv[5]);
+        ret = 1;
+    }
+
+    nfs_destroy_url(nfs_url);
+    nfs_destroy_context(nfs);
+
+    return ret;
+}

--- a/tests/test_8010_parse_url_full.sh
+++ b/tests/test_8010_parse_url_full.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+. ./functions.sh
+
+echo "URL Parsing tests."
+
+echo -n "Parsing a url with a username ..."
+./prog_parse_url_full "nfs://user@127.0.0.1/dir/file" "127.0.0.1" "0" "/dir" "/file" || failure
+success

--- a/tests/test_8010_valgrind_parse_url_full.sh
+++ b/tests/test_8010_valgrind_parse_url_full.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+. ./functions.sh
+
+echo "URL Parsing valgrind leak check."
+
+echo -n "Testing parse_url_full for memory leaks ..."
+libtool --mode=execute valgrind --leak-check=full --error-exitcode=1 ./prog_parse_url_full "nfs://user@127.0.0.1/dir/file" "127.0.0.1" "0" "/dir" "/file" || failure
+success


### PR DESCRIPTION
Fix for memory leak in `nfs_parse_url` where a value of `urls->server` is not freed when handling a URL with an `@` in it #547 .

I've added a test case for parsing urls via `nfs_parse_url_full` that can capture this leak. I couldn't get a working test case for urls with port numbers. It looks like it tries to cast everything after the `:` in a url as int, but that doesn't work for `nfs://127.0.0.1:8000/dir/file` style paths.

https://github.com/sahlberg/libnfs/blob/fdba371a1c95167dd4f2924049683255721eda18/lib/libnfs.c#L434-L438