### PR TITLE
autotools: fix 'undefined reference' if libnfs was built with gnutls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -306,6 +306,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 [[const char *v = GNUTLS_VERSION;]])],[libnfs_cv_HAVE_TLS=yes],[libnfs_cv_HAVE_TLS=no])])
 if test x"$libnfs_cv_HAVE_TLS" = x"yes"; then
     AC_DEFINE(HAVE_TLS,1,[Whether we have linux tls support])
+    # tell pkg-config that gnutls needs to be linked also
+    AC_SUBST(tls_library,"-lgnutls")
 fi
 AM_CONDITIONAL([HAVE_TLS], [test $libnfs_cv_HAVE_TLS = yes])
 

--- a/libnfs.pc.in
+++ b/libnfs.pc.in
@@ -10,6 +10,6 @@ Description: libnfs is a client library for accessing NFS shares over a network.
 Version: @VERSION@
 Requires:
 Conflicts:
-Libs: -L${libdir} -lnfs
+Libs: -L${libdir} -lnfs  @tls_library@
 Libs.private: @LIBS_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION
Linking against libnfs fails with 'undefined reference' to multiple gnutls_ symbols, if libnfs was built with gnutls and the build system uses pkg-config to determine the libraries that need to be linked to a target.

```
/home/buildroot/instance-0/output-1/host/opt/ext-toolchain/bin/../lib/gcc/sparc64-buildroot-linux-gnu/15.1.0/../../../../sparc64-buildroot-linux-gnu/bin/ld: /home/buildroot/instance-0/output-1/host/sparc64-buildroot-linux-gnu/sysroot/usr/lib/libnfs.so: undefined reference to `gnutls_certificate_set_x509_system_trust'
/home/buildroot/instance-0/output-1/host/opt/ext-toolchain/bin/../lib/gcc/sparc64-buildroot-linux-gnu/15.1.0/../../../../sparc64-buildroot-linux-gnu/bin/ld: /home/buildroot/instance-0/output-1/host/sparc64-buildroot-linux-gnu/sysroot/usr/lib/libnfs.so: undefined reference to `gnutls_set_default_priority'
/home/buildroot/instance-0/output-1/host/opt/ext-toolchain/bin/../lib/gcc/sparc64-buildroot-linux-gnu/15.1.0/../../../../sparc64-buildroot-linux-gnu/bin/ld: /home/buildroot/instance-0/output-1/host/sparc64-buildroot-linux-gnu/sysroot/usr/lib/libnfs.so: undefined reference to `gnutls_certificate_verification_status_print'
...
```

If TLS is detected by ./configure, add gnutls to the list of libraries in libnfs.pc.in. 

Fixes: #586