### PR TITLE
nfs4: make the OPEN gate a semaphore, not a mutex

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -927,7 +927,7 @@ struct nfs_context_internal {
        libnfs_thread_t service_thread;
        libnfs_mutex_t nfs_mutex;
        libnfs_mutex_t nfs4_open_counter_mutex;
-       libnfs_mutex_t nfs4_open_call_mutex;
+       libnfs_sem_t nfs4_open_call_sem;
        struct nfs_thread_context *thread_ctx;
 #endif /* HAVE_MULTITHREADING */
        int readonly;

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -742,7 +742,7 @@ nfs_init_context(void)
 #ifdef HAVE_MULTITHREADING
         nfs_mt_mutex_init(&nfs->nfsi->nfs_mutex);
         nfs_mt_mutex_init(&nfs->nfsi->nfs4_open_counter_mutex);
-        nfs_mt_mutex_init(&nfs->nfsi->nfs4_open_call_mutex);
+        nfs_mt_sem_init(&nfs->nfsi->nfs4_open_call_sem, 1);
 #endif /* HAVE_MULTITHREADING */
 
 #ifdef HAVE_SIGNAL_H
@@ -806,7 +806,7 @@ nfs_destroy_context(struct nfs_context *nfs)
 	}
 
 #ifdef HAVE_MULTITHREADING
-        nfs_mt_mutex_destroy(&nfs->nfsi->nfs4_open_call_mutex);
+        nfs_mt_sem_destroy(&nfs->nfsi->nfs4_open_call_sem);
         nfs_mt_mutex_destroy(&nfs->nfsi->nfs4_open_counter_mutex);
         nfs_mt_mutex_destroy(&nfs->nfsi->nfs_mutex);
         while (nfs->nfsi->thread_ctx) {

--- a/lib/nfs_v4.c
+++ b/lib/nfs_v4.c
@@ -260,7 +260,7 @@ free_nfs4_cb_data(struct nfs4_cb_data *data)
 {
 #ifdef HAVE_MULTITHREADING
         if (data->flags & MUTEX_HELD) {
-                nfs_mt_mutex_unlock(&data->nfs->nfsi->nfs4_open_call_mutex);
+                nfs_mt_sem_post(&data->nfs->nfsi->nfs4_open_call_sem);
         }
 #endif        
         free(data->path);
@@ -2711,7 +2711,7 @@ nfs4_open_async(struct nfs_context *nfs, const char *path, int flags,
 
 #ifdef HAVE_MULTITHREADING
         if (nfs->rpc->multithreading_enabled) {
-                nfs_mt_mutex_lock(&nfs->nfsi->nfs4_open_call_mutex);
+                nfs_mt_sem_wait(&nfs->nfsi->nfs4_open_call_sem);
                 data->flags |= MUTEX_HELD;
         }
 #endif        
@@ -2871,7 +2871,7 @@ nfs4_close_async(struct nfs_context *nfs, struct nfsfh *nfsfh, nfs_cb cb,
 
 #ifdef HAVE_MULTITHREADING
         if (nfs->rpc->multithreading_enabled) {
-                nfs_mt_mutex_lock(&nfs->nfsi->nfs4_open_call_mutex);
+                nfs_mt_sem_wait(&nfs->nfsi->nfs4_open_call_sem);
                 data->flags |= MUTEX_HELD;
         }
 #endif        
@@ -4131,7 +4131,7 @@ nfs4_truncate_async(struct nfs_context *nfs, const char *path, uint64_t length,
 
 #ifdef HAVE_MULTITHREADING
         if (nfs->rpc->multithreading_enabled) {
-                nfs_mt_mutex_lock(&nfs->nfsi->nfs4_open_call_mutex);
+                nfs_mt_sem_wait(&nfs->nfsi->nfs4_open_call_sem);
                 data->flags |= MUTEX_HELD;
         }
 #endif        


### PR DESCRIPTION
`nfs4_open_call_mutex` is acquired on the **application** thread in `nfs4_open_async()` and released in `free_nfs4_cb_data()`, which runs from the RPC callback on the **service** thread. A mutex cannot be released by a thread that does not own it, and since `DEBUG_PTHREAD_LOCKING_VIOLATIONS` is enabled unconditionally these are `PTHREAD_MUTEX_ERRORCHECK`, so the violation is enforced:

* the unlock returns `EPERM` and **does not release** the gate;
* the gate stays owned by whichever thread opened first, for the life of the context;
* every later `nfs4_open_async()` gets `EDEADLK` from the lock and proceeds **without** serialisation — so NFSv4 OPEN calls, which carry a per-owner seqid, stop being ordered.

### Reproducing

libnfs 7.0.0 (and current master) built with `-DENABLE_MULTITHREADING=yes`, against a Linux kernel NFSv4 server, one context, `nfs_open()` from several threads after `nfs_mt_service_thread_start()`:

```
libnfs: pthread_mutex_unlock() failed: 1 (Operation not permitted)
libnfs: pthread_mutex_lock() failed: 35 (Resource deadlock avoided)
```

repeating for every open after the first. A `Debug` build aborts on the first open instead, via the `assert(0)` in the `nfs_mt_mutex_*` wrappers — which is probably why this has gone unnoticed: nobody can run an MT+v4 debug build at all.

### The change

The object is used as a binary semaphore — acquired before the call is issued, released when it completes, possibly on another thread — so make it one. libnfs already has the `nfs_mt_sem_*` wrappers, and a semaphore has no owner, which is exactly the property this use needs.

No functional change for single-threaded callers: the gate is only taken when `rpc->multithreading_enabled` is set.

### Testing

Built with `-DENABLE_MULTITHREADING=yes` on manylinux_2_28 (gcc 14, glibc 2.28). With this change the `pthread_mutex_*` errors are gone and a 4-thread × 6-round concurrent open/read/readdir/unlink workload over a real NFSv4 export completes 24/24, repeatably, where it previously reported the errors above on every open.

Applies cleanly alongside 599 (`nfs4: give every context a unique client name`); the two are independent.
