### PR TITLE
NFS4: fix heap over-read from GETATTR fattr4 owner/group length desync

### DIFF
--- a/lib/nfs_v4.c
+++ b/lib/nfs_v4.c
@@ -554,6 +554,7 @@ nfs_parse_attributes(struct nfs_context *nfs, struct nfs4_cb_data *data,
         CHECK_GETATTR_BUF_SPACE(len, slen);
         st->nfs_uid = nfs_get_ugid(nfs, buf, slen, 1);
         buf += slen;
+        len -= slen;
         CHECK_GETATTR_BUF_SPACE(len, pad);
         buf += pad;
         len -= pad;
@@ -569,6 +570,7 @@ nfs_parse_attributes(struct nfs_context *nfs, struct nfs4_cb_data *data,
         CHECK_GETATTR_BUF_SPACE(len, slen);
         st->nfs_gid = nfs_get_ugid(nfs, buf, slen, 0);
         buf += slen;
+        len -= slen;
         CHECK_GETATTR_BUF_SPACE(len, pad);
         buf += pad;
         len -= pad;


### PR DESCRIPTION
As discussed by email — submitting the fix as a PR so the credit lands in the commit.

**Bug (CWE-125, client-side, malicious/compromised NFSv4 server):** in
`nfs_parse_attributes()` (`lib/nfs_v4.c`), the Owner and Group blocks do
`buf += slen` but only `len -= pad`, never `len -= slen`. After both string
fields, `len` over-reports the remaining bytes by `slen_owner + slen_group`, so
later `CHECK_GETATTR_BUF_SPACE` checks pass against an inflated budget while `buf`
has advanced further — the trailing rdev/space/time reads run off the reply
buffer (heap out-of-bounds read).

**Fix:** decrement `len` by `slen` after each string field, matching the other
attribute paths.

**Verification:** built current master with AddressSanitizer against the original
crafted GETATTR reply — heap-buffer-overflow before this change, clean after; a
valid reply still decodes correctly.

Reported privately on 2026-07-27. No CVE requested.