### PR TITLE
add HAVE_DISPATCH_DISPATCH_H and HAVE_PTHREAD_THREADID_NP CMake's config.h

### DIFF
--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -138,3 +138,9 @@
 
 /* Define for large files, on AIX-style hosts. */
 #cmakedefine _LARGE_FILES
+
+/* Define to 1 if you have the <dispatch/dispatch.h> header file. */
+#cmakedefine HAVE_DISPATCH_DISPATCH_H
+
+/* Define to 1 if pthread_threadid_np() exists. */
+#cmakedefine HAVE_PTHREAD_THREADID_NP


### PR DESCRIPTION
Fixes macOS multithreading build with CMake.

This was forgotten in #403 