### PR TITLE
Fix linking of libnfs to libpthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ if(WIN32 AND BUILD_SHARED_LIBS)
   add_definitions(-Dlibnfs_EXPORTS)
 endif()
 
+if(ENABLE_MULTITHREADING AND PTHREAD_LIBRARY)
+    list(APPEND SYSTEM_LIBRARIES pthread)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   add_definitions("-D_U_=__attribute__((unused))")
   #

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -103,6 +103,10 @@ check_c_source_compiles("#include <pthread.h>
                          }"
                         HAVE_PTHREAD)
 
+if(HAVE_PTHREAD)
+find_library(PTHREAD_LIBRARY pthread)
+endif()
+
 if(NOT NO_LFS_REQUIRED)
   check_c_source_compiles("#include <sys/types.h>
                            #define _FILE_OFFSET_BITS 64

--- a/cmake/libnfs.pc.cmake
+++ b/cmake/libnfs.pc.cmake
@@ -10,5 +10,6 @@ Description: libnfs is a client library for accessing NFS shares over a network.
 Version: @PROJECT_VERSION@
 Requires:
 Conflicts:
-Libs: -L${libdir} -lnfs @PKG_LIBLIST@
+Libs: -L${libdir} -lnfs
+Libs.private: @PKG_LIBLIST@
 Cflags: -I${includedir}

--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,19 @@ fi
 fi
 AM_CONDITIONAL([HAVE_PTHREAD], [test x$libnfs_cv_HAVE_PTHREAD = xyes])
 
+# check for libpthread
+if test "$libnfs_cv_HAVE_PTHREAD" = yes; then
+  ac_save_LIBS=$LIBS
+  AC_CHECK_LIB([pthread], [pthread_spin_lock], [])
+  LIBS="$ac_save_LIBS"
+  if test "$ac_cv_lib_pthread_pthread_spin_lock" = yes; then
+    LIBS_PRIVATE="-lpthread"
+    LIBPTHREAD="-lpthread"
+  fi
+fi
+AC_SUBST(LIBS_PRIVATE)
+AC_SUBST([LIBPTHREAD])
+
 AC_MSG_CHECKING(whether SO_BINDTODEVICE is available)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <net/if.h>]], [[
         int i = SO_BINDTODEVICE;

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,7 +20,6 @@ if (ENABLE_MULTITHREADING)
   list(APPEND EXAMPLES nfs-pthreads-writefile
                        nfs-pthreads-async-writefile
                        nfs-pthreads-async-readfile)
-  list(APPEND EXTRA_LIBRARIES pthread)
 endif()
 
 if(HAVE_TALLOC_TEVENT)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -44,7 +44,8 @@ libnfs_la_LIBADD = \
 	../nsm/libnsm.la \
 	../portmap/libportmap.la \
 	../rquota/librquota.la \
-	$(LIBSOCKET)
+	$(LIBSOCKET) \
+	$(LIBPTHREAD)
 
 if HAVE_TLS
 libnfs_la_CPPFLAGS += -I$(abs_top_srcdir)/tls

--- a/libnfs.pc.in
+++ b/libnfs.pc.in
@@ -11,4 +11,5 @@ Version: @VERSION@
 Requires:
 Conflicts:
 Libs: -L${libdir} -lnfs
+Libs.private: @LIBS_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION
libnfs utilizes a bunch of POSIX threads functions but does
not link against libpthread as it should nor the pkg-config file
properly listing libpthread as a static link time dependency.