### PR TITLE
Adding parsing of port numbers

### DIFF
--- a/tests/test_8010_parse_url_full.sh
+++ b/tests/test_8010_parse_url_full.sh
@@ -7,3 +7,12 @@ echo "URL Parsing tests."
 echo -n "Parsing a url with a username ..."
 ./prog_parse_url_full "nfs://user@127.0.0.1/dir/file" "127.0.0.1" "0" "/dir" "/file" || failure
 success
+
+echo -n "Parsing a url with a port number ..."
+./prog_parse_url_full "nfs://user@127.0.0.1:8000/dir/file" "127.0.0.1" "8000" "/dir" "/file" || failure
+success
+
+echo -n "Parsing a url with invalid port numbers ..."
+./prog_parse_url_full "nfs://user@127.0.0.1:-1/dir/file" "127.0.0.1" "-1" "/dir" "/file"  && failure || success
+./prog_parse_url_full "nfs://user@127.0.0.1:65536/dir/file" "127.0.0.1" "65536" "/dir" "/file"  && failure || success
+./prog_parse_url_full "nfs://user@127.0.0.1:invalid/dir/file" "127.0.0.1" "0" "/dir" "/file"  && failure || success

--- a/tests/test_8010_valgrind_parse_url_full.sh
+++ b/tests/test_8010_valgrind_parse_url_full.sh
@@ -5,5 +5,6 @@
 echo "URL Parsing valgrind leak check."
 
 echo -n "Testing parse_url_full for memory leaks ..."
-libtool --mode=execute valgrind --leak-check=full --error-exitcode=1 ./prog_parse_url_full "nfs://user@127.0.0.1/dir/file" "127.0.0.1" "0" "/dir" "/file" || failure
+libtool --mode=execute valgrind --leak-check=full --error-exitcode=1 ./prog_parse_url_full "nfs://user@127.0.0.1/dir/file" "127.0.0.1" "0" "/dir" "/file" >/dev/null 2>&1 || failure
+libtool --mode=execute valgrind --leak-check=full --error-exitcode=1 ./prog_parse_url_full "nfs://user@127.0.0.1:8000/dir/file" "127.0.0.1" "8000" "/dir" "/file" >/dev/null 2>&1 || failure
 success


### PR DESCRIPTION
As part of doing #550 I noticed that port number parsing isn't working correctly. Currently the `nfs_parse_url` assumes that the rest of string is a port number after seeing a `:`. This doesn't work for cases where there is more to parse e.g. `nfs://localhost:8000/dir/file`.

https://github.com/sahlberg/libnfs/blob/fdba371a1c95167dd4f2924049683255721eda18/lib/libnfs.c#L434-L438

- `strcpy(strp + 1, strp + 3);` overlapping `strcpy` operations are technically undefined. I've switched it to `memmove`.
