### PR TITLE
socket: stop reading when a callback replaces the connection

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -654,6 +654,18 @@ rpc_read_from_socket(struct rpc_context *rpc)
 	}
 
         while (1){
+                /*
+                 * A reply callback may disconnect the current endpoint and
+                 * start a new asynchronous connection. For example, the
+                 * portmapper callback replaces the connected portmapper
+                 * socket with a mountd socket that is still connecting.
+                 * Leave the read loop and let poll() finish that connection
+                 * before attempting to read from the replacement socket.
+                 */
+                if (!rpc->is_server_context && !rpc->is_connected) {
+                        return 0;
+                }
+
                 if (rpc->inpos == 0) {
                         switch (rpc->state) {
                         case READ_RM:


### PR DESCRIPTION
A reply callback may disconnect the current socket and start an asynchronous connection to another endpoint on the same RPC context. This happens after a portmapper reply when switching to the target RPC service.

The read loop could continue and call recv() on the replacement socket before its connection completed, resulting in WSAENOTCONN on Windows.

Return to the event loop when a client context is no longer connected, allowing poll() to complete the replacement connection before further I/O.