### PR TITLE
nfs4: give every context a unique client name

### DIFF
--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -76,6 +76,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
@@ -735,8 +736,24 @@ nfs_init_context(void)
         }
         nfs4_set_verifier(nfs, verifier);
 
-        snprintf(client_name, MAX_CLIENT_NAME, "Libnfs pid:%d %d", getpid(),
-                 (int)time(NULL));
+        /*
+         * The client name is the NFSv4 client identity. It must differ for
+         * every context: a second SETCLIENTID under an id the server already
+         * knows means "that client rebooted", and the server then purges the
+         * state -- including open stateids -- belonging to the earlier
+         * context. pid plus whole seconds is not enough, because an
+         * application that mounts several exports does so well within one
+         * second and every context after the first evicts its predecessors,
+         * which then fail with NFS4ERR_EXPIRED / NFS4ERR_STALE_CLIENTID.
+         *
+         * Adding the context address and a millisecond timestamp makes the
+         * name unique without needing a lock or an atomic counter: two live
+         * contexts cannot share an address, and an address can only be reused
+         * once the previous context has been destroyed, at which point its
+         * state is no longer wanted.
+         */
+        snprintf(client_name, MAX_CLIENT_NAME, "Libnfs pid:%d %" PRIu64 " %p",
+                 getpid(), rpc_current_time(), (void *)nfs);
         nfs4_set_client_name(nfs, client_name);
 
 #ifdef HAVE_MULTITHREADING


### PR DESCRIPTION
The NFSv4 client name is the client identity the server keys state on. It is built as

```c
snprintf(client_name, MAX_CLIENT_NAME, "Libnfs pid:%d %d", getpid(), (int)time(NULL));
```

so two contexts created by the same process **in the same second** get the *same* identity. A repeat `SETCLIENTID` under an id the server already knows means "that client rebooted", so the server purges the state — including open stateids — of the earlier context. Those opens then fail `NFS4ERR_EXPIRED`, or the mount itself fails at `SETCLIENTID_CONFIRM` with `NFS4ERR_STALE_CLIENTID` / `NFS4ERR_CLID_INUSE`.

Any application that mounts more than one export does so well inside one second, so in practice only the most recently created context works.

### Reproducing

Four contexts on four different exports of one Linux kernel NFSv4 server, four threads reading concurrently, six rounds each (libnfs built with `-DENABLE_MULTITHREADING=yes`, `nfs_mt_service_thread_start()` per context):

```
before:  6/24 passes,  errors: SETCLIENTID_CONFIRM ... NFS4ERR_STALE_CLIENTID
                               SETCLIENTID_CONFIRM ... NFS4ERR_CLID_INUSE
                               open ... NFS4ERR_EXPIRED
after:  24/24 passes,  three runs in a row, no errors
```

### The change

Add a millisecond timestamp and the context address. That is unique without a lock or an atomic counter, which keeps it portable to the non-pthread targets: two live contexts cannot share an address, and an address is only reused after the previous context has been destroyed — at which point its server-side state is no longer wanted.

The name still starts with `Libnfs pid:<pid> `, so anything grepping server logs for a libnfs client keeps working. `MAX_CLIENT_NAME` (64) still fits: the longest realistic form is about 48 characters.

Applies cleanly alongside 600 (`nfs4: make the OPEN gate a semaphore, not a mutex`); the two are independent.