### PR TITLE
libnfs.h: move the UDP and resiliency prototypes inside extern "C"

### DIFF
--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -2144,10 +2144,7 @@ EXTERN int nfs_mt_service_thread_start_ss(struct nfs_context *nfs, size_t stack_
  */
 EXTERN void nfs_mt_service_thread_stop(struct nfs_context *nfs);
 
-#ifdef __cplusplus
-}
-#endif
-
+struct sockaddr;
 
 /*
  * UDP contexts for UDP servers
@@ -2165,10 +2162,14 @@ EXTERN struct sockaddr *rpc_get_udp_src_sockaddr(struct rpc_context *rpc);
 EXTERN struct sockaddr *rpc_get_udp_dst_sockaddr(struct rpc_context *rpc);
 #endif
 
-void rpc_set_resiliency(struct rpc_context *rpc,
+EXTERN void rpc_set_resiliency(struct rpc_context *rpc,
 			int num_tcp_reconnect,
 			int timeout,
 			int retrans);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_LIBNFS_H_ */


### PR DESCRIPTION
@sahlberg I was using Claude Opus to [investigate an issue](https://github.com/LibreELEC/LibreELEC.tv/pull/11711) with Kodi (C++ app) accessing NFS shares using LibreELEC images. As part of the analysis it flagged the linking issue below. I lack the coding skills to assess whether this is a real issue or AI-slop; it's submitted in the hope that some or all might actually be real fixes. If garbage please reject and accept my apologies for the noise. If half-valid feel free to cherry-pick useful bits and merge fixes with or without attribution. Or I can drop invalid bits and rebase, but due to lack of skills you'll need to be quite explicit with instructions :)

>>>

The UDP context accessors and rpc_set_resiliency() were added after the closing brace of the extern "C" block, so a C++ translation unit that includes <nfsc/libnfs.h> declares them with C++ linkage and emits mangled references that the library never defines:

  undefined reference to `rpc_init_udp_context()'
  undefined reference to `rpc_set_resiliency(rpc_context*, int, int, int)'
  undefined reference to `rpc_is_udp_socket(rpc_context*)'

The library exports them unmangled, as it should:

  T rpc_bind_udp
  T rpc_init_udp_context
  T rpc_is_udp_socket

So the two can never meet. C++ consumers like Kodi that do not call these happen to build, which is why this went unnoticed. Move the block above the closing brace; C++ callers then link.

While here:

- rpc_set_resiliency() was missing EXTERN, so unlike every other public entry point it was not exported from the Windows DLL.

- Forward declare struct sockaddr, matching what the header already does for struct iovec. Without it the rpc_get_udp_*_sockaddr() parameters declare a fresh type inside the parameter list.