### PR TITLE
Don't overwrite POLLERR error with less specific POLLHUP error

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -1173,8 +1173,7 @@ rpc_service(struct rpc_context *rpc, int revents)
 				rpc_set_error(rpc, "rpc_service: POLLERR, "
 						   "Unknown socket error.");
 			}
-		}
-		if (revents != -1 && revents & POLLHUP) {
+		} else if (revents != -1 && revents & POLLHUP) {
 			rpc_set_error(rpc, "Socket failed with POLLHUP");
 		}
 		if (rpc->auto_reconnect) {


### PR DESCRIPTION
If connection fails both POLLERR and POLLHUP are triggered, but the error message from POLLERR is more useful as it includes the socket error number, while the error message from POLLHUP is very generic